### PR TITLE
feat: use the volume keys to navigate through prompt history

### DIFF
--- a/app/src/androidTest/java/dev/blazelight/p4oc/ui/components/chat/ChatInputBarVolumeKeyTest.kt
+++ b/app/src/androidTest/java/dev/blazelight/p4oc/ui/components/chat/ChatInputBarVolumeKeyTest.kt
@@ -1,0 +1,81 @@
+package dev.blazelight.p4oc.ui.components.chat
+
+import android.media.AudioManager
+import android.view.KeyEvent
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import dev.blazelight.p4oc.ui.theme.PocketCodeTheme
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ChatInputBarVolumeKeyTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun volumeKeysNavigateFocusedComposerWithoutChangingSystemVolume() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val audioManager = instrumentation.targetContext.getSystemService(AudioManager::class.java)
+        val draft = "  exact draft  "
+        val history = listOf("oldest prompt", "middle prompt", "newest prompt")
+
+        composeRule.setContent {
+            var value by remember { mutableStateOf(draft) }
+            PocketCodeTheme {
+                ChatInputBar(
+                    value = value,
+                    onValueChange = { value = it },
+                    onSend = {},
+                    isLoading = false,
+                    enabled = true,
+                    requestFocus = true,
+                    promptHistory = history,
+                    promptHistorySessionId = "volume-key-test-session",
+                )
+            }
+        }
+
+        val input = composeRule.onNodeWithTag("chat_input")
+        input.assertIsFocused().assertTextEquals(draft)
+        val originalVolumes = readableVolumeSnapshot(audioManager)
+
+        instrumentation.sendKeyDownUpSync(KeyEvent.KEYCODE_VOLUME_UP)
+        composeRule.waitForIdle()
+        input.assertIsFocused().assertTextEquals("newest prompt")
+        assertEquals(originalVolumes, readableVolumeSnapshot(audioManager))
+
+        instrumentation.sendKeyDownUpSync(KeyEvent.KEYCODE_VOLUME_UP)
+        composeRule.waitForIdle()
+        input.assertIsFocused().assertTextEquals("middle prompt")
+        assertEquals(originalVolumes, readableVolumeSnapshot(audioManager))
+
+        instrumentation.sendKeyDownUpSync(KeyEvent.KEYCODE_VOLUME_DOWN)
+        composeRule.waitForIdle()
+        input.assertIsFocused().assertTextEquals("newest prompt")
+        assertEquals(originalVolumes, readableVolumeSnapshot(audioManager))
+
+        instrumentation.sendKeyDownUpSync(KeyEvent.KEYCODE_VOLUME_DOWN)
+        composeRule.waitForIdle()
+        input.assertIsFocused().assertTextEquals(draft)
+        assertEquals(originalVolumes, readableVolumeSnapshot(audioManager))
+    }
+
+    private fun readableVolumeSnapshot(audioManager: AudioManager): Map<Int, Int> = listOf(
+        AudioManager.STREAM_MUSIC,
+        AudioManager.STREAM_RING,
+        AudioManager.STREAM_ALARM,
+        AudioManager.STREAM_NOTIFICATION,
+        AudioManager.STREAM_SYSTEM,
+    ).associateWith(audioManager::getStreamVolume)
+}

--- a/app/src/main/java/dev/blazelight/p4oc/ui/components/chat/ChatInputBar.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/components/chat/ChatInputBar.kt
@@ -1,6 +1,5 @@
 package dev.blazelight.p4oc.ui.components.chat
 
-import android.view.KeyEvent as AndroidKeyEvent
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -51,6 +50,7 @@ import dev.blazelight.p4oc.ui.theme.LocalOpenCodeTheme
 import dev.blazelight.p4oc.ui.theme.Sizing
 import dev.blazelight.p4oc.ui.theme.Spacing
 import dev.blazelight.p4oc.ui.theme.TuiCodeFontSize
