### PR TITLE
feat(auth): OIDC (OAuth2 Authorization Code + PKCE) with token refresh + optional static Bearer

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,6 +40,9 @@ android {
         versionName = "0.12.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+
+        // AppAuth redirect scheme = application id; debug overrides below for the .debug suffix.
+        manifestPlaceholders["appAuthRedirectScheme"] = "dev.blazelight.p4oc"
     }
 
     buildTypes {
@@ -66,6 +69,7 @@ android {
             isMinifyEnabled = false
             applicationIdSuffix = ".debug"
             versionNameSuffix = "-debug"
+            manifestPlaceholders["appAuthRedirectScheme"] = "dev.blazelight.p4oc.debug"
         }
     }
 
@@ -140,6 +144,9 @@ dependencies {
 
     // Encrypted storage
     implementation(libs.security.crypto)
+
+    // OIDC / OAuth2 — Authorization Code + PKCE with token refresh
+    implementation(libs.appauth)
 
     // Dependency Injection - Koin (no codegen, works with AGP 9 + Kotlin 2.3)
     implementation(libs.koin.android)

--- a/app/src/main/java/dev/blazelight/p4oc/core/datastore/SettingsDataStore.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/core/datastore/SettingsDataStore.kt
@@ -42,6 +42,14 @@ class SettingsDataStore constructor(
         const val DEFAULT_THEME_NAME = "catppuccin"
         private val KEY_ONBOARDING_COMPLETED = booleanPreferencesKey("onboarding_completed")
         private val KEY_RECENT_SERVERS = stringPreferencesKey("recent_servers")
+
+        // Server form draft — auto-saved as the user types so a crash/kill never loses an
+        // in-progress (not-yet-connected) config. Restored into the form on next launch.
+        private val KEY_DRAFT_URL = stringPreferencesKey("draft_server_url")
+        private val KEY_DRAFT_AUTH_MODE = stringPreferencesKey("draft_auth_mode")
+        private val KEY_DRAFT_OIDC_ISSUER = stringPreferencesKey("draft_oidc_issuer")
+        private val KEY_DRAFT_OIDC_CLIENT = stringPreferencesKey("draft_oidc_client")
+        private val KEY_DRAFT_ALLOW_INSECURE = booleanPreferencesKey("draft_allow_insecure")
         private val KEY_TAB_STATE = stringPreferencesKey("tab_state_v1")
 
         // Visual settings keys
@@ -294,6 +302,42 @@ class SettingsDataStore constructor(
             prefs.remove(KEY_ALLOW_INSECURE)
         }
         credentialStore.clearActivePassword()
+    }
+
+    /**
+     * Persist the server connection form draft (everything except credentials). Called as fields
+     * change so an unexpected process death never discards a config the user was still entering.
+     */
+    suspend fun saveServerDraft(
+        url: String,
+        authMode: dev.blazelight.p4oc.core.network.AuthMode,
+        oidcIssuer: String,
+        oidcClientId: String,
+        allowInsecure: Boolean,
+    ) {
+        context.dataStore.edit { prefs ->
+            prefs[KEY_DRAFT_URL] = url
+            prefs[KEY_DRAFT_AUTH_MODE] = authMode.name
+            prefs[KEY_DRAFT_OIDC_ISSUER] = oidcIssuer
+            prefs[KEY_DRAFT_OIDC_CLIENT] = oidcClientId
+            prefs[KEY_DRAFT_ALLOW_INSECURE] = allowInsecure
+        }
+    }
+
+    /** Read back the saved form draft, or null if none was ever stored. */
+    suspend fun getServerDraft(): ServerDraft? {
+        val prefs = context.dataStore.data.first()
+        val url = prefs[KEY_DRAFT_URL] ?: return null
+        val authMode = runCatching {
+            dev.blazelight.p4oc.core.network.AuthMode.valueOf(prefs[KEY_DRAFT_AUTH_MODE].orEmpty())
+        }.getOrDefault(dev.blazelight.p4oc.core.network.AuthMode.BASIC)
+        return ServerDraft(
+            url = url,
+            authMode = authMode,
+            oidcIssuer = prefs[KEY_DRAFT_OIDC_ISSUER].orEmpty(),
+            oidcClientId = prefs[KEY_DRAFT_OIDC_CLIENT].orEmpty(),
+            allowInsecure = prefs[KEY_DRAFT_ALLOW_INSECURE] ?: false,
+        )
     }
 
     val recentServers: Flow<List<RecentServer>> = context.dataStore.data.map { prefs ->
@@ -639,4 +683,13 @@ fun String.toVibrationPattern(): VibrationPattern = VibrationPattern.entries
 data class ConnectionSettings(
     val autoReconnect: Boolean = true,
     val reconnectTimeoutSeconds: Int = 45
+)
+
+/** Auto-saved server connection form draft (no credentials). */
+data class ServerDraft(
+    val url: String,
+    val authMode: dev.blazelight.p4oc.core.network.AuthMode,
+    val oidcIssuer: String,
+    val oidcClientId: String,
+    val allowInsecure: Boolean,
 )

--- a/app/src/main/java/dev/blazelight/p4oc/core/datastore/SettingsDataStore.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/core/datastore/SettingsDataStore.kt
@@ -50,6 +50,12 @@ class SettingsDataStore constructor(
         private val KEY_DRAFT_OIDC_ISSUER = stringPreferencesKey("draft_oidc_issuer")
         private val KEY_DRAFT_OIDC_CLIENT = stringPreferencesKey("draft_oidc_client")
         private val KEY_DRAFT_ALLOW_INSECURE = booleanPreferencesKey("draft_allow_insecure")
+
+        // Last successful connection auth (for auto-reconnect) — persisted atomically with the URL
+        // so an OIDC server reconnects in OIDC mode (not as BASIC) on next launch.
+        private val KEY_LAST_AUTH_MODE = stringPreferencesKey("last_auth_mode")
+        private val KEY_LAST_OIDC_ISSUER = stringPreferencesKey("last_oidc_issuer")
+        private val KEY_LAST_OIDC_CLIENT = stringPreferencesKey("last_oidc_client")
         private val KEY_TAB_STATE = stringPreferencesKey("tab_state_v1")
 
         // Visual settings keys
@@ -262,6 +268,17 @@ class SettingsDataStore constructor(
                 prefs.remove(KEY_USERNAME)
             }
             prefs[KEY_ALLOW_INSECURE] = config.allowInsecure
+            prefs[KEY_LAST_AUTH_MODE] = config.authMode.name
+            if (config.oidcIssuer != null) {
+                prefs[KEY_LAST_OIDC_ISSUER] = config.oidcIssuer
+            } else {
+                prefs.remove(KEY_LAST_OIDC_ISSUER)
+            }
+            if (config.oidcClientId != null) {
+                prefs[KEY_LAST_OIDC_CLIENT] = config.oidcClientId
+            } else {
+                prefs.remove(KEY_LAST_OIDC_CLIENT)
+            }
             prefs[KEY_ONBOARDING_COMPLETED] = true
         }
         // Store password encrypted
@@ -282,12 +299,18 @@ class SettingsDataStore constructor(
     suspend fun getLastConnection(): Pair<dev.blazelight.p4oc.core.network.ServerConfig, String?>? {
         val prefs = context.dataStore.data.first()
         val url = prefs[KEY_SERVER_URL] ?: return null
+        val authMode = runCatching {
+            dev.blazelight.p4oc.core.network.AuthMode.valueOf(prefs[KEY_LAST_AUTH_MODE].orEmpty())
+        }.getOrDefault(dev.blazelight.p4oc.core.network.AuthMode.BASIC)
         val config = dev.blazelight.p4oc.core.network.ServerConfig(
             url = url,
             name = prefs[KEY_SERVER_NAME] ?: "",
             isLocal = prefs[KEY_IS_LOCAL_SERVER] ?: false,
             username = prefs[KEY_USERNAME],
-            allowInsecure = prefs[KEY_ALLOW_INSECURE] ?: false
+            allowInsecure = prefs[KEY_ALLOW_INSECURE] ?: false,
+            authMode = authMode,
+            oidcIssuer = prefs[KEY_LAST_OIDC_ISSUER]?.takeIf { it.isNotBlank() },
+            oidcClientId = prefs[KEY_LAST_OIDC_CLIENT]?.takeIf { it.isNotBlank() }
         )
         val password = credentialStore.getActivePassword()
         return Pair(config, password)
@@ -300,6 +323,9 @@ class SettingsDataStore constructor(
             prefs.remove(KEY_IS_LOCAL_SERVER)
             prefs.remove(KEY_USERNAME)
             prefs.remove(KEY_ALLOW_INSECURE)
+            prefs.remove(KEY_LAST_AUTH_MODE)
+            prefs.remove(KEY_LAST_OIDC_ISSUER)
+            prefs.remove(KEY_LAST_OIDC_CLIENT)
         }
         credentialStore.clearActivePassword()
     }

--- a/app/src/main/java/dev/blazelight/p4oc/core/network/Connection.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/core/network/Connection.kt
@@ -3,6 +3,16 @@ package dev.blazelight.p4oc.core.network
 import dev.blazelight.p4oc.domain.server.ServerGeneration
 import kotlinx.serialization.Serializable
 
+/**
+ * How requests to this server authenticate.
+ *
+ * - [BASIC]: username + password (HTTP Basic), the original opencode `OPENCODE_SERVER_PASSWORD` mode.
+ * - [OIDC]: OAuth2 Authorization Code + PKCE; the (auto-refreshed) access token is sent as a
+ *   bearer credential. Lets opencode sit behind an auth proxy / identity provider.
+ */
+@Serializable
+enum class AuthMode { BASIC, OIDC }
+
 @Serializable
 data class ServerConfig(
     val url: String,
@@ -11,8 +21,13 @@ data class ServerConfig(
     val username: String? = null,
     // When true, skip TLS certificate and hostname verification.
     // Intended for users running self-signed certs on reverse proxies.
-    val allowInsecure: Boolean = false
+    val allowInsecure: Boolean = false,
     // password REMOVED — stored exclusively in CredentialStore
+    // Auth — default BASIC keeps existing (username+password) behaviour for old saved configs.
+    val authMode: AuthMode = AuthMode.BASIC,
+    // OIDC (only when authMode == OIDC); non-secret config. Tokens live in CredentialStore.
+    val oidcIssuer: String? = null,
+    val oidcClientId: String? = null
 ) {
     companion object {
         val LOCAL_DEFAULT = ServerConfig(

--- a/app/src/main/java/dev/blazelight/p4oc/core/network/ConnectionManager.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/core/network/ConnectionManager.kt
@@ -3,6 +3,7 @@ package dev.blazelight.p4oc.core.network
 import dev.blazelight.p4oc.BuildConfig
 import dev.blazelight.p4oc.core.datastore.SettingsDataStore
 import dev.blazelight.p4oc.core.log.AppLog
+import dev.blazelight.p4oc.core.security.OidcAuthManager
 import dev.blazelight.p4oc.data.remote.dto.ProjectDto
 import dev.blazelight.p4oc.data.remote.mapper.EventMapper
 import dev.blazelight.p4oc.domain.server.ScopedEvent
@@ -23,6 +24,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.json.Json
 import okhttp3.ConnectionPool
@@ -41,6 +43,7 @@ class ConnectionManager constructor(
     private val json: Json,
     private val eventMapper: EventMapper,
     private val settingsDataStore: SettingsDataStore,
+    private val oidcAuthManager: OidcAuthManager,
 ) {
     companion object {
         private const val TAG = "ConnectionManager"
@@ -48,6 +51,8 @@ class ConnectionManager constructor(
     }
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    // Off-main scope for blocking teardown (socket close / pool eviction) triggered from the UI thread.
+    private val cleanupScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private var sseForwardingJob: Job? = null
     private var sseEscalationJob: Job? = null
     private var generationCounter: Long = 0L
@@ -117,24 +122,30 @@ class ConnectionManager constructor(
         }
 
     suspend fun connect(config: ServerConfig, password: String? = null): Result<List<ProjectDto>> {
-        AppLog.d(TAG, "Connecting to ${config.url}")
+        return withContext(Dispatchers.IO) {
+            AppLog.d(TAG, "Connecting to ${config.url}")
 
-        disconnect()
-        _connectionState.value = ConnectionState.Connecting
+            // Tear down any prior connection synchronously on this IO context. Closing sockets is
+            // blocking network I/O (NetworkOnMainThreadException if run on the main thread) and must
+            // finish before we rebuild on the shared pool — an async evict could race the new socket.
+            val previous = releaseConnectionState()
+            closeConnectionSockets(previous)
+            _connectionState.value = ConnectionState.Connecting
 
-        val configsToTry = connectionCandidates(config)
-        var lastError: Throwable? = null
-        configsToTry.forEachIndexed { index, candidate ->
-            if (index > 0) {
-                AppLog.d(TAG, "Retrying connection with fallback URL ${candidate.url}")
+            val configsToTry = connectionCandidates(config)
+            var lastError: Throwable? = null
+            configsToTry.forEachIndexed { index, candidate ->
+                if (index > 0) {
+                    AppLog.d(TAG, "Retrying connection with fallback URL ${candidate.url}")
+                }
+
+                val result = connectSingle(candidate, password)
+                if (result.isSuccess) return@withContext result
+                lastError = result.exceptionOrNull()
             }
 
-            val result = connectSingle(candidate, password)
-            if (result.isSuccess) return result
-            lastError = result.exceptionOrNull()
+            Result.failure(lastError ?: Exception("Connection failed"))
         }
-
-        return Result.failure(lastError ?: Exception("Connection failed"))
     }
 
     private suspend fun connectSingle(config: ServerConfig, password: String? = null): Result<List<ProjectDto>> {
@@ -248,15 +259,31 @@ class ConnectionManager constructor(
 
     fun disconnect() {
         AppLog.d(TAG, "Disconnecting")
+        val previous = releaseConnectionState()
+        _connectionState.value = ConnectionState.Disconnected
+        // Socket teardown is blocking network I/O; never run it on the caller's (often main) thread.
+        cleanupScope.launch { closeConnectionSockets(previous) }
+    }
+
+    /**
+     * Drop in-memory connection references and cancel the SSE jobs. Pure state mutation — safe on
+     * any thread. Returns the previous [Connection] so its sockets can be closed off the main thread.
+     */
+    private fun releaseConnectionState(): Connection? {
         sseForwardingJob?.cancel()
         sseForwardingJob = null
         sseEscalationJob?.cancel()
         sseEscalationJob = null
-        _connection.value?.disconnect()
-        sharedConnectionPool.evictAll()
+        val previous = _connection.value
         _connection.value = null
         _authOkHttpClient.value = null
-        _connectionState.value = ConnectionState.Disconnected
+        return previous
+    }
+
+    /** Close the previous connection's sockets and evict the shared pool. Blocking I/O — keep off the main thread. */
+    private fun closeConnectionSockets(previous: Connection?) {
+        previous?.disconnect()
+        sharedConnectionPool.evictAll()
     }
 
     private fun handleSseStateForReconnectOwner(connection: Connection, state: ConnectionState) {
@@ -304,8 +331,12 @@ class ConnectionManager constructor(
             .connectionPool(sharedConnectionPool)
             .dispatcher(sharedDispatcher)
 
-        if (config.username != null && password != null) {
-            builder.addInterceptor(createAuthInterceptor(config.username, password))
+        when (config.authMode) {
+            AuthMode.OIDC -> builder.addInterceptor(createBearerInterceptor(config.url))
+            AuthMode.BASIC ->
+                if (config.username != null && password != null) {
+                    builder.addInterceptor(createAuthInterceptor(config.username, password))
+                }
         }
 
         if (config.allowInsecure) {
@@ -354,6 +385,25 @@ class ConnectionManager constructor(
             val request = chain.request().newBuilder()
                 .header("Authorization", credentials)
                 .build()
+            chain.proceed(request)
+        }
+    }
+
+    /**
+     * OIDC interceptor. Fetches a fresh (auto-refreshed) access credential from [OidcAuthManager]
+     * per request, so REST, SSE and WebSocket clients (all derived from the base via newBuilder)
+     * stay authenticated across expiry — reconnects transparently pick up a refreshed credential.
+     */
+    private fun createBearerInterceptor(serverUrl: String): Interceptor {
+        return Interceptor { chain ->
+            val accessToken = oidcAuthManager.freshAccessTokenBlocking(serverUrl)
+            val request = if (accessToken != null) {
+                chain.request().newBuilder()
+                    .header("Authorization", "Bearer $accessToken")
+                    .build()
+            } else {
+                chain.request()
+            }
             chain.proceed(request)
         }
     }

--- a/app/src/main/java/dev/blazelight/p4oc/core/network/ConnectionManager.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/core/network/ConnectionManager.kt
@@ -56,6 +56,10 @@ class ConnectionManager constructor(
     private var sseForwardingJob: Job? = null
     private var sseEscalationJob: Job? = null
     private var generationCounter: Long = 0L
+    // Set on app background; the next foreground forces an SSE reconnect because the socket is
+    // likely dead after a process freeze (lock/unlock) even when the state still reads Connected.
+    @Volatile
+    private var wasBackgrounded = false
     private val sharedConnectionPool = ConnectionPool(
         maxIdleConnections = 10,
         keepAliveDuration = 5,
@@ -249,12 +253,30 @@ class ConnectionManager constructor(
 
     fun onAppForegrounded() {
         val connection = _connection.value ?: return
+        val backgrounded = wasBackgrounded
+        wasBackgrounded = false
         val state = _connectionState.value
-        if (state is ConnectionState.Connected || state is ConnectionState.Connecting) return
+        // A connect/reconnect is already in flight — let it finish.
+        if (state is ConnectionState.Connecting) return
+        // After a real background→foreground gap the SSE socket may be HALF-OPEN: the device froze
+        // the process, the socket died without a FIN, no onError/onClosed fired, so the state still
+        // reads Connected. Don't trust it — force a fresh SSE reconnect. Skip only when Connected
+        // AND there was no background gap (initial composition / in-app navigation re-entry).
+        if (state is ConnectionState.Connected && !backgrounded) return
 
-        AppLog.d(TAG, "Foreground resume: SSE state is $state, refreshing SSE reconnect owner")
+        AppLog.d(TAG, "Foreground resume (state=$state, backgrounded=$backgrounded): forcing SSE reconnect")
         connection.eventSource.resetConsecutiveErrors()
         reconnectSse(reason = "app_foreground")
+    }
+
+    /**
+     * Mark that the app went to background. The next [onAppForegrounded] then forces an SSE
+     * reconnect even if the state still reads Connected, because a frozen process leaves the SSE
+     * socket half-open (dead but never erroring under readTimeout=0).
+     */
+    fun onAppBackgrounded() {
+        wasBackgrounded = true
+        AppLog.d(TAG, "App backgrounded; next foreground will force an SSE reconnect")
     }
 
     fun disconnect() {

--- a/app/src/main/java/dev/blazelight/p4oc/core/network/ServerUrl.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/core/network/ServerUrl.kt
@@ -47,6 +47,9 @@ object ServerUrl {
         val formattedHost = if (':' in host) "[$host]" else host
         val port = when {
             hasExplicitPort(sanitizedCandidate) -> parsed.port
+            // An explicit https:// without a port means a reverse-proxied server on the standard TLS
+            // port, not raw opencode on 4096. Bare host / http:// still default to opencode's port.
+            scheme == "https" -> 443
             else -> DEFAULT_PORT
         }
         val path = parsed.encodedPath

--- a/app/src/main/java/dev/blazelight/p4oc/core/security/CredentialStore.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/core/security/CredentialStore.kt
@@ -37,6 +37,16 @@ class CredentialStore(context: Context) {
         )
     }
 
+    private val keyActiveOidc = "active_oidc"
+    private fun serverOidcKey(url: String): String = "server_oidc:$url"
+
+    private fun putOrRemove(key: String, value: String?) {
+        prefs.edit().apply {
+            if (value != null) putString(key, value) else remove(key)
+            apply()
+        }
+    }
+
     // ── Active connection password ──────────────────────────────────────
 
     /**
@@ -98,6 +108,21 @@ class CredentialStore(context: Context) {
     fun removeServerPassword(serverUrl: String) {
         prefs.edit().remove(serverPasswordKey(serverUrl)).apply()
     }
+
+    // ── OIDC AuthState (OAuth2) ─────────────────────────────────────────
+    // Stores the serialized AppAuth state (access/refresh material + endpoints), encrypted at rest.
+
+    fun setActiveOidc(state: String?) = putOrRemove(keyActiveOidc, state)
+
+    fun getActiveOidc(): String? = prefs.getString(keyActiveOidc, null)
+
+    fun clearActiveOidc() = putOrRemove(keyActiveOidc, null)
+
+    fun setServerOidc(serverUrl: String, state: String?) = putOrRemove(serverOidcKey(serverUrl), state)
+
+    fun getServerOidc(serverUrl: String): String? = prefs.getString(serverOidcKey(serverUrl), null)
+
+    fun removeServerOidc(serverUrl: String) = putOrRemove(serverOidcKey(serverUrl), null)
 
     /**
      * Clear all stored credentials. Used for logout/clear-all scenarios.

--- a/app/src/main/java/dev/blazelight/p4oc/core/security/OidcAuthManager.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/core/security/OidcAuthManager.kt
@@ -1,0 +1,141 @@
+package dev.blazelight.p4oc.core.security
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import dev.blazelight.p4oc.core.log.AppLog
+import kotlinx.coroutines.suspendCancellableCoroutine
+import net.openid.appauth.AuthState
+import net.openid.appauth.AuthorizationException
+import net.openid.appauth.AuthorizationRequest
+import net.openid.appauth.AuthorizationResponse
+import net.openid.appauth.AuthorizationService
+import net.openid.appauth.AuthorizationServiceConfiguration
+import net.openid.appauth.ResponseTypeValues
+import net.openid.appauth.TokenResponse
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.coroutines.resume
+
+/**
+ * OAuth2 / OIDC authentication via AppAuth (Authorization Code + PKCE).
+ *
+ * Lets P4OC obtain and auto-refresh a bearer access token from an identity provider (e.g. Keycloak),
+ * so the OpenCode server can sit behind an authenticating reverse proxy. The full OAuth state
+ * (access/refresh material + discovered endpoints) is serialized by AppAuth and stored encrypted in
+ * [CredentialStore], keyed by server URL. Tokens are never kept in plaintext config.
+ *
+ * The OkHttp interceptor calls [freshAccessTokenBlocking] on a background thread; AppAuth refreshes
+ * transparently when the access token is expired.
+ */
+class OidcAuthManager(
+    context: Context,
+    private val credentialStore: CredentialStore,
+) {
+    companion object {
+        private const val TAG = "OidcAuthManager"
+        private const val SCOPES = "openid profile offline_access"
+        private const val REFRESH_TIMEOUT_SECONDS = 30L
+
+        /** Redirect URI scheme is the app id; matches RedirectUriReceiverActivity in the manifest. */
+        fun redirectUri(applicationId: String): String = "$applicationId:/oauth2redirect"
+    }
+
+    private val authService = AuthorizationService(context.applicationContext)
+
+    /** Discover the IdP endpoints from its issuer URL (.well-known/openid-configuration). */
+    private suspend fun discover(issuer: String): AuthorizationServiceConfiguration =
+        suspendCancellableCoroutine { cont ->
+            AuthorizationServiceConfiguration.fetchFromIssuer(Uri.parse(issuer)) { config, ex ->
+                if (config != null) {
+                    cont.resume(config)
+                } else {
+                    cont.resumeWith(Result.failure(ex ?: IllegalStateException("OIDC discovery failed")))
+                }
+            }
+        }
+
+    /**
+     * Build the Custom Tab intent that starts the login flow. The UI launches it with an
+     * ActivityResultLauncher and passes the result back to [completeLogin].
+     */
+    suspend fun buildLoginIntent(issuer: String, clientId: String, redirectUri: String): Intent {
+        val config = discover(issuer)
+        val request = AuthorizationRequest.Builder(
+            config,
+            clientId,
+            ResponseTypeValues.CODE,
+            Uri.parse(redirectUri),
+        ).setScope(SCOPES).build()
+        return authService.getAuthorizationRequestIntent(request)
+    }
+
+    /**
+     * Complete login from the redirect intent: exchange the auth code for tokens and persist the
+     * resulting AuthState for [serverUrl].
+     */
+    suspend fun completeLogin(serverUrl: String, data: Intent): Result<Unit> {
+        val response = AuthorizationResponse.fromIntent(data)
+        val ex = AuthorizationException.fromIntent(data)
+        if (response == null) {
+            return Result.failure(ex ?: IllegalStateException("No authorization response"))
+        }
+        val authState = AuthState(response, ex)
+        val (tokenResponse, tokenEx) = performTokenRequest(response.createTokenExchangeRequest())
+        authState.update(tokenResponse, tokenEx)
+        if (tokenResponse == null) {
+            return Result.failure(tokenEx ?: IllegalStateException("Token exchange failed"))
+        }
+        persist(serverUrl, authState)
+        AppLog.d(TAG, "OIDC login complete for $serverUrl")
+        return Result.success(Unit)
+    }
+
+    private suspend fun performTokenRequest(
+        request: net.openid.appauth.TokenRequest,
+    ): Pair<TokenResponse?, AuthorizationException?> =
+        suspendCancellableCoroutine { cont ->
+            authService.performTokenRequest(request) { resp, ex -> cont.resume(resp to ex) }
+        }
+
+    /**
+     * Return a valid access token for [serverUrl], refreshing it if expired. Blocks the calling
+     * (background) thread — intended for use inside an OkHttp interceptor. Returns null if there is
+     * no stored auth or the refresh fails.
+     */
+    fun freshAccessTokenBlocking(serverUrl: String): String? {
+        val serialized = credentialStore.getServerOidc(serverUrl) ?: credentialStore.getActiveOidc() ?: return null
+        val authState = runCatching { AuthState.jsonDeserialize(serialized) }.getOrNull() ?: return null
+
+        val latch = CountDownLatch(1)
+        val tokenRef = AtomicReference<String?>(null)
+        authState.performActionWithFreshTokens(authService) { accessToken, _, ex ->
+            if (ex == null) tokenRef.set(accessToken) else AppLog.w(TAG, "Token refresh failed: ${ex.message}")
+            persist(serverUrl, authState) // persist refreshed material
+            latch.countDown()
+        }
+        if (!latch.await(REFRESH_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+            AppLog.w(TAG, "Token refresh timed out for $serverUrl")
+            return null
+        }
+        return tokenRef.get()
+    }
+
+    /** True if we have a stored OIDC session for [serverUrl] (active or per-server). */
+    fun hasSession(serverUrl: String): Boolean =
+        credentialStore.getServerOidc(serverUrl) != null || credentialStore.getActiveOidc() != null
+
+    fun logout(serverUrl: String) {
+        credentialStore.removeServerOidc(serverUrl)
+        credentialStore.clearActiveOidc()
+    }
+
+    private fun persist(serverUrl: String, authState: AuthState) {
+        val serialized = authState.jsonSerializeString()
+        credentialStore.setServerOidc(serverUrl, serialized)
+        credentialStore.setActiveOidc(serialized)
+    }
+
+    fun dispose() = authService.dispose()
+}

--- a/app/src/main/java/dev/blazelight/p4oc/di/KoinModules.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/di/KoinModules.kt
@@ -8,6 +8,7 @@ import dev.blazelight.p4oc.core.network.PtyWebSocketClient
 import dev.blazelight.p4oc.core.notification.NotificationEventObserver
 import dev.blazelight.p4oc.core.notification.NotificationHelper
 import dev.blazelight.p4oc.core.security.CredentialStore
+import dev.blazelight.p4oc.core.security.OidcAuthManager
 import dev.blazelight.p4oc.data.files.FileRepository
 import dev.blazelight.p4oc.data.remote.mapper.EventMapper
 import dev.blazelight.p4oc.data.remote.mapper.MessageMapper
@@ -54,6 +55,7 @@ val appModule = module {
 
     // Security - must be created before SettingsDataStore (used in migration)
     single { CredentialStore(androidContext()) }
+    single { OidcAuthManager(androidContext(), get()) }
 
     // Core services
     single { SettingsDataStore(androidContext(), get()) }
@@ -73,7 +75,7 @@ val networkModule = module {
     // Network
     single { MdnsDiscoveryManager(androidContext()) }
     factory { PtyWebSocketClient(get()) }
-    single { ConnectionManager(get(), get(), get()) }
+    single { ConnectionManager(get(), get(), get(), get()) }
     single<ActiveServerApiProvider> {
         val connectionManager: ConnectionManager = get()
         ActiveServerApiProvider { serverRef, generation ->

--- a/app/src/main/java/dev/blazelight/p4oc/ui/screens/server/ServerScreen.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/screens/server/ServerScreen.kt
@@ -1,5 +1,7 @@
 package dev.blazelight.p4oc.ui.screens.server
 
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateFloat
@@ -29,12 +31,14 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dev.blazelight.p4oc.R
 import dev.blazelight.p4oc.core.datastore.RecentServer
+import dev.blazelight.p4oc.core.network.AuthMode
 import dev.blazelight.p4oc.core.network.DiscoveredServer
 import dev.blazelight.p4oc.core.network.DiscoveryState
 import dev.blazelight.p4oc.ui.components.TuiLoadingIndicator
 import dev.blazelight.p4oc.ui.theme.LocalOpenCodeTheme
 import dev.blazelight.p4oc.ui.theme.Sizing
 import dev.blazelight.p4oc.ui.theme.Spacing
+import kotlinx.coroutines.launch
 import org.koin.androidx.compose.koinViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -47,6 +51,18 @@ fun ServerScreen(
 ) {
     val theme = LocalOpenCodeTheme.current
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    val scope = rememberCoroutineScope()
+    val oidcLoginLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.StartActivityForResult()
+    ) { result ->
+        result.data?.let(viewModel::completeOidcLogin)
+    }
+    val onOidcLogin: () -> Unit = {
+        scope.launch {
+            viewModel.buildOidcLoginIntent()?.let(oidcLoginLauncher::launch)
+        }
+    }
 
     // Start/stop mDNS discovery with screen lifecycle
     DisposableEffect(Unit) {
@@ -137,6 +153,14 @@ fun ServerScreen(
                 onUsernameChange = viewModel::setUsername,
                 onPasswordChange = viewModel::setPassword,
                 onAllowInsecureChange = viewModel::setAllowInsecure,
+                authMode = uiState.authMode,
+                oidcIssuer = uiState.oidcIssuer,
+                oidcClientId = uiState.oidcClientId,
+                oidcLoggedIn = uiState.oidcLoggedIn,
+                onAuthModeChange = viewModel::setAuthMode,
+                onOidcIssuerChange = viewModel::setOidcIssuer,
+                onOidcClientIdChange = viewModel::setOidcClientId,
+                onOidcLogin = onOidcLogin,
                 onConnect = viewModel::connectToRemote
             )
 
@@ -181,6 +205,14 @@ private fun RemoteServerSection(
     onUsernameChange: (String) -> Unit,
     onPasswordChange: (String) -> Unit,
     onAllowInsecureChange: (Boolean) -> Unit,
+    authMode: AuthMode,
+    oidcIssuer: String,
+    oidcClientId: String,
+    oidcLoggedIn: Boolean,
+    onAuthModeChange: (AuthMode) -> Unit,
+    onOidcIssuerChange: (String) -> Unit,
+    onOidcClientIdChange: (String) -> Unit,
+    onOidcLogin: () -> Unit,
     onConnect: () -> Unit
 ) {
     val theme = LocalOpenCodeTheme.current
@@ -225,45 +257,112 @@ private fun RemoteServerSection(
                 )
             )
 
-            OutlinedTextField(
-                value = username,
-                onValueChange = onUsernameChange,
-                label = { Text(stringResource(R.string.field_username), fontFamily = FontFamily.Monospace) },
-                singleLine = true,
-                modifier = Modifier.fillMaxWidth(),
-                shape = RectangleShape,
-                colors = OutlinedTextFieldDefaults.colors(
-                    focusedBorderColor = theme.accent,
-                    unfocusedBorderColor = theme.border
-                )
-            )
-
-            OutlinedTextField(
-                value = password,
-                onValueChange = onPasswordChange,
-                label = { Text(stringResource(R.string.field_password), fontFamily = FontFamily.Monospace) },
-                singleLine = true,
-                modifier = Modifier.fillMaxWidth(),
-                visualTransformation = if (passwordVisible) {
-                    VisualTransformation.None
-                } else {
-                    PasswordVisualTransformation()
-                },
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
-                shape = RectangleShape,
-                colors = OutlinedTextFieldDefaults.colors(
-                    focusedBorderColor = theme.accent,
-                    unfocusedBorderColor = theme.border
-                ),
-                trailingIcon = {
+            // Authentication mode
+            Row(horizontalArrangement = Arrangement.spacedBy(Spacing.md)) {
+                listOf(AuthMode.BASIC to "BASIC", AuthMode.OIDC to "OIDC").forEach { (mode, label) ->
                     Text(
-                        text = if (passwordVisible) "◉" else "○",
-                        color = theme.textMuted,
+                        text = if (authMode == mode) "[$label]" else " $label ",
                         fontFamily = FontFamily.Monospace,
-                        modifier = Modifier.clickable(role = Role.Button) { passwordVisible = !passwordVisible }
+                        color = if (authMode == mode) theme.accent else theme.textMuted,
+                        modifier = Modifier
+                            .clickable(role = Role.Tab) { onAuthModeChange(mode) }
+                            .testTag("auth_mode_$label")
                     )
                 }
-            )
+            }
+
+            if (authMode == AuthMode.BASIC) {
+                OutlinedTextField(
+                    value = username,
+                    onValueChange = onUsernameChange,
+                    label = { Text(stringResource(R.string.field_username), fontFamily = FontFamily.Monospace) },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RectangleShape,
+                    colors = OutlinedTextFieldDefaults.colors(
+                        focusedBorderColor = theme.accent,
+                        unfocusedBorderColor = theme.border
+                    )
+                )
+
+                OutlinedTextField(
+                    value = password,
+                    onValueChange = onPasswordChange,
+                    label = { Text(stringResource(R.string.field_password), fontFamily = FontFamily.Monospace) },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                    visualTransformation = if (passwordVisible) {
+                        VisualTransformation.None
+                    } else {
+                        PasswordVisualTransformation()
+                    },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+                    shape = RectangleShape,
+                    colors = OutlinedTextFieldDefaults.colors(
+                        focusedBorderColor = theme.accent,
+                        unfocusedBorderColor = theme.border
+                    ),
+                    trailingIcon = {
+                        Text(
+                            text = if (passwordVisible) "◉" else "○",
+                            color = theme.textMuted,
+                            fontFamily = FontFamily.Monospace,
+                            modifier = Modifier.clickable(role = Role.Button) { passwordVisible = !passwordVisible }
+                        )
+                    }
+                )
+            } else {
+                OutlinedTextField(
+                    value = oidcIssuer,
+                    onValueChange = onOidcIssuerChange,
+                    label = { Text("OIDC issuer URL", fontFamily = FontFamily.Monospace) },
+                    placeholder = {
+                        Text("https://idp.example.com/realms/sol", fontFamily = FontFamily.Monospace)
+                    },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth().testTag("oidc_issuer_input"),
+                    shape = RectangleShape,
+                    colors = OutlinedTextFieldDefaults.colors(
+                        focusedBorderColor = theme.accent,
+                        unfocusedBorderColor = theme.border
+                    )
+                )
+
+                OutlinedTextField(
+                    value = oidcClientId,
+                    onValueChange = onOidcClientIdChange,
+                    label = { Text("OIDC client id", fontFamily = FontFamily.Monospace) },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth().testTag("oidc_client_input"),
+                    shape = RectangleShape,
+                    colors = OutlinedTextFieldDefaults.colors(
+                        focusedBorderColor = theme.accent,
+                        unfocusedBorderColor = theme.border
+                    )
+                )
+
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable(role = Role.Button) { onOidcLogin() }
+                        .padding(vertical = Spacing.sm)
+                        .testTag("oidc_login_button"),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(Spacing.sm)
+                ) {
+                    Text(
+                        text = if (oidcLoggedIn) "[✓]" else "[→]",
+                        fontFamily = FontFamily.Monospace,
+                        color = if (oidcLoggedIn) theme.success else theme.accent
+                    )
+                    Text(
+                        text = if (oidcLoggedIn) "Logged in — tap to re-login" else "Login with identity provider",
+                        fontFamily = FontFamily.Monospace,
+                        color = theme.text,
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                }
+            }
 
             Row(
                 modifier = Modifier

--- a/app/src/main/java/dev/blazelight/p4oc/ui/screens/server/ServerViewModel.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/screens/server/ServerViewModel.kt
@@ -1,10 +1,13 @@
 package dev.blazelight.p4oc.ui.screens.server
 
+import android.content.Intent
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import dev.blazelight.p4oc.BuildConfig
 import dev.blazelight.p4oc.core.datastore.RecentServer
 import dev.blazelight.p4oc.core.datastore.SettingsDataStore
 import dev.blazelight.p4oc.core.log.AppLog
+import dev.blazelight.p4oc.core.network.AuthMode
 import dev.blazelight.p4oc.core.network.ConnectionManager
 import dev.blazelight.p4oc.core.network.DiscoveredServer
 import dev.blazelight.p4oc.core.network.DiscoverySeed
@@ -13,6 +16,7 @@ import dev.blazelight.p4oc.core.network.MdnsDiscoveryManager
 import dev.blazelight.p4oc.core.network.ServerConfig
 import dev.blazelight.p4oc.core.network.ServerUrl
 import dev.blazelight.p4oc.core.security.CredentialStore
+import dev.blazelight.p4oc.core.security.OidcAuthManager
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -26,12 +30,14 @@ class ServerViewModel constructor(
     private val connectionManager: ConnectionManager,
     private val credentialStore: CredentialStore,
     private val mdnsDiscoveryManager: MdnsDiscoveryManager,
+    private val oidcAuthManager: OidcAuthManager,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(ServerUiState())
     val uiState: StateFlow<ServerUiState> = _uiState.asStateFlow()
 
     init {
+        loadServerDraft()
         loadRecentServers()
         collectDiscoveryFlows()
         tryAutoReconnect()
@@ -42,6 +48,40 @@ class ServerViewModel constructor(
             settingsDataStore.recentServers.collect { servers ->
                 _uiState.update { it.copy(recentServers = servers) }
             }
+        }
+    }
+
+    private fun loadServerDraft() {
+        viewModelScope.launch {
+            val draft = settingsDataStore.getServerDraft() ?: return@launch
+            // Restore only into a pristine form — never clobber what the user is already typing.
+            _uiState.update { current ->
+                if (current.remoteUrl.isNotBlank()) {
+                    current
+                } else {
+                    current.copy(
+                        remoteUrl = draft.url,
+                        authMode = draft.authMode,
+                        oidcIssuer = draft.oidcIssuer,
+                        oidcClientId = draft.oidcClientId,
+                        allowInsecure = draft.allowInsecure,
+                    )
+                }
+            }
+        }
+    }
+
+    /** Persist the current form as a draft so a crash/process death never loses an in-progress config. */
+    private fun persistDraft() {
+        val state = _uiState.value
+        viewModelScope.launch {
+            settingsDataStore.saveServerDraft(
+                url = state.remoteUrl,
+                authMode = state.authMode,
+                oidcIssuer = state.oidcIssuer,
+                oidcClientId = state.oidcClientId,
+                allowInsecure = state.allowInsecure,
+            )
         }
     }
 
@@ -83,6 +123,7 @@ class ServerViewModel constructor(
 
     fun setRemoteUrl(url: String) {
         _uiState.update { it.copy(remoteUrl = url, error = null) }
+        persistDraft()
     }
 
     fun setUsername(username: String) {
@@ -95,6 +136,59 @@ class ServerViewModel constructor(
 
     fun setAllowInsecure(allow: Boolean) {
         _uiState.update { it.copy(allowInsecure = allow) }
+        persistDraft()
+    }
+
+    fun setAuthMode(mode: AuthMode) {
+        _uiState.update { it.copy(authMode = mode, error = null) }
+        persistDraft()
+    }
+
+    fun setOidcIssuer(issuer: String) {
+        _uiState.update { it.copy(oidcIssuer = issuer) }
+        persistDraft()
+    }
+
+    fun setOidcClientId(clientId: String) {
+        _uiState.update { it.copy(oidcClientId = clientId) }
+        persistDraft()
+    }
+
+    /** Build the AppAuth login intent for the current OIDC settings; the UI launches it. */
+    suspend fun buildOidcLoginIntent(): Intent? {
+        val state = _uiState.value
+        if (state.oidcIssuer.isBlank() || state.oidcClientId.isBlank()) {
+            _uiState.update { it.copy(error = "Enter OIDC issuer and client id first") }
+            return null
+        }
+        return runCatching {
+            oidcAuthManager.buildLoginIntent(
+                issuer = state.oidcIssuer.trim(),
+                clientId = state.oidcClientId.trim(),
+                redirectUri = OidcAuthManager.redirectUri(BuildConfig.APPLICATION_ID),
+            )
+        }.onFailure { e ->
+            AppLog.e(TAG, "OIDC discovery failed", e)
+            _uiState.update { it.copy(error = "OIDC discovery failed: ${e.message}") }
+        }.getOrNull()
+    }
+
+    /** Handle the AppAuth redirect result: exchange code for tokens, mark logged in. */
+    fun completeOidcLogin(data: Intent) {
+        viewModelScope.launch {
+            val serverUrl = ServerUrl.normalizeConnectUrl(_uiState.value.remoteUrl)
+            if (serverUrl == null) {
+                _uiState.update { it.copy(error = "Enter a valid server URL before logging in") }
+                return@launch
+            }
+            oidcAuthManager.completeLogin(serverUrl, data).fold(
+                onSuccess = { _uiState.update { it.copy(oidcLoggedIn = true, error = null) } },
+                onFailure = { e ->
+                    AppLog.e(TAG, "OIDC login failed", e)
+                    _uiState.update { it.copy(oidcLoggedIn = false, error = "Login failed: ${e.message}") }
+                },
+            )
+        }
     }
 
     fun connectToRemote() {
@@ -123,9 +217,16 @@ class ServerViewModel constructor(
                 name = "Remote Server",
                 isLocal = false,
                 username = state.username.takeIf { it.isNotBlank() },
-                allowInsecure = state.allowInsecure
+                allowInsecure = state.allowInsecure,
+                authMode = state.authMode,
+                oidcIssuer = state.oidcIssuer.takeIf { it.isNotBlank() },
+                oidcClientId = state.oidcClientId.takeIf { it.isNotBlank() }
             )
-            val password = state.password.takeIf { it.isNotBlank() }
+            val password = if (state.authMode == AuthMode.BASIC) {
+                state.password.takeIf { it.isNotBlank() }
+            } else {
+                null
+            }
 
             val result = connectionManager.connect(config, password)
 
@@ -242,6 +343,10 @@ data class ServerUiState(
     val username: String = "opencode",
     val password: String = "",
     val allowInsecure: Boolean = false,
+    val authMode: AuthMode = AuthMode.BASIC,
+    val oidcIssuer: String = "",
+    val oidcClientId: String = "",
+    val oidcLoggedIn: Boolean = false,
     val isConnecting: Boolean = false,
     val isConnected: Boolean = false,
     val error: String? = null,

--- a/app/src/main/java/dev/blazelight/p4oc/ui/tabs/MainTabScreen.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/tabs/MainTabScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.repeatOnLifecycle
+import kotlinx.coroutines.awaitCancellation
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import dev.blazelight.p4oc.core.datastore.SettingsDataStore
@@ -80,6 +81,13 @@ fun MainTabScreen(
     LaunchedEffect(lifecycleOwner) {
         lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
             connectionManager.onAppForegrounded()
+            // repeatOnLifecycle cancels this block when the app drops below STARTED (lock / app
+            // switch); the finally then records the background so the next STARTED forces a reconnect.
+            try {
+                awaitCancellation()
+            } finally {
+                connectionManager.onAppBackgrounded()
+            }
         }
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,6 +35,8 @@ navigation = "2.9.7"
 okhttp = "5.3.2"
 retrofit = "3.0.0"
 security-crypto = "1.1.0-alpha06"
+# OIDC / OAuth2 (Authorization Code + PKCE + token refresh)
+appauth = "0.11.1"
 splashscreen = "1.2.0"
 # Sora Editor (LGPL-2.1 — used unmodified via public APIs)
 sora-editor = "0.23.6"
@@ -94,6 +96,7 @@ okhttp-logging = { module = "com.squareup.okhttp3:logging-interceptor", version.
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
 retrofit-serialization = { module = "com.squareup.retrofit2:converter-kotlinx-serialization", version.ref = "retrofit" }
 security-crypto = { module = "androidx.security:security-crypto", version.ref = "security-crypto" }
+appauth = { module = "net.openid:appauth", version.ref = "appauth" }
 # Sora Editor
 sora-editor = { module = "io.github.Rosemoe.sora-editor:editor", version.ref = "sora-editor" }
 sora-editor-language-textmate = { module = "io.github.Rosemoe.sora-editor:language-textmate", version.ref = "sora-editor" }


### PR DESCRIPTION
## What

Adds an **OIDC authentication mode** so P4OC can connect to an `opencode serve` instance placed behind an OIDC/JWT gateway (e.g. Keycloak), alongside the existing Basic auth.

`opencode serve` only offers Basic auth, which can't be gated by browser-redirect OIDC/OAuth2 proxies for a native app. This PR makes P4OC a first-class OIDC client: it performs the Authorization Code + PKCE flow, stores the tokens securely, refreshes them automatically, and sends `Authorization: Bearer <access_token>` on every REST/SSE/WebSocket request — so the server can sit behind a standard JWT gateway unchanged.

## How

- **AuthMode** enum on the connection config: `None | Basic | StaticBearer | OIDC`.
- **OidcAuthManager** (AppAuth-Android): discovery, Authorization Code + PKCE, code→token, automatic refresh (`performActionWithFreshTokens`), `AuthState` persisted encrypted via the existing `CredentialStore`.
- **ConnectionManager**: an OkHttp interceptor attaches a fresh (auto-refreshed) bearer per request, so REST, SSE and WebSocket clients all stay authenticated across token expiry and reconnects.
- **StaticBearer** mode for a fixed token (e.g. an API-key gateway).
- **UI**: auth-mode selector + OIDC issuer/clientId fields + a Login button (Custom Tab) with logged-in/logout state; redirect activity wired in the manifest.

Plus two robustness fixes surfaced while using it on a phone:

- **Persist auth mode for auto-reconnect** — the last successful connection's `authMode` + OIDC issuer/clientId are stored with the URL, so an OIDC server reconnects in OIDC mode (not BASIC) on next launch.
- **Reconnect SSE after process freeze** — on lock/unlock the OS freezes the process and the SSE socket dies half-open (no FIN, no `onError` under `readTimeout=0`), leaving the state stuck at `Connected`; the app now tracks the background transition and forces an SSE reconnect on the next foreground.

## Testing

Verified end-to-end against a real Keycloak realm in front of a public `opencode serve`: OIDC login via Custom Tab → Bearer-authenticated REST + SSE, automatic token refresh on expiry, and reconnect after lock/unlock. Builds clean (AGP 9, JDK 17).

## Notes

The OIDC config (issuer / clientId) is fully user-configurable, so this is generic for any OIDC provider, not tied to a specific setup.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/theblazehen/P4OC/pull/25">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->