### PR TITLE
fix: clear question modal when resolved remotely (question.replied/rejected)

### DIFF
--- a/app/src/main/java/dev/blazelight/p4oc/data/remote/dto/EventDtos.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/data/remote/dto/EventDtos.kt
@@ -69,6 +69,19 @@ data class PermissionRepliedPropertiesDto(
 )
 
 @Serializable
+data class QuestionRepliedPropertiesDto(
+    @SerialName("sessionID") val sessionID: String,
+    @SerialName("requestID") val requestID: String,
+    val answers: List<List<String>>
+)
+
+@Serializable
+data class QuestionRejectedPropertiesDto(
+    @SerialName("sessionID") val sessionID: String,
+    @SerialName("requestID") val requestID: String
+)
+
+@Serializable
 data class FileWatcherPropertiesDto(
     val file: String,
     val event: String // "add" | "change" | "unlink"

--- a/app/src/main/java/dev/blazelight/p4oc/data/remote/mapper/Mappers.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/data/remote/mapper/Mappers.kt
@@ -681,6 +681,14 @@ class EventMapper constructor(
                     )
                 )
             }
+            "question.replied" -> {
+                val props = json.decodeFromJsonElement<QuestionRepliedPropertiesDto>(dto.properties)
+                OpenCodeEvent.QuestionReplied(props.sessionID, props.requestID, props.answers)
+            }
+            "question.rejected" -> {
+                val props = json.decodeFromJsonElement<QuestionRejectedPropertiesDto>(dto.properties)
+                OpenCodeEvent.QuestionRejected(props.sessionID, props.requestID)
+            }
             "todo.updated" -> {
                 val props = json.decodeFromJsonElement<TodoEventPropertiesDto>(dto.properties)
                 OpenCodeEvent.TodoUpdated(

--- a/app/src/main/java/dev/blazelight/p4oc/data/session/SessionRepositoryImpl.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/data/session/SessionRepositoryImpl.kt
@@ -212,6 +212,8 @@ class SessionRepositoryImpl(
                     }
                 }
             }
+            is OpenCodeEvent.QuestionReplied -> resolveQuestion(event.sessionID, event.requestID)
+            is OpenCodeEvent.QuestionRejected -> resolveQuestion(event.sessionID, event.requestID)
             is OpenCodeEvent.TodoUpdated -> updateSession(event.sessionID) { it.copy(todos = event.todos) }
             is OpenCodeEvent.MessageUpdated -> upsertMessage(event.message)
             is OpenCodeEvent.MessagePartUpdated -> upsertPart(event.part, event.delta)
@@ -263,6 +265,32 @@ class SessionRepositoryImpl(
                 pendingQuestion = nextQuestion,
                 queuedQuestions = if (nextQuestion == null) emptyList() else state.queuedQuestions.drop(1),
             )
+        }
+    }
+
+    /**
+     * Resolve a question that was answered or rejected (by this client or any other,
+     * e.g. the desktop TUI). Clears it from the owning session's UI state by matching
+     * [requestID]: if it is the current pending question, the next queued question is
+     * promoted; if it is sitting in the queue, it is removed in place. Unknown
+     * requestIDs are a no-op (idempotent — a resolution we never tracked, or one
+     * already handled locally).
+     */
+    private fun resolveQuestion(eventSessionId: String, requestID: String) {
+        updateOwnedSession(eventSessionId) { state ->
+            when {
+                state.pendingQuestion?.id == requestID -> {
+                    val nextQuestion = state.queuedQuestions.firstOrNull()
+                    state.copy(
+                        pendingQuestion = nextQuestion,
+                        queuedQuestions = if (nextQuestion == null) emptyList() else state.queuedQuestions.drop(1),
+                    )
+                }
+                state.queuedQuestions.any { it.id == requestID } -> {
+                    state.copy(queuedQuestions = state.queuedQuestions.filterNot { it.id == requestID })
+                }
+                else -> state
+            }
         }
     }
 

--- a/app/src/main/java/dev/blazelight/p4oc/domain/model/Event.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/domain/model/Event.kt
@@ -25,6 +25,12 @@ sealed class OpenCodeEvent {
     data class PermissionRequested(val permission: Permission) : OpenCodeEvent()
     data class PermissionReplied(val sessionID: String, val requestID: String, val reply: String) : OpenCodeEvent()
     data class QuestionAsked(val request: QuestionRequest) : OpenCodeEvent()
+    data class QuestionReplied(
+        val sessionID: String,
+        val requestID: String,
+        val answers: List<List<String>>,
+    ) : OpenCodeEvent()
+    data class QuestionRejected(val sessionID: String, val requestID: String) : OpenCodeEvent()
     data class TodoUpdated(val sessionID: String, val todos: List<Todo>) : OpenCodeEvent()
     data class CommandExecuted(
         val name: String,


### PR DESCRIPTION
## Problem

P4OC only handles `question.asked`. It ignores the OpenCode server's `question.replied` and `question.rejected` SSE events. When a question is answered or rejected by **another client** (e.g. the desktop OpenCode TUI, or a second device), the mobile question modal stays up indefinitely, and every subsequent question is silently **queued** behind the stale `pendingQuestion` — surfacing only as the bare `question` tool-call in the chat, never as the `InlineQuestionCard`.

This also cascades: with a question stuck pending, the session never reaches idle on the mobile side, so `isBusy` stays true and new messages get stuck at "queued…".

## Evidence / repro
1. Attach the mobile app to a session that is also open in another client (e.g. the desktop TUI).
2. Trigger an `AskUserQuestion`.
3. Answer it **on the other client**.
4. Mobile: the question card never clears; subsequent questions render only as bare `question` tool-calls.

(Root cause confirmed against the server source: `packages/opencode/src/question/index.ts` publishes `question.replied {sessionID, requestID, answers}` and `question.rejected {sessionID, requestID}` — events P4OC never mapped. `acceptEvent` had `PermissionRequested`+`PermissionReplied`, but for questions only `QuestionAsked`.)

## Fix
Mirror the existing `PermissionReplied` handling for questions:
- Add `OpenCodeEvent.QuestionReplied` / `QuestionRejected` event types (`domain/model/Event.kt`).
- Add `QuestionRepliedPropertiesDto` / `QuestionRejectedPropertiesDto` (`data/remote/dto/EventDtos.kt`).
- Map `question.replied` / `question.rejected` in `EventMapper` (`data/remote/mapper/Mappers.kt`).
- Handle them in `SessionRepositoryImpl.acceptEvent` via a new `resolveQuestion(sessionID, requestID)` helper that clears the matching question by `requestID`: if it is the current `pendingQuestion`, promote the next queued question; if it is in the queue, remove it in place. Unknown `requestID`s are a no-op (idempotent — covers the local-reply-then-SSE-echo race). The repo `SessionUiState` change propagates to the modal through the existing `applyRepositorySessionState` → `dialogManager.setPendingQuestion` path.

## Expected behavior
A question answered/rejected by any client clears the mobile modal and promotes/removes any queued question accordingly.

## Acceptance criteria
- A question answered/rejected on another client clears the mobile modal.
- A queued question is correctly promoted/removed when its predecessor resolves remotely.
- No regression to the normal mobile answer/reject flow.

## Verification
- `./gradlew :app:compileDebugKotlin` ✅
- `./gradlew :app:assembleDebug` ✅ (APK builds)
- No new detekt findings in the changed files.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/theblazehen/P4OC/pull/19">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->