### PR TITLE
feat(theme): OLED black mode for dark themes

### DIFF
--- a/app/src/main/java/dev/blazelight/p4oc/MainActivity.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/MainActivity.kt
@@ -31,13 +31,14 @@ class MainActivity : ComponentActivity() {
             val themeName by settingsDataStore.themeName.collectAsStateWithLifecycle(
                 initialValue = SettingsDataStore.DEFAULT_THEME_NAME
             )
+            val oledBlack by settingsDataStore.oledBlack.collectAsStateWithLifecycle(initialValue = false)
             val darkTheme = when (themeMode) {
                 "dark" -> true
                 "light" -> false
                 else -> isSystemInDarkTheme()
             }
 
-            PocketCodeTheme(themeName = themeName, darkTheme = darkTheme) {
+            PocketCodeTheme(themeName = themeName, darkTheme = darkTheme, oledBlack = oledBlack) {
                 Surface(
                     modifier = Modifier.fillMaxSize(),
                     color = LocalOpenCodeTheme.current.background

--- a/app/src/main/java/dev/blazelight/p4oc/core/datastore/SettingsDataStore.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/core/datastore/SettingsDataStore.kt
@@ -38,6 +38,7 @@ class SettingsDataStore constructor(
         private val KEY_ALLOW_INSECURE = booleanPreferencesKey("allow_insecure_tls")
         private val KEY_THEME_MODE = stringPreferencesKey("theme_mode")
         private val KEY_THEME_NAME = stringPreferencesKey("theme_name")
+        private val KEY_OLED_BLACK = booleanPreferencesKey("oled_black")
 
         const val DEFAULT_THEME_NAME = "catppuccin"
         private val KEY_ONBOARDING_COMPLETED = booleanPreferencesKey("onboarding_completed")
@@ -138,6 +139,11 @@ class SettingsDataStore constructor(
         prefs[KEY_THEME_NAME] ?: DEFAULT_THEME_NAME
     }
 
+    /** AMOLED/OLED mode: forces pure-black backgrounds on dark themes to save power. */
+    val oledBlack: Flow<Boolean> = context.dataStore.data.map { prefs ->
+        prefs[KEY_OLED_BLACK] ?: false
+    }
+
     val onboardingCompleted: Flow<Boolean> = context.dataStore.data.map { prefs ->
         prefs[KEY_ONBOARDING_COMPLETED] ?: false
     }
@@ -183,6 +189,12 @@ class SettingsDataStore constructor(
     suspend fun setThemeName(name: String) {
         context.dataStore.edit { prefs ->
             prefs[KEY_THEME_NAME] = name
+        }
+    }
+
+    suspend fun setOledBlack(enabled: Boolean) {
+        context.dataStore.edit { prefs ->
+            prefs[KEY_OLED_BLACK] = enabled
         }
     }
 

--- a/app/src/main/java/dev/blazelight/p4oc/ui/screens/settings/VisualSettingsScreen.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/screens/settings/VisualSettingsScreen.kt
@@ -47,6 +47,9 @@ class VisualSettingsViewModel constructor(
     private val _themeMode = MutableStateFlow("system")
     val themeMode: StateFlow<String> = _themeMode.asStateFlow()
 
+    private val _oledBlack = MutableStateFlow(false)
+    val oledBlack: StateFlow<Boolean> = _oledBlack.asStateFlow()
+
     val availableThemes = listOf(
         "catppuccin" to "Catppuccin Mocha",
         "catppuccin-macchiato" to "Catppuccin Macchiato",
@@ -76,6 +79,11 @@ class VisualSettingsViewModel constructor(
                 _themeMode.value = mode
             }
         }
+        viewModelScope.launch {
+            settingsDataStore.oledBlack.collect { enabled ->
+                _oledBlack.value = enabled
+            }
+        }
     }
 
     fun updateThemeName(name: String) {
@@ -89,6 +97,13 @@ class VisualSettingsViewModel constructor(
         _themeMode.value = mode
         viewModelScope.launch {
             settingsDataStore.setThemeMode(mode)
+        }
+    }
+
+    fun updateOledBlack(enabled: Boolean) {
+        _oledBlack.value = enabled
+        viewModelScope.launch {
+            settingsDataStore.setOledBlack(enabled)
         }
     }
 
@@ -137,6 +152,7 @@ fun VisualSettingsScreen(
     val settings by viewModel.settings.collectAsStateWithLifecycle()
     val themeName by viewModel.themeName.collectAsStateWithLifecycle()
     val themeMode by viewModel.themeMode.collectAsStateWithLifecycle()
+    val oledBlack by viewModel.oledBlack.collectAsStateWithLifecycle()
 
     val theme = LocalOpenCodeTheme.current
     Scaffold(
@@ -171,6 +187,16 @@ fun VisualSettingsScreen(
                     selected = themeName,
                     options = viewModel.availableThemes,
                     onSelect = viewModel::updateThemeName
+                )
+
+                Spacer(Modifier.height(Spacing.md))
+
+                SettingsSwitch(
+                    title = stringResource(R.string.visual_settings_oled_black),
+                    subtitle = stringResource(R.string.visual_settings_oled_black_desc),
+                    checked = oledBlack,
+                    onCheckedChange = viewModel::updateOledBlack,
+                    icon = Icons.Default.DarkMode
                 )
             }
 

--- a/app/src/main/java/dev/blazelight/p4oc/ui/theme/Theme.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/theme/Theme.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
@@ -43,12 +44,26 @@ val TuiShapes = Shapes(
 fun PocketCodeTheme(
     themeName: String = "catppuccin",
     darkTheme: Boolean = isSystemInDarkTheme(),
+    oledBlack: Boolean = false,
     content: @Composable () -> Unit
 ) {
     val context = LocalContext.current
 
-    val openCodeTheme = remember(context, themeName, darkTheme) {
+    val loadedTheme = remember(context, themeName, darkTheme) {
         ThemeLoader.loadBundledThemeCached(context, themeName, darkTheme)
+    }
+    // OLED/AMOLED: on dark themes, push every background surface to pure black so
+    // unlit pixels draw zero power. Foreground/accent tokens stay untouched.
+    val openCodeTheme = remember(loadedTheme, oledBlack) {
+        if (oledBlack && loadedTheme.isDark) {
+            loadedTheme.copy(
+                background = Color.Black,
+                backgroundPanel = Color.Black,
+                backgroundElement = Color.Black,
+            )
+        } else {
+            loadedTheme
+        }
     }
 
     val colorScheme = remember(openCodeTheme) {

--- a/app/src/main/java/dev/blazelight/p4oc/ui/theme/Theme.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/theme/Theme.kt
@@ -81,8 +81,8 @@ fun PocketCodeTheme(
             @Suppress("DEPRECATION")
             window.statusBarColor = colorScheme.background.toArgb()
             WindowCompat.getInsetsController(window, view).apply {
-                isAppearanceLightStatusBars = !darkTheme
-                isAppearanceLightNavigationBars = !darkTheme
+                isAppearanceLightStatusBars = !openCodeTheme.isDark
+                isAppearanceLightNavigationBars = !openCodeTheme.isDark
             }
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -295,6 +295,8 @@
     <string name="visual_settings_title">Visual Settings</string>
     <string name="visual_settings_reset">Reset</string>
     <string name="visual_settings_theme">Theme</string>
+    <string name="visual_settings_oled_black">OLED black</string>
+    <string name="visual_settings_oled_black_desc">Pure-black backgrounds on dark themes to save power on OLED screens</string>
     <string name="visual_settings_text">Text</string>
     <string name="visual_settings_code_display">Code Display</string>
     <string name="visual_settings_accessibility">Accessibility</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -295,8 +295,8 @@
     <string name="visual_settings_title">Visual Settings</string>
     <string name="visual_settings_reset">Reset</string>
     <string name="visual_settings_theme">Theme</string>
-    <string name="visual_settings_oled_black">OLED black</string>
-    <string name="visual_settings_oled_black_desc">Pure-black backgrounds on dark themes to save power on OLED screens</string>
+    <string name="visual_settings_oled_black">OLED black backgrounds</string>
+    <string name="visual_settings_oled_black_desc">Use pure black surfaces on dark themes</string>
     <string name="visual_settings_text">Text</string>
     <string name="visual_settings_code_display">Code Display</string>
     <string name="visual_settings_accessibility">Accessibility</string>


### PR DESCRIPTION
## Summary
Adds an **OLED black** toggle in Visual Settings that forces `background`, `backgroundPanel` and `backgroundElement` to pure black (`#000000`) on dark themes — saving power on OLED/AMOLED screens.

It's a theme *transform*, not a new fixed theme: it composes on top of any base theme (Catppuccin, Dracula, Nord…), blackening only the surfaces while leaving accent/text tokens untouched. No effect on light themes.

## Implementation
- `SettingsDataStore` — `oledBlack` boolean preference (flow + setter), mirroring `themeName`.
- `Theme.kt` — new `PocketCodeTheme(oledBlack)` param; when enabled on a dark theme, `loadedTheme.copy(background/backgroundPanel/backgroundElement = Color.Black)`.
- `MainActivity` — reads the setting and passes it through.
- `VisualSettingsScreen` — a `SettingsSwitch` under the theme selector.
- New string resources only; no dependency changes.

## Testing
Built with JDK 17 and verified on a physical device: toggling OLED black blackens backgrounds on dark themes and persists across restarts.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/theblazehen/P4OC/pull/27">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->
