### PR TITLE
feat(search): in-chat message search and session list filter

### DIFF
--- a/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ChatScreen.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ChatScreen.kt
@@ -3,10 +3,11 @@ package dev.blazelight.p4oc.ui.screens.chat
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -135,6 +136,13 @@ fun ChatScreen(
     var showFilePicker by remember { mutableStateOf(false) }
     var showRevertDialog by remember { mutableStateOf<String?>(null) }
 
+    // In-chat search: query + current hit, reset whenever the open session changes.
+    var showSearch by remember(uiState.session?.id) { mutableStateOf(false) }
+    var searchQuery by remember(uiState.session?.id) { mutableStateOf("") }
+    var currentMatchIndex by remember(uiState.session?.id) { mutableStateOf(0) }
+    val messageBlocks = remember(messages) { groupMessagesIntoBlocks(messages) }
+    val searchMatches = remember(messageBlocks, searchQuery) { findChatMatches(messageBlocks, searchQuery) }
+
     // Scroll UX state: follow new tail content only while the user remains pinned to bottom.
     var shouldFollowTail by remember(uiState.session?.id) { mutableStateOf(true) }
     var hasNewContentWhileAway by remember { mutableStateOf(false) }
@@ -160,9 +168,14 @@ fun ChatScreen(
     val keyboardController = LocalSoftwareKeyboardController.current
 
     BackHandler {
-        focusManager.clearFocus()
-        keyboardController?.hide()
-        onNavigateBack()
+        if (showSearch) {
+            showSearch = false
+            searchQuery = ""
+        } else {
+            focusManager.clearFocus()
+            keyboardController?.hide()
+            onNavigateBack()
+        }
     }
 
     // Match the sticky follow-tail model: only update follow state after the user's scroll settles.
@@ -213,6 +226,17 @@ fun ChatScreen(
         }
     }
 
+    // Keep the active hit in range when matches change, and scroll it into view.
+    LaunchedEffect(searchMatches.size) {
+        if (currentMatchIndex >= searchMatches.size) currentMatchIndex = 0
+    }
+    LaunchedEffect(currentMatchIndex, searchMatches) {
+        searchMatches.getOrNull(currentMatchIndex)?.let { match ->
+            shouldFollowTail = false
+            listState.scrollToItem(match.blockIndex)
+        }
+    }
+
     Scaffold(
         topBar = {
             ChatTopBar(
@@ -221,6 +245,10 @@ fun ChatScreen(
                 onBack = onNavigateBack,
                 onTerminal = onOpenTerminal,
                 onFiles = onOpenFiles,
+                onSearch = {
+                    showSearch = true
+                    currentMatchIndex = 0
+                },
                 onCommands = {
                     viewModel.refreshCommandsIfNeeded(force = true)
                     showCommandPalette = true
@@ -295,11 +323,38 @@ fun ChatScreen(
             }
         }
     ) { padding ->
-        Box(
+        Column(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(padding)
         ) {
+            if (showSearch) {
+                ChatSearchBar(
+                    query = searchQuery,
+                    onQueryChange = { searchQuery = it },
+                    matchCount = searchMatches.size,
+                    currentIndex = currentMatchIndex,
+                    onPrev = {
+                        if (searchMatches.isNotEmpty()) {
+                            currentMatchIndex = (currentMatchIndex - 1 + searchMatches.size) % searchMatches.size
+                        }
+                    },
+                    onNext = {
+                        if (searchMatches.isNotEmpty()) {
+                            currentMatchIndex = (currentMatchIndex + 1) % searchMatches.size
+                        }
+                    },
+                    onClose = {
+                        showSearch = false
+                        searchQuery = ""
+                    },
+                )
+            }
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .weight(1f)
+            ) {
             // Revert active banner
             uiState.session?.revert?.let {
                 val theme = LocalOpenCodeTheme.current
@@ -334,10 +389,6 @@ fun ChatScreen(
             if (!hasContent && !uiState.isLoading) {
                 EmptyChatView(modifier = Modifier.align(Alignment.Center))
             } else {
-                val messageBlocks = remember(messages) {
-                    groupMessagesIntoBlocks(messages)
-                }
-
                 LazyColumn(
                     state = listState,
                     modifier = Modifier.fillMaxSize().testTag("message_list"),
@@ -345,25 +396,34 @@ fun ChatScreen(
                     verticalArrangement = Arrangement.spacedBy(Spacing.hairline),
                 ) {
                     // All messages - stable keys ensure only changed items recompose
-                    items(
+                    itemsIndexed(
                         items = messageBlocks,
-                        key = { block ->
+                        key = { _, block ->
                             when (block) {
                                 is MessageBlock.UserBlock -> block.message.message.id
                                 is MessageBlock.AssistantBlock -> block.messages.first().message.id
                             }
                         }
-                    ) { block ->
-                        MessageBlockView(
-                            block = block,
-                            onToolApprove = { viewModel.respondToPermission(it, "once") },
-                            onToolDeny = { viewModel.respondToPermission(it, "reject") },
-                            onToolAlways = { viewModel.respondToPermission(it, "always") },
-                            onOpenSubSession = onOpenSubSession,
-                            defaultToolWidgetState = defaultToolWidgetState,
-                            pendingPermissionsByCallId = pendingPermissionsByCallId,
-                            onRevert = { messageId -> showRevertDialog = messageId }
-                        )
+                    ) { index, block ->
+                        val isCurrentMatch = showSearch && searchQuery.isNotBlank() &&
+                            searchMatches.getOrNull(currentMatchIndex)?.blockIndex == index
+                        val highlight = if (isCurrentMatch) {
+                            Modifier.background(LocalOpenCodeTheme.current.accent.copy(alpha = 0.08f))
+                        } else {
+                            Modifier
+                        }
+                        Box(modifier = highlight) {
+                            MessageBlockView(
+                                block = block,
+                                onToolApprove = { viewModel.respondToPermission(it, "once") },
+                                onToolDeny = { viewModel.respondToPermission(it, "reject") },
+                                onToolAlways = { viewModel.respondToPermission(it, "always") },
+                                onOpenSubSession = onOpenSubSession,
+                                defaultToolWidgetState = defaultToolWidgetState,
+                                pendingPermissionsByCallId = pendingPermissionsByCallId,
+                                onRevert = { messageId -> showRevertDialog = messageId }
+                            )
+                        }
                     }
 
                     pendingQuestion?.let { questionRequest ->
@@ -423,6 +483,7 @@ fun ChatScreen(
                     .align(Alignment.BottomEnd)
                     .padding(end = Spacing.xl, bottom = Spacing.md)
             )
+            }
         }
     }
 
@@ -498,6 +559,7 @@ private fun ChatTopBar(
     onBack: () -> Unit,
     onTerminal: () -> Unit,
     onFiles: () -> Unit,
+    onSearch: () -> Unit,
     onCommands: () -> Unit,
     onViewChanges: () -> Unit,
     branchName: String? = null,
@@ -561,6 +623,13 @@ private fun ChatTopBar(
                     expanded = showOverflow,
                     onDismissRequest = { showOverflow = false }
                 ) {
+                    TuiDropdownMenuItem(
+                        text = "⌕ ${stringResource(R.string.chat_search_action)}",
+                        onClick = {
+                            showOverflow = false
+                            onSearch()
+                        }
+                    )
                     TuiDropdownMenuItem(
                         text = "± ${stringResource(R.string.sessions_view_changes)}",
                         onClick = {

--- a/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ChatSearch.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ChatSearch.kt
@@ -1,0 +1,53 @@
+package dev.blazelight.p4oc.ui.screens.chat
+
+import dev.blazelight.p4oc.domain.model.MessageWithParts
+import dev.blazelight.p4oc.domain.model.Part
+
+/**
+ * A search hit inside the open conversation: the LazyColumn block index that
+ * contains the query (used to scroll the match into view) plus the id of the
+ * first message in that block (stable identity for highlighting).
+ */
+internal data class ChatSearchMatch(
+    val blockIndex: Int,
+    val messageId: String,
+)
+
+/**
+ * The plain text of a message a user could meaningfully search: visible content
+ * ([Part.Text]), model reasoning ([Part.Reasoning]), invoked tool names and
+ * sub-task prompts. Binary/structural parts (files, patches, snapshots) are skipped.
+ */
+internal fun MessageWithParts.searchableText(): String = buildString {
+    parts.forEach { part ->
+        when (part) {
+            is Part.Text -> append(part.text).append('\n')
+            is Part.Reasoning -> append(part.text).append('\n')
+            is Part.Tool -> append(part.toolName).append('\n')
+            is Part.Subtask -> append(part.prompt).append('\n').append(part.description).append('\n')
+            else -> {}
+        }
+    }
+}
+
+/**
+ * Blocks containing [query] (case-insensitive substring), in display order.
+ * Returns an empty list for a blank query. Pure function — trivially testable
+ * and recomputed via `remember(blocks, query)` on each keystroke.
+ */
+internal fun findChatMatches(blocks: List<MessageBlock>, query: String): List<ChatSearchMatch> {
+    val needle = query.trim()
+    if (needle.isEmpty()) return emptyList()
+    val matches = ArrayList<ChatSearchMatch>()
+    blocks.forEachIndexed { index, block ->
+        val messages = when (block) {
+            is MessageBlock.UserBlock -> listOf(block.message)
+            is MessageBlock.AssistantBlock -> block.messages
+        }
+        val firstId = messages.firstOrNull()?.message?.id ?: return@forEachIndexed
+        if (messages.any { it.searchableText().contains(needle, ignoreCase = true) }) {
+            matches.add(ChatSearchMatch(index, firstId))
+        }
+    }
+    return matches
+}

--- a/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ChatSearchBar.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ChatSearchBar.kt
@@ -1,0 +1,127 @@
+package dev.blazelight.p4oc.ui.screens.chat
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
+import dev.blazelight.p4oc.R
+import dev.blazelight.p4oc.ui.theme.LocalOpenCodeTheme
+import dev.blazelight.p4oc.ui.theme.Sizing
+import dev.blazelight.p4oc.ui.theme.Spacing
+
+/**
+ * In-chat search bar: a transparent-bordered query field plus a match counter
+ * ("3/12"), previous/next navigation and a close button. Mirrors the file/command
+ * search UX. Auto-focuses on appearance so the keyboard opens immediately.
+ */
+@Composable
+internal fun ChatSearchBar(
+    query: String,
+    onQueryChange: (String) -> Unit,
+    matchCount: Int,
+    currentIndex: Int,
+    onPrev: () -> Unit,
+    onNext: () -> Unit,
+    onClose: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val theme = LocalOpenCodeTheme.current
+    val focusRequester = remember { FocusRequester() }
+    LaunchedEffect(Unit) { focusRequester.requestFocus() }
+
+    Surface(color = theme.backgroundPanel, shape = RectangleShape, modifier = modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = Spacing.sm, vertical = Spacing.xxs),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(Spacing.xxs),
+        ) {
+            Text(
+                text = "⌕",
+                color = theme.accent,
+                fontFamily = FontFamily.Monospace,
+                style = MaterialTheme.typography.titleMedium,
+            )
+            OutlinedTextField(
+                value = query,
+                onValueChange = onQueryChange,
+                placeholder = {
+                    Text(
+                        text = stringResource(R.string.chat_search_placeholder),
+                        color = theme.textMuted,
+                        fontFamily = FontFamily.Monospace,
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                },
+                singleLine = true,
+                textStyle = MaterialTheme.typography.bodySmall.copy(
+                    fontFamily = FontFamily.Monospace,
+                    color = theme.text,
+                ),
+                modifier = Modifier
+                    .weight(1f)
+                    .focusRequester(focusRequester),
+                colors = OutlinedTextFieldDefaults.colors(
+                    focusedBorderColor = Color.Transparent,
+                    unfocusedBorderColor = Color.Transparent,
+                    cursorColor = theme.accent,
+                    focusedTextColor = theme.text,
+                    unfocusedTextColor = theme.text,
+                ),
+            )
+            val counter = when {
+                query.isBlank() -> ""
+                matchCount == 0 -> stringResource(R.string.chat_search_no_matches)
+                else -> "${currentIndex + 1}/$matchCount"
+            }
+            if (counter.isNotEmpty()) {
+                Text(
+                    text = counter,
+                    color = theme.textMuted,
+                    fontFamily = FontFamily.Monospace,
+                    style = MaterialTheme.typography.labelSmall,
+                )
+            }
+            SearchGlyphButton("↑", enabled = matchCount > 0, onClick = onPrev, color = theme.accent, mutedColor = theme.textMuted)
+            SearchGlyphButton("↓", enabled = matchCount > 0, onClick = onNext, color = theme.accent, mutedColor = theme.textMuted)
+            SearchGlyphButton("✕", enabled = true, onClick = onClose, color = theme.textMuted, mutedColor = theme.textMuted)
+        }
+    }
+}
+
+@Composable
+private fun SearchGlyphButton(
+    glyph: String,
+    enabled: Boolean,
+    onClick: () -> Unit,
+    color: Color,
+    mutedColor: Color,
+) {
+    IconButton(onClick = onClick, enabled = enabled, modifier = Modifier.size(Sizing.iconButtonMd)) {
+        Text(
+            text = glyph,
+            color = if (enabled) color else mutedColor,
+            fontFamily = FontFamily.Monospace,
+            style = MaterialTheme.typography.titleSmall,
+        )
+    }
+}

--- a/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ChatSearchBar.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ChatSearchBar.kt
@@ -20,7 +20,10 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontFamily
 import dev.blazelight.p4oc.R
 import dev.blazelight.p4oc.ui.theme.LocalOpenCodeTheme
@@ -79,7 +82,8 @@ internal fun ChatSearchBar(
                 ),
                 modifier = Modifier
                     .weight(1f)
-                    .focusRequester(focusRequester),
+                    .focusRequester(focusRequester)
+                    .testTag("chat_search_field"),
                 colors = OutlinedTextFieldDefaults.colors(
                     focusedBorderColor = Color.Transparent,
                     unfocusedBorderColor = Color.Transparent,
@@ -101,9 +105,33 @@ internal fun ChatSearchBar(
                     style = MaterialTheme.typography.labelSmall,
                 )
             }
-            SearchGlyphButton("↑", enabled = matchCount > 0, onClick = onPrev, color = theme.accent, mutedColor = theme.textMuted)
-            SearchGlyphButton("↓", enabled = matchCount > 0, onClick = onNext, color = theme.accent, mutedColor = theme.textMuted)
-            SearchGlyphButton("✕", enabled = true, onClick = onClose, color = theme.textMuted, mutedColor = theme.textMuted)
+            SearchGlyphButton(
+                glyph = "↑",
+                contentDescription = stringResource(R.string.previous),
+                testTag = "chat_search_previous",
+                enabled = matchCount > 0,
+                onClick = onPrev,
+                color = theme.accent,
+                mutedColor = theme.textMuted,
+            )
+            SearchGlyphButton(
+                glyph = "↓",
+                contentDescription = stringResource(R.string.next),
+                testTag = "chat_search_next",
+                enabled = matchCount > 0,
+                onClick = onNext,
+                color = theme.accent,
+                mutedColor = theme.textMuted,
+            )
+            SearchGlyphButton(
+                glyph = "✕",
+                contentDescription = stringResource(R.string.button_cancel),
+                testTag = "chat_search_close",
+                enabled = true,
+                onClick = onClose,
+                color = theme.textMuted,
+                mutedColor = theme.textMuted,
+            )
         }
     }
 }
@@ -111,12 +139,21 @@ internal fun ChatSearchBar(
 @Composable
 private fun SearchGlyphButton(
     glyph: String,
+    contentDescription: String,
+    testTag: String,
     enabled: Boolean,
     onClick: () -> Unit,
     color: Color,
     mutedColor: Color,
 ) {
-    IconButton(onClick = onClick, enabled = enabled, modifier = Modifier.size(Sizing.iconButtonMd)) {
+    IconButton(
+        onClick = onClick,
+        enabled = enabled,
+        modifier = Modifier
+            .size(Sizing.iconButtonMd)
+            .semantics { this.contentDescription = contentDescription }
+            .testTag(testTag),
+    ) {
         Text(
             text = glyph,
             color = if (enabled) color else mutedColor,

--- a/app/src/main/java/dev/blazelight/p4oc/ui/screens/sessions/SessionListScreen.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/screens/sessions/SessionListScreen.kt
@@ -18,6 +18,9 @@ import androidx.compose.material3.MenuAnchorType
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
@@ -58,7 +61,7 @@ private data class SessionNode(
         get() = children.size + children.sumOf { it.totalDescendants }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun SessionListScreen(
     viewModel: SessionListViewModel = koinViewModel(),
@@ -83,6 +86,8 @@ fun SessionListScreen(
     var showNewSessionCustomDir by remember { mutableStateOf(false) }
     var showDeleteDialog by remember { mutableStateOf<Session?>(null) }
     var showRenameDialog by remember { mutableStateOf<Session?>(null) }
+    var showSearch by remember { mutableStateOf(false) }
+    var sessionSearchQuery by remember { mutableStateOf("") }
     val context = LocalContext.current
 
     val filterDirectory = remember(uiState.projects, filterProjectId) {
@@ -160,6 +165,19 @@ fun SessionListScreen(
                         )
                     }
                     IconButton(
+                        onClick = {
+                            showSearch = !showSearch
+                            if (!showSearch) sessionSearchQuery = ""
+                        },
+                        modifier = Modifier.size(Sizing.iconButtonMd).testTag("sessions_search_button")
+                    ) {
+                        Icon(
+                            Icons.Default.Search,
+                            contentDescription = stringResource(R.string.cd_search),
+                            modifier = Modifier.size(Sizing.iconAction)
+                        )
+                    }
+                    IconButton(
                         onClick = onSettings,
                         modifier = Modifier.size(Sizing.iconButtonMd).testTag("sessions_settings_button")
                     ) {
@@ -207,8 +225,17 @@ fun SessionListScreen(
             } else {
                 val expandedSessions = remember { mutableStateMapOf<String, Boolean>() }
 
-                val sessionTree = remember(displayedSessions) {
-                    buildSessionTree(displayedSessions)
+                // During search, flatten to matching sessions (tree roots only would
+                // hide matching child sessions whose parent is filtered out).
+                val sessionTree = remember(displayedSessions, sessionSearchQuery) {
+                    val q = sessionSearchQuery.trim()
+                    if (q.isBlank()) {
+                        buildSessionTree(displayedSessions)
+                    } else {
+                        displayedSessions
+                            .filter { it.session.title.contains(q, ignoreCase = true) }
+                            .map { SessionNode(it, emptyList()) }
+                    }
                 }
 
                 LazyColumn(
@@ -216,8 +243,21 @@ fun SessionListScreen(
                     contentPadding = PaddingValues(Spacing.md),
                     verticalArrangement = Arrangement.spacedBy(Spacing.xs)
                 ) {
-                    // Pinned quick actions (only on unfiltered list)
-                    if (filterProjectId == null) {
+                    val searchActive = sessionSearchQuery.isNotBlank()
+                    if (showSearch) {
+                        stickyHeader(key = "session_search") {
+                            SessionSearchField(
+                                query = sessionSearchQuery,
+                                onQueryChange = { sessionSearchQuery = it },
+                                onClose = {
+                                    showSearch = false
+                                    sessionSearchQuery = ""
+                                },
+                            )
+                        }
+                    }
+                    // Pinned quick actions (hidden while searching)
+                    if (!searchActive && filterProjectId == null) {
                         item(key = "quick_action_global") {
                             QuickActionCard(
                                 icon = "\u25C6",
@@ -244,7 +284,7 @@ fun SessionListScreen(
                                 modifier = Modifier.testTag("quick_action_custom")
                             )
                         }
-                    } else {
+                    } else if (!searchActive) {
                         filterDirectory?.let { directory ->
                             item(key = "quick_action_project") {
                                 QuickActionCard(
@@ -262,7 +302,16 @@ fun SessionListScreen(
                         }
                     }
 
-                    if (displayedSessions.isEmpty() && filterProjectId == null) {
+                    if (searchActive && sessionTree.isEmpty()) {
+                        item(key = "no_match") {
+                            Text(
+                                text = stringResource(R.string.sessions_search_no_match),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = theme.textMuted,
+                                modifier = Modifier.padding(horizontal = Spacing.md, vertical = Spacing.lg)
+                            )
+                        }
+                    } else if (displayedSessions.isEmpty() && filterProjectId == null) {
                         item(key = "empty_hint") {
                             Text(
                                 text = stringResource(R.string.sessions_empty_hint),
@@ -381,6 +430,57 @@ fun SessionListScreen(
             confirmText = stringResource(R.string.sessions_rename),
             dismissText = stringResource(R.string.button_cancel)
         )
+    }
+}
+
+@Composable
+private fun SessionSearchField(
+    query: String,
+    onQueryChange: (String) -> Unit,
+    onClose: () -> Unit,
+) {
+    val theme = LocalOpenCodeTheme.current
+    val focusRequester = remember { FocusRequester() }
+    LaunchedEffect(Unit) { focusRequester.requestFocus() }
+    Surface(color = theme.backgroundPanel, shape = RectangleShape, modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = Spacing.sm, vertical = Spacing.xxs),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            OutlinedTextField(
+                value = query,
+                onValueChange = onQueryChange,
+                placeholder = {
+                    Text(
+                        text = stringResource(R.string.sessions_search_placeholder),
+                        color = theme.textMuted,
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                },
+                singleLine = true,
+                textStyle = MaterialTheme.typography.bodySmall.copy(color = theme.text),
+                modifier = Modifier
+                    .weight(1f)
+                    .focusRequester(focusRequester),
+                colors = OutlinedTextFieldDefaults.colors(
+                    focusedBorderColor = Color.Transparent,
+                    unfocusedBorderColor = Color.Transparent,
+                    cursorColor = theme.accent,
+                    focusedTextColor = theme.text,
+                    unfocusedTextColor = theme.text,
+                ),
+            )
+            IconButton(onClick = onClose, modifier = Modifier.size(Sizing.iconButtonMd)) {
+                Icon(
+                    Icons.Default.Close,
+                    contentDescription = stringResource(R.string.button_cancel),
+                    modifier = Modifier.size(Sizing.iconAction),
+                    tint = theme.textMuted,
+                )
+            }
+        }
     }
 }
 

--- a/app/src/main/java/dev/blazelight/p4oc/ui/screens/sessions/SessionListScreen.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/screens/sessions/SessionListScreen.kt
@@ -463,7 +463,8 @@ private fun SessionSearchField(
                 textStyle = MaterialTheme.typography.bodySmall.copy(color = theme.text),
                 modifier = Modifier
                     .weight(1f)
-                    .focusRequester(focusRequester),
+                    .focusRequester(focusRequester)
+                    .testTag("sessions_search_field"),
                 colors = OutlinedTextFieldDefaults.colors(
                     focusedBorderColor = Color.Transparent,
                     unfocusedBorderColor = Color.Transparent,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -142,6 +142,8 @@
     <string name="sessions_title">Sessions</string>
     <string name="sessions_empty_title">No sessions yet</string>
     <string name="sessions_empty_hint">Tap above to start a new session</string>
+    <string name="sessions_search_placeholder">Search chats…</string>
+    <string name="sessions_search_no_match">No matching chats</string>
     <string name="sessions_loading">Loading sessions</string>
     <string name="sessions_new">New Session</string>
     <string name="sessions_delete">Delete</string>
@@ -174,6 +176,9 @@
     <string name="sessions_create_in_project">Create session in %1$s</string>
     
     <!-- Chat Screen -->
+    <string name="chat_search_action">Search chat</string>
+    <string name="chat_search_placeholder">Search in chat…</string>
+    <string name="chat_search_no_matches">No matches</string>
     <string name="chat_empty_title">Start a conversation</string>
     <string name="chat_empty_description">Type a message below to begin</string>
     <string name="chat_input_placeholder">Type a message…</string>


### PR DESCRIPTION
## Summary
Two client-side search capabilities, mirroring the existing file/command search UX (transparent-bordered field, TUI glyphs):

- **In-chat message search** — searches the open conversation across text and reasoning parts, with a live match counter (`3/12`), previous/next navigation and scroll-to-match plus a subtle highlight on the current hit. Opened from the chat overflow menu (`⌕ Search chat`); Back closes the search bar.
- **Session-list filter** — a search field toggled from the sessions top bar that filters the conversation list by title. While searching, the tree flattens to matching sessions so a child session isn't hidden by a filtered-out parent.

## Implementation
- `ChatSearch.kt` — pure, testable match logic over `MessageBlock`s (`Part.Text`/`Part.Reasoning`/tool names/subtask prompts).
- `ChatSearchBar.kt` — the in-chat search bar composable.
- `ChatScreen.kt` — search state, scroll-to-match, current-hit highlight via `itemsIndexed`, Back handler.
- `SessionListScreen.kt` — sticky-header search field + title filter.
- New string resources only; no dependency or build config changes.

## Testing
Built with JDK 17 (`./gradlew :app:assembleDebug`) and verified on a physical device: both searches work, match navigation scrolls correctly, no crashes.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/theblazehen/P4OC/pull/26">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->
