### PR TITLE
fix: list worktree and forked sessions in the session picker (scope=project)

### DIFF
--- a/app/src/main/java/dev/blazelight/p4oc/core/network/OpenCodeApi.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/core/network/OpenCodeApi.kt
@@ -26,6 +26,7 @@ interface OpenCodeApi {
     @GET("session")
     suspend fun listSessions(
         @Query("directory") directory: String?,
+        @Query("scope") scope: String? = null,
         @Query("roots") roots: Boolean? = null,
         @Query("start") start: Long? = null,
         @Query("search") search: String? = null,

--- a/app/src/main/java/dev/blazelight/p4oc/data/session/SessionRepositoryImpl.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/data/session/SessionRepositoryImpl.kt
@@ -394,7 +394,12 @@ class SessionRepositoryImpl(
                         async {
                             trackedStep("Loading sessions for ${project.worktree.substringAfterLast('/')}") {
                                 semaphore.withPermit {
-                                    client.listSessions(directory = project.worktree, roots = true, limit = 100)
+                                    client.listSessions(
+                                        directory = project.worktree,
+                                        roots = true,
+                                        limit = 100,
+                                        scope = "project",
+                                    )
                                 }
                             } to project
                         }

--- a/app/src/main/java/dev/blazelight/p4oc/data/workspace/SessionWorkspaceClient.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/data/workspace/SessionWorkspaceClient.kt
@@ -15,6 +15,7 @@ interface SessionWorkspaceClient {
 
     suspend fun listSessions(
         directory: String?,
+        scope: String? = null,
         roots: Boolean? = null,
         start: Long? = null,
         search: String? = null,

--- a/app/src/main/java/dev/blazelight/p4oc/data/workspace/WorkspaceClient.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/data/workspace/WorkspaceClient.kt
@@ -41,11 +41,12 @@ class WorkspaceClient(
 
     override suspend fun listSessions(
         directory: String?,
+        scope: String?,
         roots: Boolean?,
         start: Long?,
         search: String?,
         limit: Int?,
-    ): List<SessionDto> = api.listSessions(directory, roots, start, search, limit)
+    ): List<SessionDto> = api.listSessions(directory, scope, roots, start, search, limit)
 
     override suspend fun createSession(request: CreateSessionRequest): SessionDto =
         api.createSession(directory = directory, request = request)

--- a/app/src/test/java/dev/blazelight/p4oc/data/session/SessionRepositoryImplTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/data/session/SessionRepositoryImplTest.kt
@@ -48,6 +48,7 @@ class SessionRepositoryImplTest {
 
         assertSame(first, second)
         assertEquals(listOf(null, "/repo/p1"), client.listSessionsDirectories)
+        assertEquals(listOf(null, "project"), client.listSessionsScopes)
 
         client.statusBlocker?.complete(Unit)
         advanceUntilIdle()
@@ -96,6 +97,7 @@ class SessionRepositoryImplTest {
         assertTrue(result.isSuccess)
         assertEquals(1, client.listProjectsCalls)
         assertEquals(listOf(null, "/repo/p1"), client.listSessionsDirectories)
+        assertEquals(listOf(null, "project"), client.listSessionsScopes)
     }
 
     @Test

--- a/app/src/test/java/dev/blazelight/p4oc/fakes/FakeWorkspaceClient.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/fakes/FakeWorkspaceClient.kt
@@ -37,6 +37,7 @@ class FakeWorkspaceClient(
         private set
 
     val listSessionsDirectories = mutableListOf<String?>()
+    val listSessionsScopes = mutableListOf<String?>()
     val getSessionStatusesDirectories = mutableListOf<String?>()
 
     var projects: List<ProjectDto> = emptyList()
@@ -62,6 +63,7 @@ class FakeWorkspaceClient(
 
     override suspend fun listSessions(
         directory: String?,
+        scope: String?,
         roots: Boolean?,
         start: Long?,
         search: String?,
@@ -69,6 +71,7 @@ class FakeWorkspaceClient(
     ): List<SessionDto> {
         listSessionsCalls += 1
         listSessionsDirectories += directory
+        listSessionsScopes += scope
         listSessionsFailure?.let { throw it }
         return sessionsByDirectory?.get(directory) ?: listSessionsResult
     }


### PR DESCRIPTION
## Problem
Sessions started in a **git worktree**, and **forks** of a session that run in a
different directory, are invisible in the P4OC session picker — so they can
neither be opened nor attached to. (Example: a session created in a worktree of
the current project, and a fork of it that now runs in a different project's
directory, both silently absent from the list.)

## Root cause
The OpenCode server's `GET /session` applies a **literal directory-equality**
filter (`WHERE session.directory = <directory>`) **unless** the query carries
`scope=project`, in which case the server resolves the directory to a project
and returns **all** sessions for that project regardless of each session's own
`directory`.

`SessionRepositoryImpl.hydrate()` issued its per-project listing **without**
`scope=project`, so the server filtered out every session whose `directory`
differed from the project's worktree root:
- **worktree sessions** — their `directory` is the worktree subdir, not the
  worktree root the app queries;
- **cross-directory forks** — their `directory` is the fork's new CWD.

The app applies no client-side directory filter, and the attach path already
re-homes the tab to `session.directory` (`TabNavHost` → `updateTabWorkspace`),
so the defect was purely in **listing**.

## Fix
Thread an optional `scope` query param through `listSessions` and pass
`scope="project"` on the per-project hydrate call:
- `OpenCodeApi.listSessions` — add `@Query("scope") scope: String? = null`;
- `SessionWorkspaceClient` / `WorkspaceClient` — thread `scope` through;
- `SessionRepositoryImpl.hydrate()` — per-project call now sends
  `scope="project"` (still `roots=true`, so root-only — subagent children stay
  out of the picker).

The **global** (`directory=null`) call is left unchanged — `scope=project` is
meaningless without a directory to resolve — and the **Ofish**
literal-current-workspace probe is left unchanged.

> Note: there is a *separate* OpenCode-server bug where forking a session into a
> different project's directory records an inconsistent `project_id` (origin)
> vs `directory` (target). That is being fixed upstream in `opencode` and is out
> of scope here; this PR only fixes the P4OC listing query, which surfaces such
> forks regardless.

## Verification
- **Live server:** `GET /session?directory=<P4OC>&scope=project&roots=true`
  returns the worktree session and the cross-directory fork (both previously
  hidden), root-only.
- **Unit:** full `:app:testDebugUnitTest` green, including two new `scope`
  assertions in `SessionRepositoryImplTest` (per-project call observes
  `"project"`, global call observes `null`). `:app:compileDebugKotlin` and
  `:app:detekt` clean (no new findings).

Branch: `fix/list-worktree-and-forked-sessions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/theblazehen/P4OC/pull/24">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->