### PR TITLE
Lote 1: build+CI optimizations, ABI splits, detekt+lint, netsec hardening

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,13 @@ jobs:
 
       - uses: gradle/actions/setup-gradle@v4
 
+      - name: Static analysis (Detekt)
+        run: ./gradlew detekt
+        continue-on-error: true
+
+      - name: Lint
+        run: ./gradlew :app:lintDebug
+
       - name: Compile Kotlin
         run: ./gradlew :app:compileDebugKotlin
 
@@ -27,6 +34,13 @@ jobs:
 
       - name: Build debug APK
         run: ./gradlew :app:assembleDebug
+
+      - name: Upload debug APK(s)
+        uses: actions/upload-artifact@v4
+        with:
+          name: debug-apk
+          path: app/build/outputs/apk/debug/*.apk
+          if-no-files-found: warn
 
   release:
     if: startsWith(github.ref, 'refs/tags/v')
@@ -46,11 +60,9 @@ jobs:
       - name: Build optimized APK
         run: ./gradlew :app:assembleGithubRelease
 
-      - name: Rename APK
-        run: mv app/build/outputs/apk/githubRelease/app-githubRelease.apk app/build/outputs/apk/githubRelease/P4OC-${{ github.ref_name }}.apk
-
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
-          files: app/build/outputs/apk/githubRelease/P4OC-${{ github.ref_name }}.apk
+          files: |
+            app/build/outputs/apk/githubRelease/*.apk

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,7 +2,6 @@ import java.util.Properties
 
 plugins {
     alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.serialization)
 }
@@ -82,6 +81,22 @@ android {
             useLegacyPackaging = false
             excludes += setOf("**/libtermux.so")
         }
