### PR TITLE
fix: Skip on a question rejects it server-side instead of clearing locally

### DIFF
--- a/app/src/main/java/dev/blazelight/p4oc/core/network/OpenCodeApi.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/core/network/OpenCodeApi.kt
@@ -186,6 +186,12 @@ interface OpenCodeApi {
         @Query("directory") directory: String?
     ): Boolean
 
+    @POST("question/{requestId}/reject")
+    suspend fun rejectQuestion(
+        @Path("requestId") requestId: String,
+        @Query("directory") directory: String?
+    ): Boolean
+
     @GET("command")
     suspend fun listCommands(
         @Query("directory") directory: String?

--- a/app/src/main/java/dev/blazelight/p4oc/data/workspace/WorkspaceClient.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/data/workspace/WorkspaceClient.kt
@@ -105,6 +105,9 @@ class WorkspaceClient(
     suspend fun respondToQuestion(requestId: String, request: QuestionReplyRequest): Boolean =
         api.respondToQuestion(requestId, request, directory)
 
+    suspend fun rejectQuestion(requestId: String): Boolean =
+        api.rejectQuestion(requestId, directory)
+
     suspend fun listCommands(): List<CommandDto> = api.listCommands(directory)
 
     suspend fun executeCommand(sessionId: String, request: ExecuteCommandRequest): MessageWrapperDto =

--- a/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ChatScreen.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ChatScreen.kt
@@ -371,7 +371,7 @@ fun ChatScreen(
                             InlineQuestionCard(
                                 questionRequestId = questionRequest.id,
                                 questionData = dev.blazelight.p4oc.domain.model.QuestionData(questionRequest.questions),
-                                onDismiss = viewModel::dismissQuestion,
+                                onDismiss = { viewModel.dismissQuestion(questionRequest.id) },
                                 onSubmit = { answers ->
                                     viewModel.respondToQuestion(questionRequest.id, answers)
                                 },

--- a/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ChatViewModel.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ChatViewModel.kt
@@ -488,8 +488,23 @@ class ChatViewModel constructor(
         }
     }
 
-    fun dismissQuestion() {
-        sessionRepository.clearQuestion(SessionId(sessionId))
+    fun dismissQuestion(requestId: String) {
+        viewModelScope.launch {
+            // Reject the question server-side so the agent's pending request is
+            // resolved (otherwise it stays pending forever and the session never
+            // goes idle). The local modal is cleared optimistically; the matching
+            // question.rejected SSE event (handled in SessionRepositoryImpl) will
+            // also reconcile any other attached client.
+            when (val result = safeApiCall { workspaceClient.rejectQuestion(requestId) }) {
+                is ApiResult.Success -> sessionRepository.clearQuestion(SessionId(sessionId))
+                is ApiResult.Error -> {
+                    // A NotFound here means it was already resolved elsewhere — clear
+                    // locally anyway so the user is not stuck on a dead modal.
+                    sessionRepository.clearQuestion(SessionId(sessionId))
+                    AppLog.w(TAG, "rejectQuestion failed (clearing locally): ${result.message}")
+                }
+            }
+        }
     }
 
     // --- Commands & Todos ---


### PR DESCRIPTION
## Problem

The inline question card's **Skip** button calls `dismissQuestion()` → `sessionRepository.clearQuestion()`, which is a **purely local** state mutation with no server call. The question therefore stays **pending on the server forever** (a zombie question): the agent's `AskUserQuestion` request never resolves, the session never reaches idle, and the mobile client's view diverges from the server until a detach/reattach forces a re-hydrate. With the session stuck non-idle, `isBusy` stays true and new messages get stuck at "queued…".

Worse, replying to such a zombie question later returns `NotFound`, and because the card only cleared on success, the user could be stuck on a dead modal.

## Evidence / repro
1. Trigger an `AskUserQuestion`.
2. Tap **Skip** on the card.
3. Server still lists the question as pending (`GET /question`); the agent stays blocked; the session never goes idle on the mobile side.

## Fix
Make Skip resolve the question server-side:
- Add `POST question/{requestId}/reject` to `OpenCodeApi` and `WorkspaceClient.rejectQuestion()` (mirrors the existing `respondToQuestion` / `reply` plumbing; the server already exposes this endpoint).
- `dismissQuestion(requestId)` now POSTs the reject, then clears the local modal. On error (e.g. the question was already resolved by another client → `NotFound`) it **still clears locally** so the user is never stuck on a dead modal.
- `ChatScreen` passes `questionRequest.id` to `dismissQuestion`.

## Expected behavior
Tapping Skip rejects the question on the server, the agent's request resolves, and the session can reach idle. If the question was already resolved remotely, Skip still clears the local modal without surfacing an error.

## Acceptance criteria
- Tapping Skip rejects the question on the server (no zombie pending question).
- The agent's request resolves and the session can reach idle.
- If the question was already resolved remotely, Skip still clears the local modal.

## Verification
- `./gradlew :app:compileDebugKotlin` ✅
- `./gradlew :app:assembleDebug` ✅
- No new detekt findings in the changed files.

## Dependency note
The emitted `question.rejected` SSE event (so other attached clients reconcile) is handled by the companion PR #19 ("clear question modal when resolved remotely"). This PR's code compiles and functions independently, but for full cross-client consistency **#19 should merge first**.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/theblazehen/P4OC/pull/20">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->