### PR TITLE
fix: recover pending question on reconnect / session open (render multi-choice card)

### DIFF
--- a/app/src/main/java/dev/blazelight/p4oc/core/network/OpenCodeApi.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/core/network/OpenCodeApi.kt
@@ -192,6 +192,11 @@ interface OpenCodeApi {
         @Query("directory") directory: String?
     ): Boolean
 
+    @GET("question")
+    suspend fun listPendingQuestions(
+        @Query("directory") directory: String?
+    ): List<QuestionRequestDto>
+
     @GET("command")
     suspend fun listCommands(
         @Query("directory") directory: String?

--- a/app/src/main/java/dev/blazelight/p4oc/core/network/OpenCodeApi.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/core/network/OpenCodeApi.kt
@@ -186,6 +186,12 @@ interface OpenCodeApi {
         @Query("directory") directory: String?
     ): Boolean
 
+    @POST("question/{requestId}/reject")
+    suspend fun rejectQuestion(
+        @Path("requestId") requestId: String,
+        @Query("directory") directory: String?
+    ): Boolean
+
     @GET("command")
     suspend fun listCommands(
         @Query("directory") directory: String?

--- a/app/src/main/java/dev/blazelight/p4oc/data/remote/dto/EventDtos.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/data/remote/dto/EventDtos.kt
@@ -69,6 +69,19 @@ data class PermissionRepliedPropertiesDto(
 )
 
 @Serializable
+data class QuestionRepliedPropertiesDto(
+    @SerialName("sessionID") val sessionID: String,
+    @SerialName("requestID") val requestID: String,
+    val answers: List<List<String>>
+)
+
+@Serializable
+data class QuestionRejectedPropertiesDto(
+    @SerialName("sessionID") val sessionID: String,
+    @SerialName("requestID") val requestID: String
+)
+
+@Serializable
 data class FileWatcherPropertiesDto(
     val file: String,
     val event: String // "add" | "change" | "unlink"

--- a/app/src/main/java/dev/blazelight/p4oc/data/remote/mapper/Mappers.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/data/remote/mapper/Mappers.kt
@@ -681,6 +681,14 @@ class EventMapper constructor(
                     )
                 )
             }
+            "question.replied" -> {
+                val props = json.decodeFromJsonElement<QuestionRepliedPropertiesDto>(dto.properties)
+                OpenCodeEvent.QuestionReplied(props.sessionID, props.requestID, props.answers)
+            }
+            "question.rejected" -> {
+                val props = json.decodeFromJsonElement<QuestionRejectedPropertiesDto>(dto.properties)
+                OpenCodeEvent.QuestionRejected(props.sessionID, props.requestID)
+            }
             "todo.updated" -> {
                 val props = json.decodeFromJsonElement<TodoEventPropertiesDto>(dto.properties)
                 OpenCodeEvent.TodoUpdated(

--- a/app/src/main/java/dev/blazelight/p4oc/data/remote/mapper/Mappers.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/data/remote/mapper/Mappers.kt
@@ -561,6 +561,30 @@ object StatusMapper {
 // Event Mapper
 // ============================================================================
 
+/**
+ * Map a QuestionRequestDto to a domain QuestionRequest.
+ * Used by EventMapper for question.asked events and by SessionRepositoryImpl
+ * for reconciliation of pending questions.
+ */
+fun mapQuestionRequestDtoToDomain(dto: QuestionRequestDto): QuestionRequest = QuestionRequest(
+    id = dto.id,
+    sessionID = dto.sessionID,
+    questions = dto.questions.map { q ->
+        Question(
+            header = q.header,
+            question = q.question,
+            options = q.options.map { o ->
+                QuestionOption(label = o.label, description = o.description)
+            },
+            multiple = q.multiple,
+            custom = q.custom
+        )
+    },
+    tool = dto.tool?.let {
+        QuestionToolRef(messageID = it.messageID, callID = it.callID)
+    }
+)
+
 class EventMapper constructor(
     private val json: Json,
     private val messageMapper: MessageMapper
@@ -660,26 +684,7 @@ class EventMapper constructor(
             }
             "question.asked" -> {
                 val questionDto = json.decodeFromJsonElement<QuestionRequestDto>(dto.properties)
-                OpenCodeEvent.QuestionAsked(
-                    QuestionRequest(
-                        id = questionDto.id,
-                        sessionID = questionDto.sessionID,
-                        questions = questionDto.questions.map { q ->
-                            Question(
-                                header = q.header,
-                                question = q.question,
-                                options = q.options.map { o ->
-                                    QuestionOption(label = o.label, description = o.description)
-                                },
-                                multiple = q.multiple,
-                                custom = q.custom
-                            )
-                        },
-                        tool = questionDto.tool?.let {
-                            QuestionToolRef(messageID = it.messageID, callID = it.callID)
-                        }
-                    )
-                )
+                OpenCodeEvent.QuestionAsked(mapQuestionRequestDtoToDomain(questionDto))
             }
             "question.replied" -> {
                 val props = json.decodeFromJsonElement<QuestionRepliedPropertiesDto>(dto.properties)

--- a/app/src/main/java/dev/blazelight/p4oc/data/session/SessionRepository.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/data/session/SessionRepository.kt
@@ -25,7 +25,7 @@ interface SessionRepository {
 
     fun clearPermissionByRequestId(sessionId: SessionId, requestId: String)
 
-    fun clearQuestion(sessionId: SessionId)
+    fun clearQuestion(sessionId: SessionId, requestId: String? = null)
 
     suspend fun loadMessages(sessionId: SessionId, limit: Int? = null)
 

--- a/app/src/main/java/dev/blazelight/p4oc/data/session/SessionRepositoryImpl.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/data/session/SessionRepositoryImpl.kt
@@ -4,10 +4,12 @@ import dev.blazelight.p4oc.core.log.AppLog
 import dev.blazelight.p4oc.data.files.ofish.OfishSessionNames
 import dev.blazelight.p4oc.data.remote.dto.CreateSessionRequest
 import dev.blazelight.p4oc.data.remote.dto.ProjectDto
+import dev.blazelight.p4oc.data.remote.dto.QuestionRequestDto
 import dev.blazelight.p4oc.data.remote.dto.SendMessageRequest
 import dev.blazelight.p4oc.data.remote.dto.UpdateSessionRequest
 import dev.blazelight.p4oc.data.remote.mapper.MessageMapper
 import dev.blazelight.p4oc.data.remote.mapper.SessionMapper
+import dev.blazelight.p4oc.data.remote.mapper.mapQuestionRequestDtoToDomain
 import dev.blazelight.p4oc.data.workspace.SessionWorkspaceClient
 import dev.blazelight.p4oc.data.workspace.WorkspaceClient
 import dev.blazelight.p4oc.domain.model.Message
@@ -17,6 +19,8 @@ import dev.blazelight.p4oc.domain.model.Part
 import dev.blazelight.p4oc.domain.model.Session
 import dev.blazelight.p4oc.domain.model.SessionStatus
 import dev.blazelight.p4oc.domain.model.TokenUsage
+import dev.blazelight.p4oc.domain.model.ToolState
+import dev.blazelight.p4oc.domain.model.isQuestionTool
 import dev.blazelight.p4oc.domain.session.SessionId
 import dev.blazelight.p4oc.domain.session.WorkspaceSession
 import kotlinx.coroutines.CancellationException
@@ -30,6 +34,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -45,6 +50,7 @@ class SessionRepositoryImpl(
     private val messageMapper: MessageMapper? = null,
     private val nowMs: () -> Long = { System.currentTimeMillis() },
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val questionFetcher: (suspend () -> List<QuestionRequestDto>)? = null,
 ) : SessionRepository {
     data class CachedSnapshot(
         val snapshot: Snapshot,
@@ -71,6 +77,10 @@ class SessionRepositoryImpl(
     private val messageStates = mutableMapOf<String, MutableStateFlow<List<MessageWithParts>>>()
     private val sessionUiStates = mutableMapOf<String, MutableStateFlow<SessionUiState>>()
     private val childToParentSessionIds = mutableMapOf<String, String>()
+
+    // Question reconciliation dedup state
+    private val detectedQuestionToolCallIds = mutableSetOf<String>()
+    private val recentlyResolvedQuestionIds = mutableMapOf<String, Long>()
 
     fun peek(): CachedSnapshot? {
         val cached = lastSuccess ?: return null
@@ -224,12 +234,66 @@ class SessionRepositoryImpl(
         }
     }
 
+    private suspend fun fetchPendingQuestions(): List<QuestionRequestDto> =
+        questionFetcher?.invoke() ?: (client as? WorkspaceClient)?.listPendingQuestions() ?: emptyList()
+
+    /**
+     * Reconcile pending questions from the server.
+     * Called when a question tool part is detected or on reconnect.
+     * Fetches the list of pending questions from GET /question and sets
+     * pendingQuestion on owned sessions that don't already have one.
+     * Skips questions that were recently resolved (anti-resurrection).
+     */
+    private suspend fun reconcilePendingQuestions() {
+        AppLog.d(TAG, "reconcilePendingQuestions: fetching pending questions")
+        val questionsToCheck = runCatching { fetchPendingQuestions() }
+            .getOrElse { error ->
+                AppLog.w(TAG, "Failed to fetch pending questions: ${error.message}")
+                return
+            }
+        AppLog.d(TAG, "reconcilePendingQuestions: fetched ${questionsToCheck.size} pending question(s)")
+
+        // Expire stale entries from recentlyResolvedQuestionIds
+        val now = nowMs()
+        synchronized(recentlyResolvedQuestionIds) {
+            recentlyResolvedQuestionIds.entries.removeAll { (_, resolvedAtMs) ->
+                now - resolvedAtMs > RESOLVED_QUESTION_TTL_MS
+            }
+        }
+
+        for (questionDto in questionsToCheck) {
+            // Skip if this question was recently resolved
+            val isRecentlyResolved = synchronized(recentlyResolvedQuestionIds) {
+                recentlyResolvedQuestionIds.containsKey(questionDto.id)
+            }
+            if (isRecentlyResolved) continue
+
+            // Try to set pendingQuestion on the owned session
+            updateOwnedSession(questionDto.sessionID) { state ->
+                if (state.pendingQuestion == null && state.queuedQuestions.none { it.id == questionDto.id }) {
+                    state.copy(pendingQuestion = mapQuestionRequestDtoToDomain(questionDto))
+                } else {
+                    state
+                }
+            }
+        }
+    }
+
     private fun hydrateAfterReconnect() {
         synchronized(this) {
             if (inFlight != null) return
             _state.value = RepoState.Hydrating(snapshot = state.value.snapshot, bufferedEvents = hydrateBuffer.size)
             inFlight = scope.async {
                 runCatching { hydrate(client.listProjects()) }
+            }
+        }
+        // Trigger question reconciliation after hydration (don't block event path)
+        scope.launch {
+            try {
+                inFlight?.await()
+                reconcilePendingQuestions()
+            } catch (e: Exception) {
+                AppLog.w(TAG, "Error during post-reconnect question reconciliation: ${e.message}")
             }
         }
     }
@@ -258,8 +322,23 @@ class SessionRepositoryImpl(
         }
     }
 
-    override fun clearQuestion(sessionId: SessionId) {
-        updateSession(sessionId.value) { state ->
+    override fun clearQuestion(sessionId: SessionId, requestId: String?) {
+        clearQuestionInternal(sessionId.value, requestId)
+    }
+
+    /**
+     * Internal implementation: clear the current pending question and promote the next queued question.
+     * If [requestId] is provided, record it as recently resolved for dedup.
+     */
+    private fun clearQuestionInternal(sessionId: String, requestId: String?) {
+        // Record the request ID if provided (for dismissQuestion path)
+        if (requestId != null) {
+            synchronized(recentlyResolvedQuestionIds) {
+                recentlyResolvedQuestionIds[requestId] = nowMs()
+            }
+        }
+
+        updateSession(sessionId) { state ->
             val nextQuestion = state.queuedQuestions.firstOrNull()
             state.copy(
                 pendingQuestion = nextQuestion,
@@ -275,8 +354,14 @@ class SessionRepositoryImpl(
      * promoted; if it is sitting in the queue, it is removed in place. Unknown
      * requestIDs are a no-op (idempotent — a resolution we never tracked, or one
      * already handled locally).
+     * Records the resolved ID for dedup to prevent re-surfacing within the TTL.
      */
     private fun resolveQuestion(eventSessionId: String, requestID: String) {
+        // Record this ID as recently resolved to prevent re-surfacing on reconcile
+        synchronized(recentlyResolvedQuestionIds) {
+            recentlyResolvedQuestionIds[requestID] = nowMs()
+        }
+
         updateOwnedSession(eventSessionId) { state ->
             when {
                 state.pendingQuestion?.id == requestID -> {
@@ -300,6 +385,16 @@ class SessionRepositoryImpl(
         val mapper = messageMapper ?: error("Message loading requires MessageMapper")
         val messages = workspaceClient.getMessages(sessionId.value, limit).map { dto -> mapper.mapWrapperToDomain(dto) }
         mergeLoadedMessages(sessionId.value, messages)
+        // A question tool part loaded via REST (state=running) means a question is
+        // pending that the live question.asked SSE event was missed for. Reconcile so
+        // the interactive card renders. (upsertPart only fires for live SSE updates,
+        // not REST history load, so this is the deterministic open-a-session trigger.)
+        val hasRunningQuestion = messages.any { mwp ->
+            mwp.parts.any { it is Part.Tool && it.isQuestionTool() && it.state is ToolState.Running }
+        }
+        if (hasRunningQuestion) {
+            reconcilePendingQuestions()
+        }
     }
 
     override fun sendMessageAsync(sessionId: SessionId, request: SendMessageRequest): Deferred<Result<Unit>> = scope.async {
@@ -328,6 +423,8 @@ class SessionRepositoryImpl(
         synchronized(messageStates) { messageStates.clear() }
         synchronized(sessionUiStates) { sessionUiStates.clear() }
         synchronized(childToParentSessionIds) { childToParentSessionIds.clear() }
+        synchronized(detectedQuestionToolCallIds) { detectedQuestionToolCallIds.clear() }
+        synchronized(recentlyResolvedQuestionIds) { recentlyResolvedQuestionIds.clear() }
     }
 
     suspend fun createSession(title: String?): WorkspaceSession {
@@ -577,6 +674,34 @@ class SessionRepositoryImpl(
     }
 
     private fun upsertPart(part: Part, delta: String?) {
+        // Handle question tool detection for reconciliation (Trigger 1)
+        if (part is Part.Tool && part.isQuestionTool()) {
+            when (part.state) {
+                is ToolState.Running -> {
+                    // Question tool is running - fetch pending questions to set card
+                    val isNewDetection = synchronized(detectedQuestionToolCallIds) {
+                        detectedQuestionToolCallIds.add(part.callID)
+                    }
+                    if (isNewDetection) {
+                        scope.launch {
+                            try {
+                                reconcilePendingQuestions()
+                            } catch (e: Exception) {
+                                AppLog.w(TAG, "Error reconciling questions on tool detection: ${e.message}")
+                            }
+                        }
+                    }
+                }
+                is ToolState.Completed, is ToolState.Error -> {
+                    // Tool finished - clean up from tracking set
+                    synchronized(detectedQuestionToolCallIds) {
+                        detectedQuestionToolCallIds.remove(part.callID)
+                    }
+                }
+                else -> Unit
+            }
+        }
+
         val state = messageState(part.sessionID)
         state.update { messages ->
             val existingMessage = messages.firstOrNull { it.message.id == part.messageID }
@@ -691,5 +816,6 @@ class SessionRepositoryImpl(
         const val FRESHNESS_MS = 30_000L
         const val MAX_CONCURRENT = 10
         const val TAG = "SessionRepository"
+        const val RESOLVED_QUESTION_TTL_MS = 30_000L
     }
 }

--- a/app/src/main/java/dev/blazelight/p4oc/data/session/SessionRepositoryImpl.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/data/session/SessionRepositoryImpl.kt
@@ -212,6 +212,8 @@ class SessionRepositoryImpl(
                     }
                 }
             }
+            is OpenCodeEvent.QuestionReplied -> resolveQuestion(event.sessionID, event.requestID)
+            is OpenCodeEvent.QuestionRejected -> resolveQuestion(event.sessionID, event.requestID)
             is OpenCodeEvent.TodoUpdated -> updateSession(event.sessionID) { it.copy(todos = event.todos) }
             is OpenCodeEvent.MessageUpdated -> upsertMessage(event.message)
             is OpenCodeEvent.MessagePartUpdated -> upsertPart(event.part, event.delta)
@@ -263,6 +265,32 @@ class SessionRepositoryImpl(
                 pendingQuestion = nextQuestion,
                 queuedQuestions = if (nextQuestion == null) emptyList() else state.queuedQuestions.drop(1),
             )
+        }
+    }
+
+    /**
+     * Resolve a question that was answered or rejected (by this client or any other,
+     * e.g. the desktop TUI). Clears it from the owning session's UI state by matching
+     * [requestID]: if it is the current pending question, the next queued question is
+     * promoted; if it is sitting in the queue, it is removed in place. Unknown
+     * requestIDs are a no-op (idempotent — a resolution we never tracked, or one
+     * already handled locally).
+     */
+    private fun resolveQuestion(eventSessionId: String, requestID: String) {
+        updateOwnedSession(eventSessionId) { state ->
+            when {
+                state.pendingQuestion?.id == requestID -> {
+                    val nextQuestion = state.queuedQuestions.firstOrNull()
+                    state.copy(
+                        pendingQuestion = nextQuestion,
+                        queuedQuestions = if (nextQuestion == null) emptyList() else state.queuedQuestions.drop(1),
+                    )
+                }
+                state.queuedQuestions.any { it.id == requestID } -> {
+                    state.copy(queuedQuestions = state.queuedQuestions.filterNot { it.id == requestID })
+                }
+                else -> state
+            }
         }
     }
 

--- a/app/src/main/java/dev/blazelight/p4oc/data/workspace/WorkspaceClient.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/data/workspace/WorkspaceClient.kt
@@ -105,6 +105,9 @@ class WorkspaceClient(
     suspend fun respondToQuestion(requestId: String, request: QuestionReplyRequest): Boolean =
         api.respondToQuestion(requestId, request, directory)
 
+    suspend fun rejectQuestion(requestId: String): Boolean =
+        api.rejectQuestion(requestId, directory)
+
     suspend fun listCommands(): List<CommandDto> = api.listCommands(directory)
 
     suspend fun executeCommand(sessionId: String, request: ExecuteCommandRequest): MessageWrapperDto =

--- a/app/src/main/java/dev/blazelight/p4oc/data/workspace/WorkspaceClient.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/data/workspace/WorkspaceClient.kt
@@ -14,6 +14,7 @@ import dev.blazelight.p4oc.data.remote.dto.MessageWrapperDto
 import dev.blazelight.p4oc.data.remote.dto.PermissionResponseRequest
 import dev.blazelight.p4oc.data.remote.dto.ProjectDto
 import dev.blazelight.p4oc.data.remote.dto.QuestionReplyRequest
+import dev.blazelight.p4oc.data.remote.dto.QuestionRequestDto
 import dev.blazelight.p4oc.data.remote.dto.RevertSessionRequest
 import dev.blazelight.p4oc.data.remote.dto.SendMessageRequest
 import dev.blazelight.p4oc.data.remote.dto.SessionDto
@@ -107,6 +108,9 @@ class WorkspaceClient(
 
     suspend fun rejectQuestion(requestId: String): Boolean =
         api.rejectQuestion(requestId, directory)
+
+    suspend fun listPendingQuestions(): List<QuestionRequestDto> =
+        api.listPendingQuestions(directory)
 
     suspend fun listCommands(): List<CommandDto> = api.listCommands(directory)
 

--- a/app/src/main/java/dev/blazelight/p4oc/domain/model/Event.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/domain/model/Event.kt
@@ -25,6 +25,12 @@ sealed class OpenCodeEvent {
     data class PermissionRequested(val permission: Permission) : OpenCodeEvent()
     data class PermissionReplied(val sessionID: String, val requestID: String, val reply: String) : OpenCodeEvent()
     data class QuestionAsked(val request: QuestionRequest) : OpenCodeEvent()
+    data class QuestionReplied(
+        val sessionID: String,
+        val requestID: String,
+        val answers: List<List<String>>,
+    ) : OpenCodeEvent()
+    data class QuestionRejected(val sessionID: String, val requestID: String) : OpenCodeEvent()
     data class TodoUpdated(val sessionID: String, val todos: List<Todo>) : OpenCodeEvent()
     data class CommandExecuted(
         val name: String,

--- a/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ChatScreen.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ChatScreen.kt
@@ -371,7 +371,7 @@ fun ChatScreen(
                             InlineQuestionCard(
                                 questionRequestId = questionRequest.id,
                                 questionData = dev.blazelight.p4oc.domain.model.QuestionData(questionRequest.questions),
-                                onDismiss = viewModel::dismissQuestion,
+                                onDismiss = { viewModel.dismissQuestion(questionRequest.id) },
                                 onSubmit = { answers ->
                                     viewModel.respondToQuestion(questionRequest.id, answers)
                                 },

--- a/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ChatViewModel.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ChatViewModel.kt
@@ -478,7 +478,7 @@ class ChatViewModel constructor(
         viewModelScope.launch {
             val request = QuestionReplyRequest(answers = answers)
             when (val result = safeApiCall { workspaceClient.respondToQuestion(requestId, request) }) {
-                is ApiResult.Success -> sessionRepository.clearQuestion(SessionId(sessionId))
+                is ApiResult.Success -> sessionRepository.clearQuestion(SessionId(sessionId), requestId)
                 is ApiResult.Error -> _uiState.update {
                     it.copy(
                         error = "Failed to answer question: ${result.message}"
@@ -496,11 +496,11 @@ class ChatViewModel constructor(
             // question.rejected SSE event (handled in SessionRepositoryImpl) will
             // also reconcile any other attached client.
             when (val result = safeApiCall { workspaceClient.rejectQuestion(requestId) }) {
-                is ApiResult.Success -> sessionRepository.clearQuestion(SessionId(sessionId))
+                is ApiResult.Success -> sessionRepository.clearQuestion(SessionId(sessionId), requestId)
                 is ApiResult.Error -> {
                     // A NotFound here means it was already resolved elsewhere — clear
                     // locally anyway so the user is not stuck on a dead modal.
-                    sessionRepository.clearQuestion(SessionId(sessionId))
+                    sessionRepository.clearQuestion(SessionId(sessionId), requestId)
                     AppLog.w(TAG, "rejectQuestion failed (clearing locally): ${result.message}")
                 }
             }

--- a/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ChatViewModel.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ChatViewModel.kt
@@ -488,8 +488,23 @@ class ChatViewModel constructor(
         }
     }
 
-    fun dismissQuestion() {
-        sessionRepository.clearQuestion(SessionId(sessionId))
+    fun dismissQuestion(requestId: String) {
+        viewModelScope.launch {
+            // Reject the question server-side so the agent's pending request is
+            // resolved (otherwise it stays pending forever and the session never
+            // goes idle). The local modal is cleared optimistically; the matching
+            // question.rejected SSE event (handled in SessionRepositoryImpl) will
+            // also reconcile any other attached client.
+            when (val result = safeApiCall { workspaceClient.rejectQuestion(requestId) }) {
+                is ApiResult.Success -> sessionRepository.clearQuestion(SessionId(sessionId))
+                is ApiResult.Error -> {
+                    // A NotFound here means it was already resolved elsewhere — clear
+                    // locally anyway so the user is not stuck on a dead modal.
+                    sessionRepository.clearQuestion(SessionId(sessionId))
+                    AppLog.w(TAG, "rejectQuestion failed (clearing locally): ${result.message}")
+                }
+            }
+        }
     }
 
     // --- Commands & Todos ---

--- a/app/src/test/java/dev/blazelight/p4oc/data/session/QuestionReconciliationTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/data/session/QuestionReconciliationTest.kt
@@ -1,0 +1,343 @@
+package dev.blazelight.p4oc.data.session
+
+import dev.blazelight.p4oc.data.remote.dto.QuestionDto
+import dev.blazelight.p4oc.data.remote.dto.QuestionOptionDto
+import dev.blazelight.p4oc.data.remote.dto.QuestionRequestDto
+import dev.blazelight.p4oc.data.remote.dto.QuestionToolRefDto
+import dev.blazelight.p4oc.domain.model.OpenCodeEvent
+import dev.blazelight.p4oc.domain.model.Part
+import dev.blazelight.p4oc.domain.model.QuestionRequest
+import dev.blazelight.p4oc.domain.model.Session
+import dev.blazelight.p4oc.domain.model.ToolState
+import dev.blazelight.p4oc.domain.session.SessionId
+import dev.blazelight.p4oc.fakes.FakeWorkspaceClient
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.buildJsonObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class QuestionReconciliationTest {
+
+    @Test
+    fun `running question tool part triggers reconciliation and sets pendingQuestion`() = runTest {
+        val sessionId = "sess_001"
+        val callId = "call_001"
+        val questionId = "que_001"
+        val questionDto = buildQuestionRequestDto(questionId, sessionId, callId)
+        var fetchCount = 0
+
+        val client = FakeWorkspaceClient()
+        val repository = SessionRepositoryImpl(
+            client,
+            nowMs = { testScheduler.currentTime },
+            dispatcher = StandardTestDispatcher(testScheduler),
+            questionFetcher = {
+                fetchCount++
+                listOf(questionDto)
+            }
+        )
+
+        // Initialize with a session
+        val session = Session(
+            id = sessionId,
+            projectID = "proj_001",
+            directory = "/test",
+            parentID = null,
+            title = "Test Session",
+            version = "1",
+            createdAt = 0L,
+            updatedAt = 0L,
+            compactingAt = null,
+            summary = null,
+            shareUrl = null,
+            revert = null
+        )
+        repository.acceptEvent(OpenCodeEvent.SessionCreated(session))
+
+        // Simulate a running question tool part
+        val toolPart = Part.Tool(
+            id = "part_001",
+            sessionID = sessionId,
+            messageID = "msg_001",
+            callID = callId,
+            toolName = "question",
+            state = ToolState.Running(
+                input = buildJsonObject {},
+                title = "Asking question",
+                startedAt = testScheduler.currentTime,
+                metadata = null
+            )
+        )
+        repository.acceptEvent(
+            OpenCodeEvent.MessagePartUpdated(toolPart, null)
+        )
+        advanceUntilIdle()
+
+        // Verify pendingQuestion was set via reconciliation
+        val sessionState = repository.sessionUiState(SessionId(sessionId))
+        assertNotNull("pendingQuestion should be set", sessionState.value.pendingQuestion)
+        assertEquals(questionId, sessionState.value.pendingQuestion?.id)
+        assertEquals(1, fetchCount)
+    }
+
+    @Test
+    fun `anti_thrash same callID does not trigger multiple fetches`() = runTest {
+        val sessionId = "sess_001"
+        val callId = "call_001"
+        val questionId = "que_001"
+        val questionDto = buildQuestionRequestDto(questionId, sessionId, callId)
+        var fetchCount = 0
+
+        val client = FakeWorkspaceClient()
+        val repository = SessionRepositoryImpl(
+            client,
+            nowMs = { testScheduler.currentTime },
+            dispatcher = StandardTestDispatcher(testScheduler),
+            questionFetcher = {
+                fetchCount++
+                listOf(questionDto)
+            }
+        )
+
+        val session = Session(
+            id = sessionId,
+            projectID = "proj_001",
+            directory = "/test",
+            parentID = null,
+            title = "Test Session",
+            version = "1",
+            createdAt = 0L,
+            updatedAt = 0L,
+            compactingAt = null,
+            summary = null,
+            shareUrl = null,
+            revert = null
+        )
+        repository.acceptEvent(OpenCodeEvent.SessionCreated(session))
+
+        // Simulate two Running updates with the same callID
+        repeat(2) {
+            val toolPart = Part.Tool(
+                id = "part_00${it + 1}",
+                sessionID = sessionId,
+                messageID = "msg_001",
+                callID = callId,
+                toolName = "question",
+                state = ToolState.Running(
+                    input = buildJsonObject {},
+                    title = "Asking question",
+                    startedAt = testScheduler.currentTime,
+                    metadata = null
+                )
+            )
+            repository.acceptEvent(
+                OpenCodeEvent.MessagePartUpdated(toolPart, null)
+            )
+        }
+        advanceUntilIdle()
+
+        // Should fetch only once despite two Running parts
+        assertEquals("fetchCount should be 1", 1, fetchCount)
+    }
+
+    @Test
+    fun `anti_resurrection recently resolved question is not re_surfaced on sweep`() = runTest {
+        val sessionId = "sess_001"
+        val questionId = "que_001"
+        val questionDto = buildQuestionRequestDto(questionId, sessionId, null)
+        var fetchCount = 0
+
+        val client = FakeWorkspaceClient()
+        val repository = SessionRepositoryImpl(
+            client,
+            nowMs = { testScheduler.currentTime },
+            dispatcher = StandardTestDispatcher(testScheduler),
+            questionFetcher = {
+                fetchCount++
+                listOf(questionDto)
+            }
+        )
+
+        val session = Session(
+            id = sessionId,
+            projectID = "proj_001",
+            directory = "/test",
+            parentID = null,
+            title = "Test Session",
+            version = "1",
+            createdAt = 0L,
+            updatedAt = 0L,
+            compactingAt = null,
+            summary = null,
+            shareUrl = null,
+            revert = null
+        )
+        repository.acceptEvent(OpenCodeEvent.SessionCreated(session))
+
+        // Simulate receiving a question.replied event (marks as resolved)
+        repository.acceptEvent(
+            OpenCodeEvent.QuestionReplied(sessionId, questionId, emptyList())
+        )
+        advanceUntilIdle()
+
+        var sessionState = repository.sessionUiState(SessionId(sessionId))
+        assertNull("pendingQuestion should be cleared after reply", sessionState.value.pendingQuestion)
+
+        // Now simulate a reconnect trigger that would fetch the same question
+        // The question should NOT be re-set due to anti-resurrection dedup
+        repository.acceptEvent(OpenCodeEvent.Connected)
+        advanceUntilIdle()
+
+        sessionState = repository.sessionUiState(SessionId(sessionId))
+        assertNull("pendingQuestion should not be re-surfaced within TTL", sessionState.value.pendingQuestion)
+        // fetchCount should be 1 (from the Connected event reconciliation)
+        assertEquals(1, fetchCount)
+    }
+
+    @Test
+    fun `reconnect sweep hydrates pendingQuestion`() = runTest {
+        val sessionId = "sess_001"
+        val questionId = "que_001"
+        val questionDto = buildQuestionRequestDto(questionId, sessionId, null)
+        var fetchCount = 0
+
+        val client = FakeWorkspaceClient()
+        val repository = SessionRepositoryImpl(
+            client,
+            nowMs = { testScheduler.currentTime },
+            dispatcher = StandardTestDispatcher(testScheduler),
+            questionFetcher = {
+                fetchCount++
+                listOf(questionDto)
+            }
+        )
+
+        val session = Session(
+            id = sessionId,
+            projectID = "proj_001",
+            directory = "/test",
+            parentID = null,
+            title = "Test Session",
+            version = "1",
+            createdAt = 0L,
+            updatedAt = 0L,
+            compactingAt = null,
+            summary = null,
+            shareUrl = null,
+            revert = null
+        )
+        repository.acceptEvent(OpenCodeEvent.SessionCreated(session))
+
+        // Initially no pending question
+        var sessionState = repository.sessionUiState(SessionId(sessionId))
+        assertNull("initially no pendingQuestion", sessionState.value.pendingQuestion)
+
+        // Simulate reconnect which triggers question reconciliation
+        repository.acceptEvent(OpenCodeEvent.Connected)
+        advanceUntilIdle()
+
+        // Question should now be set
+        sessionState = repository.sessionUiState(SessionId(sessionId))
+        assertNotNull("pendingQuestion should be set after reconnect", sessionState.value.pendingQuestion)
+        assertEquals(questionId, sessionState.value.pendingQuestion?.id)
+        assertEquals(1, fetchCount)
+    }
+
+    @Test
+    fun `clearQuestion with requestId records dedup id`() = runTest {
+        val sessionId = "sess_001"
+        val questionId = "que_001"
+        val questionDto = buildQuestionRequestDto(questionId, sessionId, null)
+        var fetchCount = 0
+
+        val client = FakeWorkspaceClient()
+        val repository = SessionRepositoryImpl(
+            client,
+            nowMs = { testScheduler.currentTime },
+            dispatcher = StandardTestDispatcher(testScheduler),
+            questionFetcher = {
+                fetchCount++
+                listOf(questionDto)
+            }
+        )
+
+        val session = Session(
+            id = sessionId,
+            projectID = "proj_001",
+            directory = "/test",
+            parentID = null,
+            title = "Test Session",
+            version = "1",
+            createdAt = 0L,
+            updatedAt = 0L,
+            compactingAt = null,
+            summary = null,
+            shareUrl = null,
+            revert = null
+        )
+        repository.acceptEvent(OpenCodeEvent.SessionCreated(session))
+
+        // Set a pending question via event
+        repository.acceptEvent(
+            OpenCodeEvent.QuestionAsked(
+                QuestionRequest(
+                    id = questionId,
+                    sessionID = sessionId,
+                    questions = emptyList(),
+                    tool = null
+                )
+            )
+        )
+        advanceUntilIdle()
+
+        var sessionState = repository.sessionUiState(SessionId(sessionId))
+        assertNotNull("pendingQuestion should be set", sessionState.value.pendingQuestion)
+
+        // Clear with requestId (dismissQuestion path)
+        repository.clearQuestion(SessionId(sessionId), questionId)
+        sessionState = repository.sessionUiState(SessionId(sessionId))
+        assertNull("pendingQuestion should be cleared", sessionState.value.pendingQuestion)
+
+        // Now trigger a reconciliation - the question should NOT be re-set
+        // because it was recorded in the dedup map
+        repository.acceptEvent(OpenCodeEvent.Connected)
+        advanceUntilIdle()
+
+        sessionState = repository.sessionUiState(SessionId(sessionId))
+        assertNull(
+            "pendingQuestion should not be re-surfaced after clearQuestion with id",
+            sessionState.value.pendingQuestion
+        )
+    }
+
+    // Helper functions
+    private fun buildQuestionRequestDto(
+        id: String,
+        sessionId: String,
+        callId: String?
+    ): QuestionRequestDto {
+        return QuestionRequestDto(
+            id = id,
+            sessionID = sessionId,
+            questions = listOf(
+                QuestionDto(
+                    header = "Test",
+                    question = "Do you want to continue?",
+                    options = listOf(
+                        QuestionOptionDto(label = "Yes", description = "Continue"),
+                        QuestionOptionDto(label = "No", description = "Stop")
+                    ),
+                    multiple = false,
+                    custom = true
+                )
+            ),
+            tool = callId?.let { QuestionToolRefDto(messageID = "msg_001", callID = it) }
+        )
+    }
+}

--- a/app/src/test/java/dev/blazelight/p4oc/fakes/FakeSessionRepository.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/fakes/FakeSessionRepository.kt
@@ -57,7 +57,7 @@ class FakeSessionRepository(
 
     override fun clearPermissionByRequestId(sessionId: SessionId, requestId: String) = Unit
 
-    override fun clearQuestion(sessionId: SessionId) = Unit
+    override fun clearQuestion(sessionId: SessionId, requestId: String?) = Unit
 
     override suspend fun loadMessages(sessionId: SessionId, limit: Int?) = Unit
 


### PR DESCRIPTION
## 🔗 Stacked PR — depends on #19 and #20
This PR is stacked on top of (and currently includes the commits of):
- **#19** — B1: clear question modal when resolved remotely (`question.replied` / `question.rejected`)
- **#20** — B2: Skip rejects the question server-side

B5 reuses B1's `resolveQuestion` + `QuestionReplied`/`QuestionRejected` events and B2's reject endpoint, so it does **not** build standalone. The diff below therefore currently includes the #19 + #20 changes — **review the final commit (`fix: recover pending question on session open/reconnect …`) for the B5-specific change.** Suggested merge order: **#19 → #20 → this**; after #19 and #20 land, rebasing reduces this diff to the B5-only change (8 files).

---

## Problem
Multi-choice questions (the `question` tool / AskUserQuestion) render as an interactive card in the octmux TUI but as a bare `● question` tool-call on the P4OC mobile client whenever the question was asked **before** the client opened/owned the session (cold open, reconnect, or app relaunch).

## Root cause
P4OC sets `pendingQuestion` (which drives `InlineQuestionCard`) **only** from the live, non-replayed `question.asked` SSE event (`/global/event` is `replay=0`). A question already pending when the user opens/reconnects to a session is never ingested; only its `question` tool part (loaded via REST) remains, rendered by the generic tool renderer. The `que_` requestID needed to reply lives only in `GET /question`, not the tool part.

## Fix
Add `GET /question` reconciliation that rebuilds `pendingQuestion` from authoritative server state, on three triggers:
- **`loadMessages`** (REST history load) when a loaded message has a running `question` tool part — the decisive open-a-session trigger;
- **`upsertPart`** when a running `question` tool part arrives via live SSE;
- **`OpenCodeEvent.Connected`** reconnect sweep.

Dedup: `detectedQuestionToolCallIds` (anti-thrash) + `recentlyResolvedQuestionIds` (30s TTL, anti-resurrection after reply/reject/skip). Surfaces zombie (abandoned) pending questions for manual drain. Reuses the existing `resolveQuestion` + reply/reject endpoints; extracts `mapQuestionRequestDtoToDomain`. Adds `QuestionReconciliationTest` (5 cases).

## Verification
- Unit: full `:app:testDebugUnitTest` green (incl. 5 new tests); `assembleDebug` OK.
- On-device (Samsung SM-S936B): opening a session with a pending question now fires `GET /question?directory=<dir>` -> 200 and renders the interactive card with all options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