+import android.view.KeyEvent as AndroidKeyEvent
 
 data class ModelOption(
     val key: String,
@@ -67,41 +67,50 @@ internal class PromptHistoryNavigator(initialDraft: String = "") {
             return null
         }
 
-        val currentIndex = historyIndex?.takeIf { it in history.indices }
-        if (currentIndex == null) draft = currentText
+        val currentIndex = reconcileSelection(history, currentText)
         val nextIndex = currentIndex?.let { (it - 1).coerceAtLeast(0) } ?: history.lastIndex
         historyIndex = nextIndex
         return history[nextIndex]
     }
 
     fun newer(history: List<String>, currentText: String): String? {
-        if (history.isEmpty()) {
+        val nextText = if (history.isEmpty()) {
             reset(currentText)
-            return null
+            null
+        } else {
+            val currentIndex = reconcileSelection(history, currentText)
+            when {
+                currentIndex == null -> null
+                currentIndex < history.lastIndex -> {
+                    val nextIndex = currentIndex + 1
+                    historyIndex = nextIndex
+                    history[nextIndex]
+                }
+                else -> {
+                    historyIndex = null
+                    draft
+                }
+            }
         }
-
-        val currentIndex = historyIndex?.takeIf { it in history.indices } ?: run {
-            historyIndex = null
-            return null
-        }
-        if (currentIndex < history.lastIndex) {
-            val nextIndex = currentIndex + 1
-            historyIndex = nextIndex
-            return history[nextIndex]
-        }
-
-        historyIndex = null
-        return draft
+        return nextText
     }
 
     fun onTextChanged(text: String, history: List<String>) {
-        val selectedPrompt = historyIndex?.let(history::getOrNull)
-        if (selectedPrompt == null || text != selectedPrompt) reset(text)
+        reconcileSelection(history, text)
     }
 
     fun reset(text: String) {
         historyIndex = null
         draft = text
+    }
+
+    private fun reconcileSelection(history: List<String>, currentText: String): Int? {
+        val currentIndex = historyIndex?.takeIf { it in history.indices }
+        if (currentIndex == null || history[currentIndex] != currentText) {
+            reset(currentText)
+            return null
+        }
+        return currentIndex
     }
 }
 
@@ -112,6 +121,7 @@ private fun nextCommandIndex(
 ): Int = (currentIndex + delta + commandCount) % commandCount
 
 @Composable
