### PR TITLE
fix(chat): clear input after send; stop Enter re-populating the field

### DIFF
--- a/app/src/main/java/dev/blazelight/p4oc/ui/components/chat/ChatInputBar.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/components/chat/ChatInputBar.kt
@@ -153,14 +153,21 @@ fun ChatInputBar(
         return true
     }
 
+    fun clearInput() {
+        inputFieldValue = TextFieldValue("")
+        onValueChange("")
+    }
+
     fun submitFromEnter(): Boolean = when {
         showSlashCommands -> selectActiveCommand()
         canSend -> {
             onSend()
+            clearInput()
             true
         }
         canQueue -> {
             onQueueMessage()
+            clearInput()
             true
         }
         else -> false
@@ -305,7 +312,13 @@ fun ChatInputBar(
                                         Key.Enter, Key.NumPadEnter -> {
                                             when {
                                                 showSlashCommands -> selectActiveCommand()
-                                                enterToSend -> submitFromEnter()
+                                                // When enter-to-send is on, always consume Enter so the
+                                                // TextField can't commit a trailing newline that
+                                                // re-populates the field after the message is sent.
+                                                enterToSend -> {
+                                                    submitFromEnter()
+                                                    true
+                                                }
                                                 else -> false
                                             }
                                         }
@@ -357,6 +370,7 @@ fun ChatInputBar(
                                 canQueue -> onQueueMessage()
                                 else -> return@IconButton
                             }
+                            clearInput()
                             focusRequester.requestFocus()
                         },
                         enabled = canSend || canQueue,


### PR DESCRIPTION
When **Enter to Send** is on, sending (via Enter or the send button) left the typed text in the input box.

**Causes**
1. Clearing relied only on the hoisted `value` → `LaunchedEffect` round-trip to reset the local `TextFieldValue`; that sync was unreliable, so the field kept the text after the optimistic send.
2. The `Key.Enter` handler returned `submitFromEnter()`'s result — `false` once the input is already cleared — so the keystroke wasn't consumed and the `TextField` committed a trailing newline that re-populated the field.

**Fix**
- `clearInput()` helper clears the local input immediately on submit (Enter **and** send button).
- Always consume `Enter`/`NumPadEnter` when `enterToSend` so no newline is committed.
- Restore-on-error is preserved (a failed send still re-populates via the existing `value` round-trip).

Tested behavior: typing + Enter (and tapping send) now clears the field and sends once, with no leftover newline.