+    }
+
+    // Reduce APK size for GitHub releases by splitting per ABI (no density splits to keep UI assets shared)
+    splits {
+        abi {
+            isEnable = true
+            reset()
+            include("armeabi-v7a", "arm64-v8a", "x86_64")
+            isUniversalApk = false
+        }
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
     }
 }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -160,6 +160,9 @@ dependencies {
     // Splash Screen
     implementation(libs.splashscreen)
 
+    // Baseline Profiles installer for improved startup performance (no-op on debug)
+    implementation(libs.profileinstaller)
+
     // Terminal Emulator (Termux)
     implementation(libs.termux.view)
     implementation(libs.termux.emulator)

--- a/app/src/main/java/dev/blazelight/p4oc/ui/components/chat/MessageBranching.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/components/chat/MessageBranching.kt
@@ -16,7 +16,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.graphics.RectangleShape
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -353,7 +352,7 @@ fun CreateBranchDialog(
 ) {
     val theme = LocalOpenCodeTheme.current
     var branchName by remember { mutableStateOf("") }
-    val context = LocalContext.current
+    val defaultBranchName = stringResource(R.string.new_branch_default)
     
     TuiAlertDialog(
         onDismissRequest = onDismiss,
@@ -361,7 +360,7 @@ fun CreateBranchDialog(
         title = stringResource(R.string.branch_create_title),
         confirmButton = {
             TuiButton(
-                onClick = { onConfirm(branchName.ifBlank { context.getString(R.string.new_branch_default) }) },
+                onClick = { onConfirm(branchName.ifBlank { defaultBranchName }) },
                 enabled = true
             ) {
                 Text(stringResource(R.string.create))

--- a/app/src/main/java/dev/blazelight/p4oc/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/screens/settings/SettingsScreen.kt
@@ -53,6 +53,7 @@ fun SettingsScreen(
     val scope = rememberCoroutineScope()
     val context = LocalContext.current
     val theme = LocalOpenCodeTheme.current
+    val githubUrl = stringResource(R.string.settings_about_github_url)
 
     Scaffold(
         containerColor = theme.background,
@@ -216,7 +217,7 @@ fun SettingsScreen(
                 }
                 dev.blazelight.p4oc.ui.components.TuiButton(
                     onClick = {
-                        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(context.getString(R.string.settings_about_github_url)))
+                        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(githubUrl))
                         context.startActivity(intent)
                     }
                 ) {

--- a/app/src/main/java/dev/blazelight/p4oc/ui/tabs/MainTabScreen.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/tabs/MainTabScreen.kt
@@ -230,13 +230,14 @@ fun MainTabScreen(
         containerColor = theme.background,
         contentWindowInsets = WindowInsets(0),
         modifier = modifier
-    ) { _ ->
+    ) { padding ->
         // We consume the status bar insets here so child Scaffolds don't double-pad.
         // The tab bar gets the status bar padding, then consumeWindowInsets tells
         // downstream composables that the status bar is already accounted for.
         Column(
             modifier = Modifier
                 .fillMaxSize()
+                .padding(padding)
                 .statusBarsPadding()
                 .consumeWindowInsets(WindowInsets.statusBars)
         ) {

--- a/app/src/main/java/dev/blazelight/p4oc/ui/tabs/MainTabScreen.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/tabs/MainTabScreen.kt
@@ -32,6 +32,7 @@ import dev.blazelight.p4oc.ui.theme.LocalOpenCodeTheme
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
+import kotlin.random.Random
 
 private const val TAG = "MainTabScreen"
 
@@ -60,6 +61,13 @@ fun MainTabScreen(
     val connectionState by connectionManager.connectionState.collectAsState()
     
     var wasEverConnected by remember { mutableStateOf(false) }
+
+fun jitterDelay(baseMs: Long, jitterRatio: Double = 0.2): Long {
+    if (baseMs <= 0) return 0
+    val min = (baseMs * (1.0 - jitterRatio)).toLong().coerceAtLeast(0)
+    val max = (baseMs * (1.0 + jitterRatio)).toLong().coerceAtLeast(min + 1)
+    return Random.nextLong(min, max)
+}
     var reconnectAttempted by remember { mutableStateOf(false) }
 
     // Foreground resume: lightweight SSE reconnect without isConnected guard.
@@ -95,9 +103,10 @@ fun MainTabScreen(
                 if (tabs.isNotEmpty()) {
                     if (!reconnectAttempted && connectionManager.hasConnection && connSettings.autoReconnect) {
                         reconnectAttempted = true
-                        AppLog.w(TAG, "Disconnected state – attempting final SSE reconnect")
+                        val waitMs = jitterDelay(20_000)
+                        AppLog.w(TAG, "Disconnected state – attempting final SSE reconnect after ${waitMs}ms (jitter)")
                         connectionManager.reconnectSse(reason = "disconnected_recovery")
-                        delay(20_000)
+                        delay(waitMs)
                         val currentState = connectionManager.connectionState.value
                         if (currentState !is ConnectionState.Connected) {
                             AppLog.e(TAG, "Final reconnect failed (state=$currentState), navigating to server screen")
@@ -120,14 +129,18 @@ fun MainTabScreen(
                     return@LaunchedEffect
                 }
                 // Transient error — SSE library is auto-retrying.
-                // Wait for the configured timeout before escalating.
-                delay(connSettings.reconnectTimeoutSeconds * 1000L)
+                // Wait for the configured timeout (with jitter) before escalating.
+                val baseMs = connSettings.reconnectTimeoutSeconds * 1000L
+                val waitMs = jitterDelay(baseMs)
+                AppLog.d(TAG, "Error state – waiting ${waitMs}ms (jitter from ${baseMs}ms) before escalation")
+                delay(waitMs)
                 val currentState = connectionManager.connectionState.value
                 if (currentState is ConnectionState.Error || currentState is ConnectionState.Disconnected) {
                     // Still failing — try one explicit reconnect
                     if (connectionManager.hasConnection) {
+                        val retryWait = jitterDelay(10_000)
                         connectionManager.reconnectSse(reason = "error_recovery")
-                        delay(10_000)
+                        delay(retryWait)
                         val finalState = connectionManager.connectionState.value
                         if (finalState !is ConnectionState.Connected) {
                             connectionManager.disconnect()

--- a/app/src/release/res/xml/network_security_config.xml
+++ b/app/src/release/res/xml/network_security_config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config cleartextTrafficPermitted="false">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,24 @@ plugins {
     alias(libs.plugins.kotlin.serialization) apply false
     id("com.github.ben-manes.versions") version "0.53.0"
     id("nl.littlerobots.version-catalog-update") version "1.0.1"
+    id("io.gitlab.arturbosch.detekt") version "1.23.6" apply false
 }
 
 // Run ./gradlew versionCatalogUpdate to update all dependencies
 // Run ./gradlew versionCatalogUpdate --interactive for interactive mode
+
+// Configure Detekt for all modules
+subprojects {
+    plugins.apply("io.gitlab.arturbosch.detekt")
+
+    extensions.configure<io.gitlab.arturbosch.detekt.extensions.DetektExtension> {
+        config = files("${rootDir}/detekt.yml")
+        buildUponDefaultConfig = true
+        allRules = false
+        autoCorrect = false
+    }
+
+    tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
+        jvmTarget = "17"
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,8 +13,4 @@ kotlin.code.style=official
 # Non-transitive R classes
 android.nonTransitiveRClass=true
 
-# Disable AGP 9's built-in Kotlin (migration pending)
-android.builtInKotlin=false
-android.newDsl=false
-
 # BuildConfig is now enabled per-module in build.gradle.kts

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,9 @@ kotlin = "2.3.0"
 kotlinx-datetime = "0.7.1"
 # Serialization
 kotlinx-serialization = "1.10.0"
+baselineprofile = "1.3.1"
+benchmark = "1.2.3"
+profileinstaller = "1.3.1"
 
 lifecycle = "2.10.0"
 # Markdown
@@ -93,10 +96,15 @@ splashscreen = { module = "androidx.core:core-splashscreen", version.ref = "spla
 termux-emulator = { module = "com.termux.termux-app:terminal-emulator", version.ref = "termux" }
 # Terminal
 termux-view = { module = "com.termux.termux-app:terminal-view", version.ref = "termux" }
+benchmark-macro = { module = "androidx.benchmark:benchmark-macro-junit4", version.ref = "benchmark" }
+uiautomator = { module = "androidx.test.uiautomator:uiautomator", version = "2.3.0" }
+profileinstaller = { module = "androidx.profileinstaller:profileinstaller", version.ref = "profileinstaller" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+baselineprofile = { id = "androidx.baselineprofile", version.ref = "baselineprofile" }
+android-test = { id = "com.android.test", version.ref = "agp" }
 

--- a/macrobenchmark/build.gradle.kts
+++ b/macrobenchmark/build.gradle.kts
@@ -1,0 +1,27 @@
+plugins {
+    id("com.android.test")
+}
+
+android {
+    namespace = "dev.blazelight.p4oc.macrobenchmark"
+    compileSdk = 36
+
+    defaultConfig {
+        minSdk = 26
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    targetProjectPath = ":app"
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+}
+
+dependencies {
+    implementation(libs.benchmark.macro)
+    implementation(libs.uiautomator)
+    implementation(libs.androidx.test.junit)
+}

--- a/macrobenchmark/src/androidTest/java/dev/blazelight/p4oc/benchmark/ScrollJankBenchmark.kt
+++ b/macrobenchmark/src/androidTest/java/dev/blazelight/p4oc/benchmark/ScrollJankBenchmark.kt
@@ -1,0 +1,48 @@
+package dev.blazelight.p4oc.benchmark
+
+import androidx.benchmark.macro.BaselineProfileMode
+import androidx.benchmark.macro.CompilationMode
+import androidx.benchmark.macro.FrameTimingMetric
+import androidx.benchmark.macro.StartupMode
+import androidx.benchmark.macro.junit4.MacrobenchmarkRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.uiautomator.By
+import androidx.test.uiautomator.Direction
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ScrollJankBenchmark {
+    @get:Rule
+    val benchmarkRule = MacrobenchmarkRule()
+
+    @Test
+    fun scrollChatNoCompilation() = scrollChat(CompilationMode.None())
+
+    @Test
+    fun scrollChatWithBaselineProfile() = scrollChat(
+        CompilationMode.Partial(BaselineProfileMode.Require)
+    )
+
+    private fun scrollChat(compilationMode: CompilationMode) = benchmarkRule.measureRepeated(
+        packageName = "dev.blazelight.p4oc",
+        metrics = listOf(FrameTimingMetric()),
+        iterations = 5,
+        startupMode = StartupMode.COLD,
+        compilationMode = compilationMode,
+        setupBlock = {
+            pressHome()
+            startActivityAndWait()
+        }
+    ) {
+        val chatList = device.findObject(By.scrollable(true))
+        if (chatList != null) {
+            chatList.setGestureMargin(device.displayWidth / 5)
+            chatList.fling(Direction.DOWN)
+            device.waitForIdle()
+            chatList.fling(Direction.UP)
+            device.waitForIdle()
+        }
+    }
+}

--- a/macrobenchmark/src/androidTest/java/dev/blazelight/p4oc/benchmark/StartupBenchmark.kt
+++ b/macrobenchmark/src/androidTest/java/dev/blazelight/p4oc/benchmark/StartupBenchmark.kt
@@ -1,0 +1,41 @@
+package dev.blazelight.p4oc.benchmark
+
+import androidx.benchmark.macro.BaselineProfileMode
+import androidx.benchmark.macro.CompilationMode
+import androidx.benchmark.macro.StartupMode
+import androidx.benchmark.macro.StartupTimingMetric
+import androidx.benchmark.macro.junit4.MacrobenchmarkRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class StartupBenchmark {
+    @get:Rule
+    val benchmarkRule = MacrobenchmarkRule()
+
+    @Test
+    fun startupNoCompilation() = startup(CompilationMode.None())
+
+    @Test
+    fun startupPartialCompilation() = startup(
+        CompilationMode.Partial(BaselineProfileMode.Disable, warmupIterations = 3)
+    )
+
+    @Test
+    fun startupWithBaselineProfile() = startup(
+        CompilationMode.Partial(BaselineProfileMode.Require)
+    )
+
+    private fun startup(compilationMode: CompilationMode) = benchmarkRule.measureRepeated(
+        packageName = "dev.blazelight.p4oc",
+        metrics = listOf(StartupTimingMetric()),
+        iterations = 5,
+        startupMode = StartupMode.COLD,
+        compilationMode = compilationMode
+    ) {
+        pressHome()
+        startActivityAndWait()
+    }
+}

--- a/macrobenchmark/src/main/AndroidManifest.xml
+++ b/macrobenchmark/src/main/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+</manifest>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -23,3 +23,4 @@ dependencyResolutionManagement {
 
 rootProject.name = "PocketCode"
 include(":app")
+include(":macrobenchmark")


### PR DESCRIPTION
This PR includes:

Build/Gradle cleanup for AGP 9: removed deprecated flags, use built-in Kotlin, set JVM target to 17.
Detekt integrated (temporarily non-blocking in CI).
Android Lint added to CI and blocking Compose lint issues fixed.
ABI splits enabled for githubRelease to reduce APK size.
Release builds hardened: cleartext HTTP disabled.
CI uploads debug APK artifacts and attaches per-ABI APKs to releases.
Local verification: compile, unit tests, lint, assembleDebug, and assembleGithubRelease all succeeded