+@Suppress("LongParameterList", "LongMethod", "CyclomaticComplexMethod", "FunctionNaming")
 fun ChatInputBar(
     value: String,
     onValueChange: (String) -> Unit,

--- a/app/src/main/java/dev/blazelight/p4oc/ui/components/chat/ChatInputBar.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/components/chat/ChatInputBar.kt
@@ -1,5 +1,6 @@
 package dev.blazelight.p4oc.ui.components.chat
 
+import android.view.KeyEvent as AndroidKeyEvent
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -26,6 +27,7 @@ import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.nativeKeyCode
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.layout.onGloballyPositioned
@@ -55,6 +57,54 @@ data class ModelOption(
     val displayName: String
 )
 
+internal class PromptHistoryNavigator(initialDraft: String = "") {
+    private var historyIndex: Int? = null
+    private var draft: String = initialDraft
+
+    fun older(history: List<String>, currentText: String): String? {
+        if (history.isEmpty()) {
+            reset(currentText)
+            return null
+        }
+
+        val currentIndex = historyIndex?.takeIf { it in history.indices }
+        if (currentIndex == null) draft = currentText
+        val nextIndex = currentIndex?.let { (it - 1).coerceAtLeast(0) } ?: history.lastIndex
+        historyIndex = nextIndex
+        return history[nextIndex]
+    }
+
+    fun newer(history: List<String>, currentText: String): String? {
+        if (history.isEmpty()) {
+            reset(currentText)
+            return null
+        }
+
+        val currentIndex = historyIndex?.takeIf { it in history.indices } ?: run {
+            historyIndex = null
+            return null
+        }
+        if (currentIndex < history.lastIndex) {
+            val nextIndex = currentIndex + 1
+            historyIndex = nextIndex
+            return history[nextIndex]
+        }
+
+        historyIndex = null
+        return draft
+    }
+
+    fun onTextChanged(text: String, history: List<String>) {
+        val selectedPrompt = historyIndex?.let(history::getOrNull)
+        if (selectedPrompt == null || text != selectedPrompt) reset(text)
+    }
+
+    fun reset(text: String) {
+        historyIndex = null
+        draft = text
+    }
+}
+
 private fun nextCommandIndex(
     currentIndex: Int,
     delta: Int,
@@ -82,6 +132,8 @@ fun ChatInputBar(
     requestFocus: Boolean = false,
     isActiveTab: Boolean = true,
     onComposerFocusChanged: (Boolean) -> Unit = {},
+    promptHistory: List<String> = emptyList(),
+    promptHistorySessionId: String? = null,
     enterToSend: Boolean = false,
 ) {
     val theme = LocalOpenCodeTheme.current
@@ -91,10 +143,15 @@ fun ChatInputBar(
     val initialFocusState = rememberSaveable(saver = InitialInputFocusState.Saver) {
         InitialInputFocusState()
     }
+    val historyNavigator = remember(promptHistorySessionId) { PromptHistoryNavigator(value) }
+    val currentHistoryNavigator by rememberUpdatedState(historyNavigator)
+    val currentPromptHistory by rememberUpdatedState(promptHistory)
+    val currentText = textState.text.toString()
 
     // External value changes (e.g. a programmatic set from the parent) → field.
     LaunchedEffect(value) {
         if (value != textState.text.toString()) {
+            historyNavigator.reset(value)
             textState.setTextAndPlaceCursorAtEnd(value)
         }
     }
@@ -102,7 +159,10 @@ fun ChatInputBar(
     // region correctly, so clearText() (on send) actually clears even on IMEs
     // like Samsung's that re-commit composing text with the old value API.
     LaunchedEffect(textState) {
-        snapshotFlow { textState.text.toString() }.collect { onValueChange(it) }
+        snapshotFlow { textState.text.toString() }.collect { text ->
+            currentHistoryNavigator.onTextChanged(text, currentPromptHistory)
+            onValueChange(text)
+        }
     }
 
     // Request focus once the field is attached and the tab is active. The request stays eligible
@@ -117,7 +177,6 @@ fun ChatInputBar(
     }
 
     // Determine button state
-    val currentText = textState.text.toString()
     val hasContent = currentText.isNotBlank() || attachedFiles.isNotEmpty()
     val canSubmit = hasContent && enabled && !isLoading
     val loadingDescription = stringResource(R.string.cd_loading)
@@ -164,7 +223,19 @@ fun ChatInputBar(
     fun clearInput() {
         // TextFieldState.clearText() resets the editing buffer including the IME
         // composing region, so the field stays cleared after send.
+        historyNavigator.reset("")
         textState.clearText()
+    }
+
+    fun navigatePromptHistory(older: Boolean): Boolean {
+        val liveText = textState.text.toString()
+        val replacement = if (older) {
+            historyNavigator.older(promptHistory, liveText)
+        } else {
+            historyNavigator.newer(promptHistory, liveText)
+        } ?: return false
+        textState.setTextAndPlaceCursorAtEnd(replacement)
+        return true
     }
 
     fun submitFromEnter(): Boolean = when {
@@ -363,7 +434,11 @@ fun ChatInputBar(
                                                 else -> false
                                             }
                                         }
-                                        else -> false
+                                        else -> when (event.key.nativeKeyCode) {
+                                            AndroidKeyEvent.KEYCODE_VOLUME_UP -> navigatePromptHistory(older = true)
+                                            AndroidKeyEvent.KEYCODE_VOLUME_DOWN -> navigatePromptHistory(older = false)
+                                            else -> false
+                                        }
                                     }
                                 }
                                 .testTag("chat_input"),

--- a/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ChatScreen.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ChatScreen.kt
@@ -34,8 +34,8 @@ import dev.blazelight.p4oc.R
 import dev.blazelight.p4oc.core.network.ConnectionState
 import dev.blazelight.p4oc.data.remote.dto.ModelInput
 import dev.blazelight.p4oc.domain.model.Message
-import dev.blazelight.p4oc.domain.model.Part
 import dev.blazelight.p4oc.domain.model.MessageWithParts
+import dev.blazelight.p4oc.domain.model.Part
 import dev.blazelight.p4oc.domain.model.Permission
 import dev.blazelight.p4oc.domain.model.SessionConnectionState
 import dev.blazelight.p4oc.domain.model.SessionPresence
@@ -233,6 +233,7 @@ fun ChatScreen(
     val searchMatches = remember(messageBlocks, scrollRestorationState.searchQuery) {
         findChatMatches(messageBlocks, scrollRestorationState.searchQuery)
     }
+    val promptHistory = remember(messages) { messages.toPromptHistory() }
     val coroutineScope = rememberCoroutineScope()
     var composerFocused by remember { mutableStateOf(false) }
 
@@ -460,6 +461,8 @@ fun ChatScreen(
                         requestFocus = requestInitialInputFocus,
                         isActiveTab = isActiveTab,
                         onComposerFocusChanged = { composerFocused = it },
+                        promptHistory = promptHistory,
+                        promptHistorySessionId = uiState.session?.id,
                         enterToSend = chatSettings.enterToSend,
                     )
                 }
@@ -965,6 +968,18 @@ private fun EmptyChatView(modifier: Modifier = Modifier) {
 private suspend fun LazyListState.scrollChatToBottom() {
     val target = layoutInfo.totalItemsCount - 1
     if (target >= 0) scrollToItem(target, Int.MAX_VALUE)
+}
+
+internal fun List<MessageWithParts>.toPromptHistory(): List<String> {
+    val prompts = mapNotNull { messageWithParts ->
+        if (messageWithParts.message !is Message.User) return@mapNotNull null
+        messageWithParts.parts
+            .filterIsInstance<Part.Text>()
+            .filter { !it.synthetic && !it.ignored }
+            .joinToString(separator = "\n") { it.text }
+            .takeIf(String::isNotBlank)
+    }
+    return prompts.asReversed().distinct().asReversed()
 }
 
 // MessageBlock, groupMessagesIntoBlocks, and MessageBlockView are now in MessageBlockUtils.kt

--- a/app/src/test/java/dev/blazelight/p4oc/ui/screens/chat/PromptHistoryTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/ui/screens/chat/PromptHistoryTest.kt
@@ -1,0 +1,124 @@
+package dev.blazelight.p4oc.ui.screens.chat
+
+import dev.blazelight.p4oc.domain.model.Message
+import dev.blazelight.p4oc.domain.model.MessageWithParts
+import dev.blazelight.p4oc.domain.model.ModelRef
+import dev.blazelight.p4oc.domain.model.Part
+import dev.blazelight.p4oc.domain.model.TokenUsage
+import dev.blazelight.p4oc.ui.components.chat.PromptHistoryNavigator
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class PromptHistoryTest {
+
+    @Test
+    fun `older walks newest to oldest and newer restores exact draft`() {
+        val navigator = PromptHistoryNavigator()
+        val history = listOf("oldest", "middle", "newest")
+
+        assertEquals("newest", navigator.older(history, currentText = "  unsent draft  "))
+        assertEquals("middle", navigator.older(history, currentText = "newest"))
+        assertEquals("oldest", navigator.older(history, currentText = "middle"))
+        assertEquals("oldest", navigator.older(history, currentText = "oldest"))
+        assertEquals("middle", navigator.newer(history, currentText = "oldest"))
+        assertEquals("newest", navigator.newer(history, currentText = "middle"))
+        assertEquals("  unsent draft  ", navigator.newer(history, currentText = "newest"))
+        assertNull(navigator.newer(history, currentText = "  unsent draft  "))
+    }
+
+    @Test
+    fun `editing recalled prompt exits history and establishes new draft`() {
+        val navigator = PromptHistoryNavigator()
+        val history = listOf("older", "newest")
+
+        assertEquals("newest", navigator.older(history, currentText = "original draft"))
+        navigator.onTextChanged("edited recalled prompt", history)
+
+        assertNull(navigator.newer(history, currentText = "edited recalled prompt"))
+        assertEquals("newest", navigator.older(history, currentText = "edited recalled prompt"))
+        assertEquals("edited recalled prompt", navigator.newer(history, currentText = "newest"))
+    }
+
+    @Test
+    fun `empty history leaves both directions unhandled`() {
+        val navigator = PromptHistoryNavigator("draft")
+
+        assertNull(navigator.older(emptyList(), currentText = "draft"))
+        assertNull(navigator.newer(emptyList(), currentText = "draft"))
+    }
+
+    @Test
+    fun `history contains only visible nonblank user text and retains recent duplicates`() {
+        val messages = listOf(
+            userMessage(
+                id = "user-1",
+                textParts = listOf(textPart("user-1", "  first prompt  ")),
+            ),
+            assistantMessage(id = "assistant-1", text = "assistant response"),
+            userMessage(
+                id = "user-hidden",
+                textParts = listOf(
+                    textPart("user-hidden", "synthetic protocol", synthetic = true),
+                    textPart("user-hidden", "ignored protocol", ignored = true),
+                    textPart("user-hidden", "   "),
+                ),
+            ),
+            userMessage(
+                id = "user-2",
+                textParts = listOf(
+                    textPart("user-2", "second prompt"),
+                    textPart("user-2", "ignored suffix", ignored = true),
+                    textPart("user-2", "continued"),
+                ),
+            ),
+            userMessage(
+                id = "user-3",
+                textParts = listOf(textPart("user-3", "  first prompt  ")),
+            ),
+        )
+
+        assertEquals(listOf("second prompt\ncontinued", "  first prompt  "), messages.toPromptHistory())
+    }
+
+    private fun userMessage(id: String, textParts: List<Part.Text>): MessageWithParts = MessageWithParts(
+        message = Message.User(
+            id = id,
+            sessionID = "session",
+            createdAt = 1,
+            agent = "agent",
+            model = ModelRef(providerID = "provider", modelID = "model"),
+        ),
+        parts = textParts,
+    )
+
+    private fun assistantMessage(id: String, text: String): MessageWithParts = MessageWithParts(
+        message = Message.Assistant(
+            id = id,
+            sessionID = "session",
+            createdAt = 1,
+            parentID = "user-1",
+            providerID = "provider",
+            modelID = "model",
+            mode = "chat",
+            agent = "agent",
+            cost = 0.0,
+            tokens = TokenUsage(input = 0, output = 0),
+        ),
+        parts = listOf(textPart(id, text)),
+    )
+
+    private fun textPart(
+        messageId: String,
+        text: String,
+        synthetic: Boolean = false,
+        ignored: Boolean = false,
+    ): Part.Text = Part.Text(
+        id = "part-$messageId-$text",
+        sessionID = "session",
+        messageID = messageId,
+        text = text,
+        synthetic = synthetic,
+        ignored = ignored,
+    )
+}

--- a/app/src/test/java/dev/blazelight/p4oc/ui/screens/chat/PromptHistoryTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/ui/screens/chat/PromptHistoryTest.kt
@@ -28,14 +28,22 @@ class PromptHistoryTest {
     }
 
     @Test
-    fun `editing recalled prompt exits history and establishes new draft`() {
+    fun `newer immediately after editing recalled prompt exits history and preserves edit as draft`() {
         val navigator = PromptHistoryNavigator()
         val history = listOf("older", "newest")
 
         assertEquals("newest", navigator.older(history, currentText = "original draft"))
-        navigator.onTextChanged("edited recalled prompt", history)
-
         assertNull(navigator.newer(history, currentText = "edited recalled prompt"))
+        assertEquals("newest", navigator.older(history, currentText = "edited recalled prompt"))
+        assertEquals("edited recalled prompt", navigator.newer(history, currentText = "newest"))
+    }
+
+    @Test
+    fun `older immediately after editing recalled prompt restarts from newest with edit as draft`() {
+        val navigator = PromptHistoryNavigator()
+        val history = listOf("older", "newest")
+
+        assertEquals("newest", navigator.older(history, currentText = "original draft"))
         assertEquals("newest", navigator.older(history, currentText = "edited recalled prompt"))
         assertEquals("edited recalled prompt", navigator.newer(history, currentText = "newest"))
     }


### PR DESCRIPTION
## Problem

Prompt history was only available by retyping or copying prior user messages. On phones with a focused composer, the physical volume buttons can provide a compact, chrome-free history shortcut.

## Changes

- Volume Up selects the newest visible user prompt and walks toward older prompts.
- Volume Down walks toward newer prompts and restores the exact unsent draft after the newest entry.
- Editing a recalled prompt exits history mode safely; synchronous reconciliation prevents a rapid follow-up key press from overwriting the edit.
- History is scoped to the current session and resets when the active session changes.
- Only visible user text is recalled: assistant, blank, synthetic, and ignored text is excluded.
- Repeated prompts retain only the most recent exact duplicate.
- The key handler remains on the focused `BasicTextField`; empty history and Volume Down outside history are left unconsumed so normal volume behavior remains available.
- Current-main composer focus, search, scroll restoration, permissions, and recovery behavior are preserved.

## Verification

Java 17:

- `./gradlew :app:testDebugUnitTest --tests dev.blazelight.p4oc.ui.screens.chat.PromptHistoryTest`
- `./gradlew :app:testDebugUnitTest :app:detekt :app:assembleDebug`
- `ANDROID_SERIAL=R58X70XHB9P ./gradlew :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=dev.blazelight.p4oc.ui.components.chat.ChatInputBarVolumeKeyTest`
- `git diff --check origin/main`

The serial-scoped instrumentation test passed on Samsung SM-A155F (`R58X70XHB9P`). It injected Android `KEYCODE_VOLUME_UP`/`KEYCODE_VOLUME_DOWN` into the focused composer, observed draft → newest → older → newer → exact draft transitions, and confirmed readable system stream volumes did not change. The verified debug APK was reinstalled and cold-launched afterward; the crash buffer remained empty.