### PR TITLE
fix: recover pending question on session open

### DIFF
--- a/app/src/main/java/dev/blazelight/p4oc/core/network/OpenCodeApi.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/core/network/OpenCodeApi.kt
@@ -192,6 +192,11 @@ interface OpenCodeApi {
         @Query("directory") directory: String?
     ): Boolean
 
+    @GET("question")
+    suspend fun listPendingQuestions(
+        @Query("directory") directory: String?
+    ): List<QuestionRequestDto>
+
     @GET("command")
     suspend fun listCommands(
         @Query("directory") directory: String?

--- a/app/src/main/java/dev/blazelight/p4oc/data/remote/mapper/Mappers.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/data/remote/mapper/Mappers.kt
@@ -561,6 +561,30 @@ object StatusMapper {
 // Event Mapper
 // ============================================================================
 
+/**
+ * Map a QuestionRequestDto to a domain QuestionRequest.
+ * Used by EventMapper for question.asked events and by SessionRepositoryImpl
+ * for reconciliation of pending questions.
+ */
+fun mapQuestionRequestDtoToDomain(dto: QuestionRequestDto): QuestionRequest = QuestionRequest(
+    id = dto.id,
+    sessionID = dto.sessionID,
+    questions = dto.questions.map { q ->
+        Question(
+            header = q.header,
+            question = q.question,
+            options = q.options.map { o ->
+                QuestionOption(label = o.label, description = o.description)
+            },
+            multiple = q.multiple,
+            custom = q.custom
+        )
+    },
+    tool = dto.tool?.let {
+        QuestionToolRef(messageID = it.messageID, callID = it.callID)
+    }
+)
+
 class EventMapper constructor(
     private val json: Json,
     private val messageMapper: MessageMapper
@@ -660,26 +684,7 @@ class EventMapper constructor(
             }
             "question.asked" -> {
                 val questionDto = json.decodeFromJsonElement<QuestionRequestDto>(dto.properties)
-                OpenCodeEvent.QuestionAsked(
-                    QuestionRequest(
-                        id = questionDto.id,
-                        sessionID = questionDto.sessionID,
-                        questions = questionDto.questions.map { q ->
-                            Question(
-                                header = q.header,
-                                question = q.question,
-                                options = q.options.map { o ->
-                                    QuestionOption(label = o.label, description = o.description)
-                                },
-                                multiple = q.multiple,
-                                custom = q.custom
-                            )
-                        },
-                        tool = questionDto.tool?.let {
-                            QuestionToolRef(messageID = it.messageID, callID = it.callID)
-                        }
-                    )
-                )
+                OpenCodeEvent.QuestionAsked(mapQuestionRequestDtoToDomain(questionDto))
             }
             "question.replied" -> {
                 val props = json.decodeFromJsonElement<QuestionRepliedPropertiesDto>(dto.properties)

--- a/app/src/main/java/dev/blazelight/p4oc/data/session/SessionRepository.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/data/session/SessionRepository.kt
@@ -25,7 +25,7 @@ interface SessionRepository {
 
     fun clearPermissionByRequestId(sessionId: SessionId, requestId: String)
 
-    fun clearQuestion(sessionId: SessionId)
+    fun clearQuestion(sessionId: SessionId, requestId: String? = null)
 
     suspend fun loadMessages(sessionId: SessionId, limit: Int? = null)
 

--- a/app/src/main/java/dev/blazelight/p4oc/data/session/SessionRepositoryImpl.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/data/session/SessionRepositoryImpl.kt
@@ -4,10 +4,12 @@ import dev.blazelight.p4oc.core.log.AppLog
 import dev.blazelight.p4oc.data.files.ofish.OfishSessionNames
 import dev.blazelight.p4oc.data.remote.dto.CreateSessionRequest
 import dev.blazelight.p4oc.data.remote.dto.ProjectDto
+import dev.blazelight.p4oc.data.remote.dto.QuestionRequestDto
 import dev.blazelight.p4oc.data.remote.dto.SendMessageRequest
 import dev.blazelight.p4oc.data.remote.dto.UpdateSessionRequest
 import dev.blazelight.p4oc.data.remote.mapper.MessageMapper
 import dev.blazelight.p4oc.data.remote.mapper.SessionMapper
+import dev.blazelight.p4oc.data.remote.mapper.mapQuestionRequestDtoToDomain
 import dev.blazelight.p4oc.data.workspace.SessionWorkspaceClient
 import dev.blazelight.p4oc.data.workspace.WorkspaceClient
 import dev.blazelight.p4oc.domain.model.Message
@@ -17,6 +19,8 @@ import dev.blazelight.p4oc.domain.model.Part
 import dev.blazelight.p4oc.domain.model.Session
 import dev.blazelight.p4oc.domain.model.SessionStatus
 import dev.blazelight.p4oc.domain.model.TokenUsage
+import dev.blazelight.p4oc.domain.model.ToolState
+import dev.blazelight.p4oc.domain.model.isQuestionTool
 import dev.blazelight.p4oc.domain.session.SessionId
 import dev.blazelight.p4oc.domain.session.WorkspaceSession
 import kotlinx.coroutines.CancellationException
@@ -30,6 +34,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -45,6 +50,7 @@ class SessionRepositoryImpl(
     private val messageMapper: MessageMapper? = null,
     private val nowMs: () -> Long = { System.currentTimeMillis() },
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val questionFetcher: (suspend () -> List<QuestionRequestDto>)? = null,
 ) : SessionRepository {
     data class CachedSnapshot(
         val snapshot: Snapshot,
@@ -71,6 +77,10 @@ class SessionRepositoryImpl(
     private val messageStates = mutableMapOf<String, MutableStateFlow<List<MessageWithParts>>>()
     private val sessionUiStates = mutableMapOf<String, MutableStateFlow<SessionUiState>>()
     private val childToParentSessionIds = mutableMapOf<String, String>()
+
+    // Question reconciliation dedup state
+    private val detectedQuestionToolCallIds = mutableSetOf<String>()
+    private val recentlyResolvedQuestionIds = mutableMapOf<String, Long>()
 
     fun peek(): CachedSnapshot? {
         val cached = lastSuccess ?: return null
@@ -224,12 +234,66 @@ class SessionRepositoryImpl(
         }
     }
 
+    private suspend fun fetchPendingQuestions(): List<QuestionRequestDto> =
+        questionFetcher?.invoke() ?: (client as? WorkspaceClient)?.listPendingQuestions() ?: emptyList()
+
+    /**
+     * Reconcile pending questions from the server.
+     * Called when a question tool part is detected or on reconnect.
+     * Fetches the list of pending questions from GET /question and sets
+     * pendingQuestion on owned sessions that don't already have one.
+     * Skips questions that were recently resolved (anti-resurrection).
+     */
+    private suspend fun reconcilePendingQuestions() {
+        AppLog.d(TAG, "reconcilePendingQuestions: fetching pending questions")
+        val questionsToCheck = runCatching { fetchPendingQuestions() }
+            .getOrElse { error ->
+                AppLog.w(TAG, "Failed to fetch pending questions: ${error.message}")
+                return
+            }
+        AppLog.d(TAG, "reconcilePendingQuestions: fetched ${questionsToCheck.size} pending question(s)")
+
+        // Expire stale entries from recentlyResolvedQuestionIds
+        val now = nowMs()
+        synchronized(recentlyResolvedQuestionIds) {
+            recentlyResolvedQuestionIds.entries.removeAll { (_, resolvedAtMs) ->
+                now - resolvedAtMs > RESOLVED_QUESTION_TTL_MS
+            }
+        }
+
+        for (questionDto in questionsToCheck) {
+            // Skip if this question was recently resolved
+            val isRecentlyResolved = synchronized(recentlyResolvedQuestionIds) {
+                recentlyResolvedQuestionIds.containsKey(questionDto.id)
+            }
+            if (isRecentlyResolved) continue
+
+            // Try to set pendingQuestion on the owned session
+            updateOwnedSession(questionDto.sessionID) { state ->
+                if (state.pendingQuestion == null && state.queuedQuestions.none { it.id == questionDto.id }) {
+                    state.copy(pendingQuestion = mapQuestionRequestDtoToDomain(questionDto))
+                } else {
+                    state
+                }
+            }
+        }
+    }
+
     private fun hydrateAfterReconnect() {
         synchronized(this) {
             if (inFlight != null) return
             _state.value = RepoState.Hydrating(snapshot = state.value.snapshot, bufferedEvents = hydrateBuffer.size)
             inFlight = scope.async {
                 runCatching { hydrate(client.listProjects()) }
+            }
+        }
+        // Trigger question reconciliation after hydration (don't block event path)
+        scope.launch {
+            try {
+                inFlight?.await()
+                reconcilePendingQuestions()
+            } catch (e: Exception) {
+                AppLog.w(TAG, "Error during post-reconnect question reconciliation: ${e.message}")
             }
         }
     }
@@ -258,8 +322,23 @@ class SessionRepositoryImpl(
         }
     }
 
-    override fun clearQuestion(sessionId: SessionId) {
-        updateSession(sessionId.value) { state ->
+    override fun clearQuestion(sessionId: SessionId, requestId: String?) {
+        clearQuestionInternal(sessionId.value, requestId)
+    }
+
+    /**
+     * Internal implementation: clear the current pending question and promote the next queued question.
+     * If [requestId] is provided, record it as recently resolved for dedup.
+     */
+    private fun clearQuestionInternal(sessionId: String, requestId: String?) {
+        // Record the request ID if provided (for dismissQuestion path)
+        if (requestId != null) {
+            synchronized(recentlyResolvedQuestionIds) {
+                recentlyResolvedQuestionIds[requestId] = nowMs()
+            }
+        }
+
+        updateSession(sessionId) { state ->
             val nextQuestion = state.queuedQuestions.firstOrNull()
             state.copy(
                 pendingQuestion = nextQuestion,
@@ -275,8 +354,14 @@ class SessionRepositoryImpl(
      * promoted; if it is sitting in the queue, it is removed in place. Unknown
      * requestIDs are a no-op (idempotent — a resolution we never tracked, or one
      * already handled locally).
+     * Records the resolved ID for dedup to prevent re-surfacing within the TTL.
      */
     private fun resolveQuestion(eventSessionId: String, requestID: String) {
+        // Record this ID as recently resolved to prevent re-surfacing on reconcile
+        synchronized(recentlyResolvedQuestionIds) {
+            recentlyResolvedQuestionIds[requestID] = nowMs()
+        }
+
         updateOwnedSession(eventSessionId) { state ->
             when {
                 state.pendingQuestion?.id == requestID -> {
@@ -300,6 +385,16 @@ class SessionRepositoryImpl(
         val mapper = messageMapper ?: error("Message loading requires MessageMapper")
         val messages = workspaceClient.getMessages(sessionId.value, limit).map { dto -> mapper.mapWrapperToDomain(dto) }
         mergeLoadedMessages(sessionId.value, messages)
+        // A question tool part loaded via REST (state=running) means a question is
+        // pending that the live question.asked SSE event was missed for. Reconcile so
+        // the interactive card renders. (upsertPart only fires for live SSE updates,
+        // not REST history load, so this is the deterministic open-a-session trigger.)
+        val hasRunningQuestion = messages.any { mwp ->
+            mwp.parts.any { it is Part.Tool && it.isQuestionTool() && it.state is ToolState.Running }
+        }
+        if (hasRunningQuestion) {
+            reconcilePendingQuestions()
+        }
     }
 
     override fun sendMessageAsync(sessionId: SessionId, request: SendMessageRequest): Deferred<Result<Unit>> = scope.async {
@@ -328,6 +423,8 @@ class SessionRepositoryImpl(
         synchronized(messageStates) { messageStates.clear() }
         synchronized(sessionUiStates) { sessionUiStates.clear() }
         synchronized(childToParentSessionIds) { childToParentSessionIds.clear() }
+        synchronized(detectedQuestionToolCallIds) { detectedQuestionToolCallIds.clear() }
+        synchronized(recentlyResolvedQuestionIds) { recentlyResolvedQuestionIds.clear() }
     }
 
     suspend fun createSession(title: String?): WorkspaceSession {
@@ -577,6 +674,34 @@ class SessionRepositoryImpl(
     }
 
     private fun upsertPart(part: Part, delta: String?) {
+        // Handle question tool detection for reconciliation (Trigger 1)
+        if (part is Part.Tool && part.isQuestionTool()) {
+            when (part.state) {
+                is ToolState.Running -> {
+                    // Question tool is running - fetch pending questions to set card
+                    val isNewDetection = synchronized(detectedQuestionToolCallIds) {
+                        detectedQuestionToolCallIds.add(part.callID)
+                    }
+                    if (isNewDetection) {
+                        scope.launch {
+                            try {
+                                reconcilePendingQuestions()
+                            } catch (e: Exception) {
+                                AppLog.w(TAG, "Error reconciling questions on tool detection: ${e.message}")
+                            }
+                        }
+                    }
+                }
+                is ToolState.Completed, is ToolState.Error -> {
+                    // Tool finished - clean up from tracking set
+                    synchronized(detectedQuestionToolCallIds) {
+                        detectedQuestionToolCallIds.remove(part.callID)
+                    }
+                }
+                else -> Unit
+            }
+        }
+
         val state = messageState(part.sessionID)
         state.update { messages ->
             val existingMessage = messages.firstOrNull { it.message.id == part.messageID }
@@ -691,5 +816,6 @@ class SessionRepositoryImpl(
         const val FRESHNESS_MS = 30_000L
         const val MAX_CONCURRENT = 10
         const val TAG = "SessionRepository"
+        const val RESOLVED_QUESTION_TTL_MS = 30_000L
     }
 }

--- a/app/src/main/java/dev/blazelight/p4oc/data/session/SessionRepositoryImpl.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/data/session/SessionRepositoryImpl.kt
@@ -268,12 +268,14 @@ class SessionRepositoryImpl(
             }
             if (isRecentlyResolved) continue
 
-            // Try to set pendingQuestion on the owned session
+            // Mirror live question.asked handling: first pending question is shown,
+            // additional recovered questions are queued behind it.
             updateOwnedSession(questionDto.sessionID) { state ->
-                if (state.pendingQuestion == null && state.queuedQuestions.none { it.id == questionDto.id }) {
-                    state.copy(pendingQuestion = mapQuestionRequestDtoToDomain(questionDto))
-                } else {
-                    state
+                val question = mapQuestionRequestDtoToDomain(questionDto)
+                when {
+                    state.pendingQuestion?.id == question.id || state.queuedQuestions.any { it.id == question.id } -> state
+                    state.pendingQuestion == null -> state.copy(pendingQuestion = question)
+                    else -> state.copy(queuedQuestions = state.queuedQuestions + question)
                 }
             }
         }

--- a/app/src/main/java/dev/blazelight/p4oc/data/workspace/WorkspaceClient.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/data/workspace/WorkspaceClient.kt
@@ -14,6 +14,7 @@ import dev.blazelight.p4oc.data.remote.dto.MessageWrapperDto
 import dev.blazelight.p4oc.data.remote.dto.PermissionResponseRequest
 import dev.blazelight.p4oc.data.remote.dto.ProjectDto
 import dev.blazelight.p4oc.data.remote.dto.QuestionReplyRequest
+import dev.blazelight.p4oc.data.remote.dto.QuestionRequestDto
 import dev.blazelight.p4oc.data.remote.dto.RevertSessionRequest
 import dev.blazelight.p4oc.data.remote.dto.SendMessageRequest
 import dev.blazelight.p4oc.data.remote.dto.SessionDto
@@ -107,6 +108,9 @@ class WorkspaceClient(
 
     suspend fun rejectQuestion(requestId: String): Boolean =
         api.rejectQuestion(requestId, directory)
+
+    suspend fun listPendingQuestions(): List<QuestionRequestDto> =
+        api.listPendingQuestions(directory)
 
     suspend fun listCommands(): List<CommandDto> = api.listCommands(directory)
 

--- a/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ChatViewModel.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ChatViewModel.kt
@@ -480,7 +480,7 @@ class ChatViewModel constructor(
         viewModelScope.launch {
             val request = QuestionReplyRequest(answers = answers)
             when (val result = safeApiCall { workspaceClient.respondToQuestion(requestId, request) }) {
-                is ApiResult.Success -> sessionRepository.clearQuestion(SessionId(sessionId))
+                is ApiResult.Success -> sessionRepository.clearQuestion(SessionId(sessionId), requestId)
                 is ApiResult.Error -> _uiState.update {
                     it.copy(
                         error = "Failed to answer question: ${result.message}"
@@ -498,11 +498,11 @@ class ChatViewModel constructor(
             // question.rejected SSE event (handled in SessionRepositoryImpl) will
             // also reconcile any other attached client.
             when (val result = safeApiCall { workspaceClient.rejectQuestion(requestId) }) {
-                is ApiResult.Success -> sessionRepository.clearQuestion(SessionId(sessionId))
+                is ApiResult.Success -> sessionRepository.clearQuestion(SessionId(sessionId), requestId)
                 is ApiResult.Error -> {
                     // A NotFound here means it was already resolved elsewhere — clear
                     // locally anyway so the user is not stuck on a dead modal.
-                    sessionRepository.clearQuestion(SessionId(sessionId))
+                    sessionRepository.clearQuestion(SessionId(sessionId), requestId)
                     AppLog.w(TAG, "rejectQuestion failed (clearing locally): ${result.message}")
                 }
             }

--- a/app/src/test/java/dev/blazelight/p4oc/data/session/QuestionReconciliationTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/data/session/QuestionReconciliationTest.kt
@@ -1,0 +1,343 @@
+package dev.blazelight.p4oc.data.session
+
+import dev.blazelight.p4oc.data.remote.dto.QuestionDto
+import dev.blazelight.p4oc.data.remote.dto.QuestionOptionDto
+import dev.blazelight.p4oc.data.remote.dto.QuestionRequestDto
+import dev.blazelight.p4oc.data.remote.dto.QuestionToolRefDto
+import dev.blazelight.p4oc.domain.model.OpenCodeEvent
+import dev.blazelight.p4oc.domain.model.Part
+import dev.blazelight.p4oc.domain.model.QuestionRequest
+import dev.blazelight.p4oc.domain.model.Session
+import dev.blazelight.p4oc.domain.model.ToolState
+import dev.blazelight.p4oc.domain.session.SessionId
+import dev.blazelight.p4oc.fakes.FakeWorkspaceClient
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.buildJsonObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class QuestionReconciliationTest {
+
+    @Test
+    fun `running question tool part triggers reconciliation and sets pendingQuestion`() = runTest {
+        val sessionId = "sess_001"
+        val callId = "call_001"
+        val questionId = "que_001"
+        val questionDto = buildQuestionRequestDto(questionId, sessionId, callId)
+        var fetchCount = 0
+
+        val client = FakeWorkspaceClient()
+        val repository = SessionRepositoryImpl(
+            client,
+            nowMs = { testScheduler.currentTime },
+            dispatcher = StandardTestDispatcher(testScheduler),
+            questionFetcher = {
+                fetchCount++
+                listOf(questionDto)
+            }
+        )
+
+        // Initialize with a session
+        val session = Session(
+            id = sessionId,
+            projectID = "proj_001",
+            directory = "/test",
+            parentID = null,
+            title = "Test Session",
+            version = "1",
+            createdAt = 0L,
+            updatedAt = 0L,
+            compactingAt = null,
+            summary = null,
+            shareUrl = null,
+            revert = null
+        )
+        repository.acceptEvent(OpenCodeEvent.SessionCreated(session))
+
+        // Simulate a running question tool part
+        val toolPart = Part.Tool(
+            id = "part_001",
+            sessionID = sessionId,
+            messageID = "msg_001",
+            callID = callId,
+            toolName = "question",
+            state = ToolState.Running(
+                input = buildJsonObject {},
+                title = "Asking question",
+                startedAt = testScheduler.currentTime,
+                metadata = null
+            )
+        )
+        repository.acceptEvent(
+            OpenCodeEvent.MessagePartUpdated(toolPart, null)
+        )
+        advanceUntilIdle()
+
+        // Verify pendingQuestion was set via reconciliation
+        val sessionState = repository.sessionUiState(SessionId(sessionId))
+        assertNotNull("pendingQuestion should be set", sessionState.value.pendingQuestion)
+        assertEquals(questionId, sessionState.value.pendingQuestion?.id)
+        assertEquals(1, fetchCount)
+    }
+
+    @Test
+    fun `anti_thrash same callID does not trigger multiple fetches`() = runTest {
+        val sessionId = "sess_001"
+        val callId = "call_001"
+        val questionId = "que_001"
+        val questionDto = buildQuestionRequestDto(questionId, sessionId, callId)
+        var fetchCount = 0
+
+        val client = FakeWorkspaceClient()
+        val repository = SessionRepositoryImpl(
+            client,
+            nowMs = { testScheduler.currentTime },
+            dispatcher = StandardTestDispatcher(testScheduler),
+            questionFetcher = {
+                fetchCount++
+                listOf(questionDto)
+            }
+        )
+
+        val session = Session(
+            id = sessionId,
+            projectID = "proj_001",
+            directory = "/test",
+            parentID = null,
+            title = "Test Session",
+            version = "1",
+            createdAt = 0L,
+            updatedAt = 0L,
+            compactingAt = null,
+            summary = null,
+            shareUrl = null,
+            revert = null
+        )
+        repository.acceptEvent(OpenCodeEvent.SessionCreated(session))
+
+        // Simulate two Running updates with the same callID
+        repeat(2) {
+            val toolPart = Part.Tool(
+                id = "part_00${it + 1}",
+                sessionID = sessionId,
+                messageID = "msg_001",
+                callID = callId,
+                toolName = "question",
+                state = ToolState.Running(
+                    input = buildJsonObject {},
+                    title = "Asking question",
+                    startedAt = testScheduler.currentTime,
+                    metadata = null
+                )
+            )
+            repository.acceptEvent(
+                OpenCodeEvent.MessagePartUpdated(toolPart, null)
+            )
+        }
+        advanceUntilIdle()
+
+        // Should fetch only once despite two Running parts
+        assertEquals("fetchCount should be 1", 1, fetchCount)
+    }
+
+    @Test
+    fun `anti_resurrection recently resolved question is not re_surfaced on sweep`() = runTest {
+        val sessionId = "sess_001"
+        val questionId = "que_001"
+        val questionDto = buildQuestionRequestDto(questionId, sessionId, null)
+        var fetchCount = 0
+
+        val client = FakeWorkspaceClient()
+        val repository = SessionRepositoryImpl(
+            client,
+            nowMs = { testScheduler.currentTime },
+            dispatcher = StandardTestDispatcher(testScheduler),
+            questionFetcher = {
+                fetchCount++
+                listOf(questionDto)
+            }
+        )
+
+        val session = Session(
+            id = sessionId,
+            projectID = "proj_001",
+            directory = "/test",
+            parentID = null,
+            title = "Test Session",
+            version = "1",
+            createdAt = 0L,
+            updatedAt = 0L,
+            compactingAt = null,
+            summary = null,
+            shareUrl = null,
+            revert = null
+        )
+        repository.acceptEvent(OpenCodeEvent.SessionCreated(session))
+
+        // Simulate receiving a question.replied event (marks as resolved)
+        repository.acceptEvent(
+            OpenCodeEvent.QuestionReplied(sessionId, questionId, emptyList())
+        )
+        advanceUntilIdle()
+
+        var sessionState = repository.sessionUiState(SessionId(sessionId))
+        assertNull("pendingQuestion should be cleared after reply", sessionState.value.pendingQuestion)
+
+        // Now simulate a reconnect trigger that would fetch the same question
+        // The question should NOT be re-set due to anti-resurrection dedup
+        repository.acceptEvent(OpenCodeEvent.Connected)
+        advanceUntilIdle()
+
+        sessionState = repository.sessionUiState(SessionId(sessionId))
+        assertNull("pendingQuestion should not be re-surfaced within TTL", sessionState.value.pendingQuestion)
+        // fetchCount should be 1 (from the Connected event reconciliation)
+        assertEquals(1, fetchCount)
+    }
+
+    @Test
+    fun `reconnect sweep hydrates pendingQuestion`() = runTest {
+        val sessionId = "sess_001"
+        val questionId = "que_001"
+        val questionDto = buildQuestionRequestDto(questionId, sessionId, null)
+        var fetchCount = 0
+
+        val client = FakeWorkspaceClient()
+        val repository = SessionRepositoryImpl(
+            client,
+            nowMs = { testScheduler.currentTime },
+            dispatcher = StandardTestDispatcher(testScheduler),
+            questionFetcher = {
+                fetchCount++
+                listOf(questionDto)
+            }
+        )
+
+        val session = Session(
+            id = sessionId,
+            projectID = "proj_001",
+            directory = "/test",
+            parentID = null,
+            title = "Test Session",
+            version = "1",
+            createdAt = 0L,
+            updatedAt = 0L,
+            compactingAt = null,
+            summary = null,
+            shareUrl = null,
+            revert = null
+        )
+        repository.acceptEvent(OpenCodeEvent.SessionCreated(session))
+
+        // Initially no pending question
+        var sessionState = repository.sessionUiState(SessionId(sessionId))
+        assertNull("initially no pendingQuestion", sessionState.value.pendingQuestion)
+
+        // Simulate reconnect which triggers question reconciliation
+        repository.acceptEvent(OpenCodeEvent.Connected)
+        advanceUntilIdle()
+
+        // Question should now be set
+        sessionState = repository.sessionUiState(SessionId(sessionId))
+        assertNotNull("pendingQuestion should be set after reconnect", sessionState.value.pendingQuestion)
+        assertEquals(questionId, sessionState.value.pendingQuestion?.id)
+        assertEquals(1, fetchCount)
+    }
+
+    @Test
+    fun `clearQuestion with requestId records dedup id`() = runTest {
+        val sessionId = "sess_001"
+        val questionId = "que_001"
+        val questionDto = buildQuestionRequestDto(questionId, sessionId, null)
+        var fetchCount = 0
+
+        val client = FakeWorkspaceClient()
+        val repository = SessionRepositoryImpl(
+            client,
+            nowMs = { testScheduler.currentTime },
+            dispatcher = StandardTestDispatcher(testScheduler),
+            questionFetcher = {
+                fetchCount++
+                listOf(questionDto)
+            }
+        )
+
+        val session = Session(
+            id = sessionId,
+            projectID = "proj_001",
+            directory = "/test",
+            parentID = null,
+            title = "Test Session",
+            version = "1",
+            createdAt = 0L,
+            updatedAt = 0L,
+            compactingAt = null,
+            summary = null,
+            shareUrl = null,
+            revert = null
+        )
+        repository.acceptEvent(OpenCodeEvent.SessionCreated(session))
+
+        // Set a pending question via event
+        repository.acceptEvent(
+            OpenCodeEvent.QuestionAsked(
+                QuestionRequest(
+                    id = questionId,
+                    sessionID = sessionId,
+                    questions = emptyList(),
+                    tool = null
+                )
+            )
+        )
+        advanceUntilIdle()
+
+        var sessionState = repository.sessionUiState(SessionId(sessionId))
+        assertNotNull("pendingQuestion should be set", sessionState.value.pendingQuestion)
+
+        // Clear with requestId (dismissQuestion path)
+        repository.clearQuestion(SessionId(sessionId), questionId)
+        sessionState = repository.sessionUiState(SessionId(sessionId))
+        assertNull("pendingQuestion should be cleared", sessionState.value.pendingQuestion)
+
+        // Now trigger a reconciliation - the question should NOT be re-set
+        // because it was recorded in the dedup map
+        repository.acceptEvent(OpenCodeEvent.Connected)
+        advanceUntilIdle()
+
+        sessionState = repository.sessionUiState(SessionId(sessionId))
+        assertNull(
+            "pendingQuestion should not be re-surfaced after clearQuestion with id",
+            sessionState.value.pendingQuestion
+        )
+    }
+
+    // Helper functions
+    private fun buildQuestionRequestDto(
+        id: String,
+        sessionId: String,
+        callId: String?
+    ): QuestionRequestDto {
+        return QuestionRequestDto(
+            id = id,
+            sessionID = sessionId,
+            questions = listOf(
+                QuestionDto(
+                    header = "Test",
+                    question = "Do you want to continue?",
+                    options = listOf(
+                        QuestionOptionDto(label = "Yes", description = "Continue"),
+                        QuestionOptionDto(label = "No", description = "Stop")
+                    ),
+                    multiple = false,
+                    custom = true
+                )
+            ),
+            tool = callId?.let { QuestionToolRefDto(messageID = "msg_001", callID = it) }
+        )
+    }
+}

--- a/app/src/test/java/dev/blazelight/p4oc/data/session/QuestionReconciliationTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/data/session/QuestionReconciliationTest.kt
@@ -250,6 +250,59 @@ class QuestionReconciliationTest {
     }
 
     @Test
+    fun `reconciliation queues additional pending questions for the same session`() = runTest {
+        val sessionId = "sess_001"
+        val firstQuestionId = "que_001"
+        val secondQuestionId = "que_002"
+        val firstQuestionDto = buildQuestionRequestDto(firstQuestionId, sessionId, "call_001")
+        val secondQuestionDto = buildQuestionRequestDto(secondQuestionId, sessionId, "call_002")
+
+        val client = FakeWorkspaceClient()
+        val repository = SessionRepositoryImpl(
+            client,
+            nowMs = { testScheduler.currentTime },
+            dispatcher = StandardTestDispatcher(testScheduler),
+            questionFetcher = { listOf(firstQuestionDto, secondQuestionDto) }
+        )
+
+        val session = Session(
+            id = sessionId,
+            projectID = "proj_001",
+            directory = "/test",
+            parentID = null,
+            title = "Test Session",
+            version = "1",
+            createdAt = 0L,
+            updatedAt = 0L,
+            compactingAt = null,
+            summary = null,
+            shareUrl = null,
+            revert = null
+        )
+        repository.acceptEvent(OpenCodeEvent.SessionCreated(session))
+
+        val toolPart = Part.Tool(
+            id = "part_001",
+            sessionID = sessionId,
+            messageID = "msg_001",
+            callID = "call_001",
+            toolName = "question",
+            state = ToolState.Running(
+                input = buildJsonObject {},
+                title = "Asking question",
+                startedAt = testScheduler.currentTime,
+                metadata = null
+            )
+        )
+        repository.acceptEvent(OpenCodeEvent.MessagePartUpdated(toolPart, null))
+        advanceUntilIdle()
+
+        val sessionState = repository.sessionUiState(SessionId(sessionId)).value
+        assertEquals(firstQuestionId, sessionState.pendingQuestion?.id)
+        assertEquals(listOf(secondQuestionId), sessionState.queuedQuestions.map { it.id })
+    }
+
+    @Test
     fun `clearQuestion with requestId records dedup id`() = runTest {
         val sessionId = "sess_001"
         val questionId = "que_001"

--- a/app/src/test/java/dev/blazelight/p4oc/fakes/FakeSessionRepository.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/fakes/FakeSessionRepository.kt
@@ -57,7 +57,7 @@ class FakeSessionRepository(
 
     override fun clearPermissionByRequestId(sessionId: SessionId, requestId: String) = Unit
 
-    override fun clearQuestion(sessionId: SessionId) = Unit
+    override fun clearQuestion(sessionId: SessionId, requestId: String?) = Unit
 
     override suspend fun loadMessages(sessionId: SessionId, limit: Int?) = Unit
 


### PR DESCRIPTION
Problem:
P4OC can miss the live question.asked SSE event when a question is created while the app is closed, detached, or reconnecting. Opening the session later shows only the running question tool part, without the interactive multi-choice card needed to answer.

Expected Behavior:
When session history or reconnect reveals a running question tool, reconcile with the server's authoritative pending question list and restore the interactive question card.

Changes:
- Add GET /question to the workspace API client.
- Reconcile pending questions on session message load, live running question tool detection, and reconnect.
- Track recently resolved question IDs to avoid immediate resurrection after reply/reject/skip.
- Queue additional recovered questions for the same session to match live question.asked behavior.
- Add focused unit coverage for recovery, dedup, anti-resurrection, reconnect, and queued recovery.

Verification:
- export JAVA_HOME=/usr/lib/jvm/java-17-openjdk && ./gradlew :app:compileDebugKotlin
- export JAVA_HOME=/usr/lib/jvm/java-17-openjdk && ./gradlew :app:testDebugUnitTest --tests dev.blazelight.p4oc.data.session.QuestionReconciliationTest --tests dev.blazelight.p4oc.data.session.SessionRepositoryImplTest
- export JAVA_HOME=/usr/lib/jvm/java-17-openjdk && ./gradlew :app:assembleDebug
- Device smoke test: created a pending multi-choice question, force-stopped the app, relaunched, and verified the interactive question card and awaiting-input tab state recovered.