### PR TITLE
Persist model and reasoning selection per session

### DIFF
--- a/app/src/main/java/dev/blazelight/p4oc/core/datastore/SettingsDataStore.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/core/datastore/SettingsDataStore.kt
@@ -36,7 +36,6 @@ private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(
 
 private const val TAG = "SettingsDataStore"
 internal const val MAX_SESSION_AGENT_SELECTIONS = 100
-internal const val MAX_SESSION_MODEL_SELECTIONS = 100
 internal const val MAX_SESSION_COMPOSER_SELECTIONS = 100
 
 @Serializable
@@ -65,30 +64,6 @@ internal fun updatedSessionAgentSelections(
     selections.remove(sessionId)
     selections[sessionId] = agentName
     while (selections.size > MAX_SESSION_AGENT_SELECTIONS) {
-        selections.remove(selections.keys.first())
-    }
-    return Json.encodeToString(selections)
-}
-
-private fun parseSessionModelSelections(stored: String?): LinkedHashMap<String, String> =
-    stored?.let {
-        runCatching {
-            Json.decodeFromString<LinkedHashMap<String, String>>(it)
-        }.getOrNull()
-    } ?: linkedMapOf()
-
-internal fun selectedModelForSession(stored: String?, sessionId: String): ModelInput? =
-    parseSessionModelSelections(stored)[sessionId]?.toModelInput()
-
-internal fun updatedSessionModelSelections(
-    stored: String?,
-    sessionId: String,
-    model: ModelInput,
-): String {
-    val selections = parseSessionModelSelections(stored)
-    selections.remove(sessionId)
-    selections[sessionId] = model.toStorageKey()
-    while (selections.size > MAX_SESSION_MODEL_SELECTIONS) {
         selections.remove(selections.keys.first())
     }
     return Json.encodeToString(selections)
@@ -220,7 +195,6 @@ class SettingsDataStore constructor(
         private val KEY_FAVORITE_MODELS = stringSetPreferencesKey("favorite_models")
         private val KEY_RECENT_MODELS = stringPreferencesKey("recent_models")
         private val KEY_SESSION_AGENTS = stringPreferencesKey("session_agents")
-        private val KEY_SESSION_MODELS = stringPreferencesKey("session_models")
         private val KEY_SESSION_COMPOSER_SELECTIONS = stringPreferencesKey("session_composer_selections_v1")
         private const val MAX_RECENT_MODELS = 10
 
@@ -791,21 +765,6 @@ class SettingsDataStore constructor(
         }
     }
 
-    suspend fun getSelectedModelForSession(sessionId: String): ModelInput? {
-        val stored = context.dataStore.data.first()[KEY_SESSION_MODELS] ?: return null
-        return selectedModelForSession(stored, sessionId)
-    }
-
-    suspend fun setSelectedModelForSession(sessionId: String, model: ModelInput) {
-        context.dataStore.edit { prefs ->
-            prefs[KEY_SESSION_MODELS] = updatedSessionModelSelections(
-                stored = prefs[KEY_SESSION_MODELS],
-                sessionId = sessionId,
-                model = model,
-            )
-        }
-    }
-
     suspend fun getComposerSelectionForSession(
         workspace: Workspace,
         sessionId: String,
@@ -925,9 +884,9 @@ private fun removeDeadWorkspacePrefsMigration(): DataMigration<Preferences> = ob
     override suspend fun cleanUp() = Unit
 }
 
-internal fun ModelInput.toStorageKey(): String = "$providerID/$modelID"
+private fun ModelInput.toStorageKey(): String = "$providerID/$modelID"
 
-internal fun String.toModelInput(): ModelInput? {
+private fun String.toModelInput(): ModelInput? {
     val parts = split("/", limit = 2)
     return if (parts.size >= 2) {
         ModelInput(providerID = parts[0], modelID = parts.drop(1).joinToString("/"))

--- a/app/src/main/java/dev/blazelight/p4oc/core/datastore/SettingsDataStore.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/core/datastore/SettingsDataStore.kt
@@ -13,6 +13,7 @@ import dev.blazelight.p4oc.data.remote.dto.ModelInput
 import dev.blazelight.p4oc.domain.server.ServerIdentity
 import dev.blazelight.p4oc.domain.server.WorkspaceKey
 import dev.blazelight.p4oc.domain.session.SessionId
+import dev.blazelight.p4oc.domain.workspace.Workspace
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -35,6 +36,15 @@ private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(
 
 private const val TAG = "SettingsDataStore"
 internal const val MAX_SESSION_AGENT_SELECTIONS = 100
+internal const val MAX_SESSION_MODEL_SELECTIONS = 100
+internal const val MAX_SESSION_COMPOSER_SELECTIONS = 100
+
+@Serializable
+data class SessionComposerSelection(
+    val model: ModelInput,
+    val variant: String? = null,
+    val pendingServerSync: Boolean = false,
+)
 
 private fun parseSessionAgentSelections(stored: String?): LinkedHashMap<String, String> =
     stored?.let {
@@ -59,6 +69,68 @@ internal fun updatedSessionAgentSelections(
     }
     return Json.encodeToString(selections)
 }
+
+private fun parseSessionModelSelections(stored: String?): LinkedHashMap<String, String> =
+    stored?.let {
+        runCatching {
+            Json.decodeFromString<LinkedHashMap<String, String>>(it)
+        }.getOrNull()
+    } ?: linkedMapOf()
+
+internal fun selectedModelForSession(stored: String?, sessionId: String): ModelInput? =
+    parseSessionModelSelections(stored)[sessionId]?.toModelInput()
+
+internal fun updatedSessionModelSelections(
+    stored: String?,
+    sessionId: String,
+    model: ModelInput,
+): String {
+    val selections = parseSessionModelSelections(stored)
+    selections.remove(sessionId)
+    selections[sessionId] = model.toStorageKey()
+    while (selections.size > MAX_SESSION_MODEL_SELECTIONS) {
+        selections.remove(selections.keys.first())
+    }
+    return Json.encodeToString(selections)
+}
+
+private fun parseSessionComposerSelections(stored: String?): LinkedHashMap<String, SessionComposerSelection> =
+    stored?.let {
+        runCatching {
+            Json.decodeFromString<LinkedHashMap<String, SessionComposerSelection>>(it)
+        }.getOrNull()
+    } ?: linkedMapOf()
+
+internal fun composerSelectionForSession(
+    stored: String?,
+    selectionKey: String,
+): SessionComposerSelection? = parseSessionComposerSelections(stored)[selectionKey]
+
+internal fun updatedSessionComposerSelections(
+    stored: String?,
+    selectionKey: String,
+    selection: SessionComposerSelection,
+): String {
+    val selections = parseSessionComposerSelections(stored)
+    selections.remove(selectionKey)
+    selections[selectionKey] = selection
+    while (selections.size > MAX_SESSION_COMPOSER_SELECTIONS) {
+        selections.remove(selections.keys.first())
+    }
+    return Json.encodeToString(selections)
+}
+
+internal fun sessionComposerSelectionKey(workspace: Workspace, sessionId: String): String = Json.encodeToString(
+    listOf(
+        workspace.server.endpointKey,
+        when (val key = workspace.key) {
+            WorkspaceKey.Global -> "global"
+            is WorkspaceKey.Directory -> "directory:${key.value}"
+            is WorkspaceKey.SessionScoped -> "session:${key.sessionId.value}"
+        },
+        sessionId,
+    )
+)
 
 internal const val MAX_LAST_UPLOAD_DIRECTORIES = 50
 
@@ -148,6 +220,8 @@ class SettingsDataStore constructor(
         private val KEY_FAVORITE_MODELS = stringSetPreferencesKey("favorite_models")
         private val KEY_RECENT_MODELS = stringPreferencesKey("recent_models")
         private val KEY_SESSION_AGENTS = stringPreferencesKey("session_agents")
+        private val KEY_SESSION_MODELS = stringPreferencesKey("session_models")
+        private val KEY_SESSION_COMPOSER_SELECTIONS = stringPreferencesKey("session_composer_selections_v1")
         private const val MAX_RECENT_MODELS = 10
 
         // Notification settings keys
@@ -717,6 +791,43 @@ class SettingsDataStore constructor(
         }
     }
 
+    suspend fun getSelectedModelForSession(sessionId: String): ModelInput? {
+        val stored = context.dataStore.data.first()[KEY_SESSION_MODELS] ?: return null
+        return selectedModelForSession(stored, sessionId)
+    }
+
+    suspend fun setSelectedModelForSession(sessionId: String, model: ModelInput) {
+        context.dataStore.edit { prefs ->
+            prefs[KEY_SESSION_MODELS] = updatedSessionModelSelections(
+                stored = prefs[KEY_SESSION_MODELS],
+                sessionId = sessionId,
+                model = model,
+            )
+        }
+    }
+
+    suspend fun getComposerSelectionForSession(
+        workspace: Workspace,
+        sessionId: String,
+    ): SessionComposerSelection? {
+        val stored = context.dataStore.data.first()[KEY_SESSION_COMPOSER_SELECTIONS] ?: return null
+        return composerSelectionForSession(stored, sessionComposerSelectionKey(workspace, sessionId))
+    }
+
+    suspend fun setComposerSelectionForSession(
+        workspace: Workspace,
+        sessionId: String,
+        selection: SessionComposerSelection,
+    ) {
+        context.dataStore.edit { prefs ->
+            prefs[KEY_SESSION_COMPOSER_SELECTIONS] = updatedSessionComposerSelections(
+                stored = prefs[KEY_SESSION_COMPOSER_SELECTIONS],
+                selectionKey = sessionComposerSelectionKey(workspace, sessionId),
+                selection = selection,
+            )
+        }
+    }
+
     /**
      * Parse recent servers from stored format (kotlinx.serialization JSON).
      */
@@ -814,9 +925,9 @@ private fun removeDeadWorkspacePrefsMigration(): DataMigration<Preferences> = ob
     override suspend fun cleanUp() = Unit
 }
 
-private fun ModelInput.toStorageKey(): String = "$providerID/$modelID"
+internal fun ModelInput.toStorageKey(): String = "$providerID/$modelID"
 
-private fun String.toModelInput(): ModelInput? {
+internal fun String.toModelInput(): ModelInput? {
     val parts = split("/", limit = 2)
     return if (parts.size >= 2) {
         ModelInput(providerID = parts[0], modelID = parts.drop(1).joinToString("/"))

--- a/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ChatViewModel.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ChatViewModel.kt
@@ -280,6 +280,12 @@ class ChatViewModel constructor(
         _isActiveTab.value = false
     }
 
+    /** Reconciles REST-backed chat state after Android resumes from the background. */
+    fun refreshAfterForeground() {
+        loadSession()
+        loadMessages()
+    }
+
     fun updateInput(text: String) {
         persistInputText(text)
         _uiState.update { it.copy(inputText = text) }
@@ -298,6 +304,7 @@ class ChatViewModel constructor(
             endLoadStep("Loading session metadata")
             when (result) {
                 is ApiResult.Success -> {
+                    modelAgentManager.applyServerSessionModel(result.data.model)
                     val session = SessionMapper.mapToDomain(result.data)
                     _uiState.update { it.copy(session = session) }
                     // Reload VCS now that we have the canonical session directory
@@ -528,6 +535,7 @@ class ChatViewModel constructor(
         val result = sessionRepository.sendMessageAsync(SessionId(sessionId), request).await().toApiResult()
         when (result) {
             is ApiResult.Success -> {
+                modelAgentManager.markComposerSelectionSent()
                 sessionRepository.acceptEvent(
                     OpenCodeEvent.SessionStatusChanged(sessionId, SessionStatus.Busy)
                 )

--- a/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ChatViewModel.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ChatViewModel.kt
@@ -280,12 +280,6 @@ class ChatViewModel constructor(
         _isActiveTab.value = false
     }
 
-    /** Reconciles REST-backed chat state after Android resumes from the background. */
-    fun refreshAfterForeground() {
-        loadSession()
-        loadMessages()
-    }
-
     fun updateInput(text: String) {
         persistInputText(text)
         _uiState.update { it.copy(inputText = text) }
@@ -535,7 +529,7 @@ class ChatViewModel constructor(
         val result = sessionRepository.sendMessageAsync(SessionId(sessionId), request).await().toApiResult()
         when (result) {
             is ApiResult.Success -> {
-                modelAgentManager.markComposerSelectionSent()
+                modelAgentManager.markComposerSelectionSent(selectedModel, selectedVariant)
                 sessionRepository.acceptEvent(
                     OpenCodeEvent.SessionStatusChanged(sessionId, SessionStatus.Busy)
                 )

--- a/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ModelAgentManager.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ModelAgentManager.kt
@@ -1,5 +1,6 @@
 package dev.blazelight.p4oc.ui.screens.chat
 
+import dev.blazelight.p4oc.core.datastore.SessionComposerSelection
 import dev.blazelight.p4oc.core.datastore.SettingsDataStore
 import dev.blazelight.p4oc.core.log.AppLog
 import dev.blazelight.p4oc.core.network.ApiResult
@@ -8,6 +9,7 @@ import dev.blazelight.p4oc.core.network.safeApiCall
 import dev.blazelight.p4oc.data.remote.dto.AgentDto
 import dev.blazelight.p4oc.data.remote.dto.ModelDto
 import dev.blazelight.p4oc.data.remote.dto.ModelInput
+import dev.blazelight.p4oc.data.remote.dto.SessionModelDto
 import dev.blazelight.p4oc.data.remote.dto.reasoningEfforts
 import dev.blazelight.p4oc.data.workspace.WorkspaceClient
 import dev.blazelight.p4oc.domain.model.OpenCodeEvent
@@ -54,6 +56,11 @@ class ModelAgentManager(
 
     private var selectedModelFromAgent = false
     private var selectedModelExplicitly = false
+    private var catalogLoaded = false
+    private var catalogDefaultModel: ModelInput? = null
+    private var catalogLastUsedModel: ModelInput? = null
+    private var localComposerSelection: SessionComposerSelection? = null
+    private var serverComposerSelection: SessionComposerSelection? = null
 
     val favoriteModels: StateFlow<Set<ModelInput>> = settingsDataStore.favoriteModels
         .stateIn(scope, SharingStarted.Eagerly, emptySet())
@@ -131,12 +138,17 @@ class ModelAgentManager(
             }
         }
         val agentModel = _availableAgents.value.find { it.name == agentName }?.model ?: return
-        _selectedModel.value = ModelInput(
+        val model = ModelInput(
             providerID = agentModel.providerID,
             modelID = agentModel.modelID
         )
-        selectedModelFromAgent = true
-        selectedModelExplicitly = false
+        if (persist || !hasPreferredSessionSelection()) {
+            if (_selectedModel.value != model) _selectedReasoningEffort.value = null
+            _selectedModel.value = model
+            selectedModelFromAgent = true
+            selectedModelExplicitly = persist
+            if (persist) persistComposerSelection(pendingServerSync = true)
+        }
     }
 
     fun loadModels() {
@@ -153,30 +165,26 @@ class ModelAgentManager(
                             models.add(providerId to model)
                         }
                     }
-                    val defaultModel = result.data.default.entries
+                    catalogDefaultModel = result.data.default.entries
                         .map { (provider, modelId) -> ModelInput(providerID = provider, modelID = modelId) }
                         .firstOrNull { candidate ->
                             models.any { (providerId, model) ->
                                 providerId == candidate.providerID && model.id == candidate.modelID
                             }
                         }
-                    val lastUsedModel = recentModels.value.firstOrNull { candidate ->
-                        models.any { (providerId, model) ->
-                            providerId == candidate.providerID && model.id == candidate.modelID
-                        }
+                    catalogLastUsedModel = recentModels.value.firstOrNull { candidate ->
+                        candidate.isAvailableIn(models)
                     }
-                    val fallbackModel = defaultModel ?: lastUsedModel
-                    val currentSelectionIsAvailable = _selectedModel.value?.let { selected ->
-                        models.any { (providerId, model) ->
-                            providerId == selected.providerID && model.id == selected.modelID
-                        }
-                    } == true
+                    localComposerSelection = sessionId?.let { currentSessionId ->
+                        settingsDataStore.getComposerSelectionForSession(workspaceClient.workspace, currentSessionId)
+                            ?: settingsDataStore.getSelectedModelForSession(currentSessionId)?.let { legacyModel ->
+                                SessionComposerSelection(model = legacyModel, pendingServerSync = true)
+                            }
+                    }
                     _availableModels.value = models
                     _providerNames.value = names
-                    if (!selectedModelFromAgent && (!selectedModelExplicitly || !currentSelectionIsAvailable)) {
-                        _selectedModel.value = fallbackModel
-                        selectedModelExplicitly = false
-                    }
+                    catalogLoaded = true
+                    reconcileComposerSelection()
                 }
                 is ApiResult.Error -> {}
             }
@@ -192,11 +200,27 @@ class ModelAgentManager(
         selectedModelExplicitly = true
         scope.launch {
             settingsDataStore.addRecentModel(model)
+            persistComposerSelectionValue(pendingServerSync = true)
         }
     }
 
     fun selectReasoningEffort(reasoningEffort: String?) {
         _selectedReasoningEffort.value = reasoningEffort
+        persistComposerSelection(pendingServerSync = true)
+    }
+
+    fun applyServerSessionModel(model: SessionModelDto?) {
+        serverComposerSelection = model?.let {
+            SessionComposerSelection(
+                model = ModelInput(providerID = it.providerID, modelID = it.id),
+                variant = it.variant,
+            )
+        }
+        if (catalogLoaded && !selectedModelExplicitly) reconcileComposerSelection()
+    }
+
+    fun markComposerSelectionSent() {
+        persistComposerSelection(pendingServerSync = false)
     }
 
     fun currentReasoningEffort(): String? {
@@ -223,6 +247,77 @@ class ModelAgentManager(
         }
         _selectedModel.value = model
     }
+
+    private fun reconcileComposerSelection() {
+        val currentSelectionIsAvailable = _selectedModel.value?.isAvailableIn(_availableModels.value) == true
+        if (selectedModelExplicitly && currentSelectionIsAvailable) return
+
+        val local = localComposerSelection?.takeIf { it.model.isAvailableIn(_availableModels.value) }
+        val server = serverComposerSelection?.takeIf { it.model.isAvailableIn(_availableModels.value) }
+        val preferred = preferredComposerSelection(local, server)
+
+        if (preferred != null) {
+            applyComposerSelection(preferred)
+            if (server != null && preferred == server && local != server) {
+                persistComposerSelection(pendingServerSync = false)
+            }
+            return
+        }
+
+        if (!selectedModelFromAgent && (!currentSelectionIsAvailable || _selectedModel.value == null)) {
+            _selectedModel.value = catalogDefaultModel ?: catalogLastUsedModel
+            _selectedReasoningEffort.value = null
+        }
+        selectedModelExplicitly = false
+    }
+
+    private fun preferredComposerSelection(
+        local: SessionComposerSelection?,
+        server: SessionComposerSelection?,
+    ): SessionComposerSelection? = when {
+        local?.pendingServerSync == true && local != server -> local
+        server != null -> server
+        else -> local
+    }
+
+    private fun applyComposerSelection(selection: SessionComposerSelection) {
+        _selectedModel.value = selection.model
+        val availableEfforts = _availableModels.value.firstOrNull { (providerId, dto) ->
+            providerId == selection.model.providerID && dto.id == selection.model.modelID
+        }?.second?.reasoningEfforts().orEmpty()
+        _selectedReasoningEffort.value = selection.variant?.takeIf { it in availableEfforts }
+        selectedModelFromAgent = false
+        selectedModelExplicitly = false
+    }
+
+    private fun hasPreferredSessionSelection(): Boolean =
+        serverComposerSelection != null || localComposerSelection != null
+
+    private fun persistComposerSelection(pendingServerSync: Boolean) {
+        scope.launch { persistComposerSelectionValue(pendingServerSync) }
+    }
+
+    private suspend fun persistComposerSelectionValue(pendingServerSync: Boolean) {
+        val currentSessionId = sessionId ?: return
+        val model = _selectedModel.value ?: return
+        val selection = SessionComposerSelection(
+            model = model,
+            variant = currentReasoningEffort(),
+            pendingServerSync = pendingServerSync,
+        )
+        localComposerSelection = selection
+        settingsDataStore.setSelectedModelForSession(currentSessionId, model)
+        settingsDataStore.setComposerSelectionForSession(
+            workspaceClient.workspace,
+            currentSessionId,
+            selection,
+        )
+    }
+
+    private fun ModelInput.isAvailableIn(models: List<Pair<String, ModelDto>>): Boolean =
+        models.any { (providerId, model) ->
+            providerId == providerID && model.id == modelID
+        }
 
     private companion object {
         const val TAG = "ModelAgentManager"

--- a/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ModelAgentManager.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ModelAgentManager.kt
@@ -23,6 +23,9 @@ import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.util.concurrent.atomic.AtomicLong
 
 /**
  * Manages model/agent loading, selection, favorites, and recents.
@@ -57,10 +60,15 @@ class ModelAgentManager(
     private var selectedModelFromAgent = false
     private var selectedModelExplicitly = false
     private var catalogLoaded = false
+    private var composerSelectionLoaded = false
     private var catalogDefaultModel: ModelInput? = null
     private var catalogLastUsedModel: ModelInput? = null
     private var localComposerSelection: SessionComposerSelection? = null
     private var serverComposerSelection: SessionComposerSelection? = null
+
+    /** Serializes DataStore writes and tracks the newest selection so a stale write is skipped. */
+    private val composerPersistenceMutex = Mutex()
+    private val composerPersistenceVersion = AtomicLong(0L)
 
     val favoriteModels: StateFlow<Set<ModelInput>> = settingsDataStore.favoriteModels
         .stateIn(scope, SharingStarted.Eagerly, emptySet())
@@ -71,8 +79,12 @@ class ModelAgentManager(
     init {
         modelSelectionCoordinator?.let { coordinator ->
             scope.launch {
-                coordinator.activeModelChanges.collect { model ->
-                    reconcileActiveModel(model)
+                coordinator.activeModelChanges.collect { change ->
+                    if (change.workspace == workspaceClient.workspace &&
+                        change.generation == workspaceClient.generation
+                    ) {
+                        reconcileActiveModel(change.model)
+                    }
                 }
             }
         }
@@ -147,7 +159,15 @@ class ModelAgentManager(
             _selectedModel.value = model
             selectedModelFromAgent = true
             selectedModelExplicitly = persist
-            if (persist) persistComposerSelection(pendingServerSync = true)
+            if (persist) {
+                persistComposerSelection(
+                    SessionComposerSelection(
+                        model = model,
+                        variant = _selectedReasoningEffort.value,
+                        pendingServerSync = true,
+                    )
+                )
+            }
         }
     }
 
@@ -175,11 +195,19 @@ class ModelAgentManager(
                     catalogLastUsedModel = recentModels.value.firstOrNull { candidate ->
                         candidate.isAvailableIn(models)
                     }
-                    localComposerSelection = sessionId?.let { currentSessionId ->
-                        settingsDataStore.getComposerSelectionForSession(workspaceClient.workspace, currentSessionId)
-                            ?: settingsDataStore.getSelectedModelForSession(currentSessionId)?.let { legacyModel ->
-                                SessionComposerSelection(model = legacyModel, pendingServerSync = true)
-                            }
+                    if (!composerSelectionLoaded) {
+                        val stored = sessionId?.let { currentSessionId ->
+                            settingsDataStore.getComposerSelectionForSession(
+                                workspaceClient.workspace,
+                                currentSessionId,
+                            )
+                        }
+                        // A selection may have been made (or persistence begun) while this read
+                        // was in flight; a stale storage snapshot must not clobber it.
+                        if (!composerSelectionLoaded) {
+                            localComposerSelection = stored
+                            composerSelectionLoaded = true
+                        }
                     }
                     _availableModels.value = models
                     _providerNames.value = names
@@ -198,15 +226,28 @@ class ModelAgentManager(
         _selectedModel.value = model
         selectedModelFromAgent = false
         selectedModelExplicitly = true
+        persistComposerSelection(
+            SessionComposerSelection(
+                model = model,
+                variant = _selectedReasoningEffort.value,
+                pendingServerSync = true,
+            )
+        )
         scope.launch {
             settingsDataStore.addRecentModel(model)
-            persistComposerSelectionValue(pendingServerSync = true)
         }
     }
 
     fun selectReasoningEffort(reasoningEffort: String?) {
         _selectedReasoningEffort.value = reasoningEffort
-        persistComposerSelection(pendingServerSync = true)
+        val model = _selectedModel.value ?: return
+        persistComposerSelection(
+            SessionComposerSelection(
+                model = model,
+                variant = reasoningEffort,
+                pendingServerSync = true,
+            )
+        )
     }
 
     fun applyServerSessionModel(model: SessionModelDto?) {
@@ -219,8 +260,15 @@ class ModelAgentManager(
         if (catalogLoaded && !selectedModelExplicitly) reconcileComposerSelection()
     }
 
-    fun markComposerSelectionSent() {
-        persistComposerSelection(pendingServerSync = false)
+    fun markComposerSelectionSent(model: ModelInput?, variant: String?) {
+        val pending = localComposerSelection ?: return
+        if (!pending.pendingServerSync || pending.model != model || pending.variant != variant) return
+        val acknowledged = pending.copy(pendingServerSync = false)
+        localComposerSelection = acknowledged
+        serverComposerSelection = acknowledged
+        selectedModelExplicitly = false
+        selectedModelFromAgent = false
+        persistComposerSelection(acknowledged)
     }
 
     fun currentReasoningEffort(): String? {
@@ -241,7 +289,7 @@ class ModelAgentManager(
     }
 
     private fun reconcileActiveModel(model: ModelInput) {
-        if (selectedModelFromAgent || selectedModelExplicitly) return
+        if (selectedModelFromAgent || selectedModelExplicitly || hasPreferredSessionSelection()) return
         if (_selectedModel.value != model) {
             _selectedReasoningEffort.value = null
         }
@@ -257,9 +305,12 @@ class ModelAgentManager(
         val preferred = preferredComposerSelection(local, server)
 
         if (preferred != null) {
-            applyComposerSelection(preferred)
-            if (server != null && preferred == server && local != server) {
-                persistComposerSelection(pendingServerSync = false)
+            val applied = applyComposerSelection(preferred)
+            val serverWins = server != null && preferred == server && local != server
+            if (serverWins || applied.variant != preferred.variant) {
+                persistComposerSelection(
+                    if (serverWins) applied.copy(pendingServerSync = false) else applied
+                )
             }
             return
         }
@@ -280,38 +331,39 @@ class ModelAgentManager(
         else -> local
     }
 
-    private fun applyComposerSelection(selection: SessionComposerSelection) {
-        _selectedModel.value = selection.model
+    private fun applyComposerSelection(selection: SessionComposerSelection): SessionComposerSelection {
         val availableEfforts = _availableModels.value.firstOrNull { (providerId, dto) ->
             providerId == selection.model.providerID && dto.id == selection.model.modelID
         }?.second?.reasoningEfforts().orEmpty()
-        _selectedReasoningEffort.value = selection.variant?.takeIf { it in availableEfforts }
+        val normalizedVariant = selection.variant?.takeIf { it in availableEfforts }
+        _selectedModel.value = selection.model
+        _selectedReasoningEffort.value = normalizedVariant
         selectedModelFromAgent = false
         selectedModelExplicitly = false
+        val applied = selection.copy(variant = normalizedVariant)
+        localComposerSelection = applied
+        return applied
     }
 
     private fun hasPreferredSessionSelection(): Boolean =
         serverComposerSelection != null || localComposerSelection != null
 
-    private fun persistComposerSelection(pendingServerSync: Boolean) {
-        scope.launch { persistComposerSelectionValue(pendingServerSync) }
-    }
-
-    private suspend fun persistComposerSelectionValue(pendingServerSync: Boolean) {
-        val currentSessionId = sessionId ?: return
-        val model = _selectedModel.value ?: return
-        val selection = SessionComposerSelection(
-            model = model,
-            variant = currentReasoningEffort(),
-            pendingServerSync = pendingServerSync,
-        )
+    private fun persistComposerSelection(selection: SessionComposerSelection) {
         localComposerSelection = selection
-        settingsDataStore.setSelectedModelForSession(currentSessionId, model)
-        settingsDataStore.setComposerSelectionForSession(
-            workspaceClient.workspace,
-            currentSessionId,
-            selection,
-        )
+        composerSelectionLoaded = true
+        val version = composerPersistenceVersion.incrementAndGet()
+        val currentSessionId = sessionId ?: return
+        scope.launch {
+            composerPersistenceMutex.withLock {
+                // A newer selection superseded this one while this write was queued; skip.
+                if (version != composerPersistenceVersion.get()) return@withLock
+                settingsDataStore.setComposerSelectionForSession(
+                    workspaceClient.workspace,
+                    currentSessionId,
+                    selection,
+                )
+            }
+        }
     }
 
     private fun ModelInput.isAvailableIn(models: List<Pair<String, ModelDto>>): Boolean =

--- a/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ModelSelectionCoordinator.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ModelSelectionCoordinator.kt
@@ -1,18 +1,35 @@
 package dev.blazelight.p4oc.ui.screens.chat
 
 import dev.blazelight.p4oc.data.remote.dto.ModelInput
+import dev.blazelight.p4oc.domain.server.ServerGeneration
+import dev.blazelight.p4oc.domain.workspace.Workspace
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 
 /**
+ * A successful active-model write scoped to the exact workspace and server generation
+ * that produced it. Consumers must only apply events whose [workspace] and [generation]
+ * match their own, so a global coordinator singleton can never cross-update tabs across
+ * workspaces or stale server generations.
+ */
+data class ScopedModelSelectionChange(
+    val workspace: Workspace,
+    val generation: ServerGeneration,
+    val model: ModelInput,
+)
+
+/**
  * Shares successful active-model writes with live chat model managers.
+ * Because this is a Koin singleton shared process-wide, events carry the originating
+ * workspace and server generation and consumers filter on exact matches.
  */
 class ModelSelectionCoordinator {
-    private val _activeModelChanges = MutableSharedFlow<ModelInput>(extraBufferCapacity = 1)
-    val activeModelChanges: SharedFlow<ModelInput> = _activeModelChanges.asSharedFlow()
+    private val _activeModelChanges =
+        MutableSharedFlow<ScopedModelSelectionChange>(extraBufferCapacity = 1)
+    val activeModelChanges: SharedFlow<ScopedModelSelectionChange> = _activeModelChanges.asSharedFlow()
 
-    fun publishActiveModel(model: ModelInput) {
-        _activeModelChanges.tryEmit(model)
+    fun publishActiveModel(workspace: Workspace, generation: ServerGeneration, model: ModelInput) {
+        _activeModelChanges.tryEmit(ScopedModelSelectionChange(workspace, generation, model))
     }
 }

--- a/app/src/main/java/dev/blazelight/p4oc/ui/screens/settings/ModelControlsScreen.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/screens/settings/ModelControlsScreen.kt
@@ -159,7 +159,11 @@ class ModelControlsViewModel constructor(
             when (safeApiCall { workspaceClient.updateCurrentModel("${model.providerId}/${model.id}") }) {
                 is ApiResult.Success -> {
                     _state.update { it.copy(selectedModelId = modelId, error = null, loadFailed = false) }
-                    modelSelectionCoordinator.publishActiveModel(selectedModel)
+                    modelSelectionCoordinator.publishActiveModel(
+                        workspaceClient.workspace,
+                        workspaceClient.generation,
+                        selectedModel,
+                    )
                 }
                 is ApiResult.Error -> {
                     _state.update {

--- a/app/src/main/java/dev/blazelight/p4oc/ui/screens/settings/ProviderConfigViewModel.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/screens/settings/ProviderConfigViewModel.kt
@@ -202,7 +202,13 @@ class ProviderConfigViewModel constructor(
                 val savedConfig = workspaceClient.updateConfig(updatedConfig)
                 val savedModel = savedConfig.model ?: newModel
                 _uiState.update { it.copy(currentModel = savedModel, error = null) }
-                parseModelInput(savedModel)?.let(modelSelectionCoordinator::publishActiveModel)
+                parseModelInput(savedModel)?.let { model ->
+                    modelSelectionCoordinator.publishActiveModel(
+                        workspaceClient.workspace,
+                        workspaceClient.generation,
+                        model,
+                    )
+                }
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {

--- a/app/src/test/java/dev/blazelight/p4oc/core/datastore/SettingsDataStoreSelectedModelTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/core/datastore/SettingsDataStoreSelectedModelTest.kt
@@ -1,0 +1,101 @@
+package dev.blazelight.p4oc.core.datastore
+
+import dev.blazelight.p4oc.data.remote.dto.ModelInput
+import dev.blazelight.p4oc.domain.server.ServerRef
+import dev.blazelight.p4oc.domain.workspace.Workspace
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class SettingsDataStoreSelectedModelTest {
+    @Test
+    fun `composer selection round trips explicit variant and default`() {
+        val model = ModelInput(providerID = "openai", modelID = "gpt-5")
+        val high = SessionComposerSelection(model = model, variant = "high", pendingServerSync = true)
+        val selectionKey = "workspace-session"
+
+        val withHigh = updatedSessionComposerSelections(null, selectionKey, high)
+        assertEquals(high, composerSelectionForSession(withHigh, selectionKey))
+
+        val explicitDefault = high.copy(variant = null)
+        val withDefault = updatedSessionComposerSelections(withHigh, selectionKey, explicitDefault)
+        assertEquals(explicitDefault, composerSelectionForSession(withDefault, selectionKey))
+    }
+
+    @Test
+    fun `composer selection key isolates server workspace and session`() {
+        val serverA = ServerRef.fromEndpointKey("http://server-a")
+        val serverB = ServerRef.fromEndpointKey("http://server-b")
+
+        val keys = setOf(
+            sessionComposerSelectionKey(Workspace(serverA, "/repo-a"), "session-1"),
+            sessionComposerSelectionKey(Workspace(serverA, "/repo-b"), "session-1"),
+            sessionComposerSelectionKey(Workspace(serverB, "/repo-a"), "session-1"),
+            sessionComposerSelectionKey(Workspace(serverA, "/repo-a"), "session-2"),
+        )
+
+        assertEquals(4, keys.size)
+    }
+
+    @Test
+    fun `malformed composer state recovers for lookup and next write`() {
+        assertNull(composerSelectionForSession("not-json", "session"))
+        val selection = SessionComposerSelection(
+            model = ModelInput(providerID = "anthropic", modelID = "claude-3"),
+            variant = "high",
+        )
+
+        val recovered = updatedSessionComposerSelections("not-json", "session", selection)
+
+        assertEquals(selection, composerSelectionForSession(recovered, "session"))
+    }
+
+    @Test
+    fun `lookup returns stored model and null for unknown session`() {
+        val stored = """{"session-1":"anthropic/claude-3","session-2":"openai/gpt-4"}"""
+
+        assertEquals(
+            ModelInput(providerID = "anthropic", modelID = "claude-3"),
+            selectedModelForSession(stored, "session-1"),
+        )
+        assertNull(selectedModelForSession(stored, "unknown"))
+    }
+
+    @Test
+    fun `model id containing slash round trips`() {
+        val model = ModelInput(providerID = "openrouter", modelID = "anthropic/claude-sonnet")
+
+        val stored = updatedSessionModelSelections(null, "session", model)
+
+        assertEquals(model, selectedModelForSession(stored, "session"))
+    }
+
+    @Test
+    fun `oldest selection is evicted when cap is exceeded`() {
+        var stored: String? = null
+        repeat(MAX_SESSION_MODEL_SELECTIONS + 1) { index ->
+            stored = updatedSessionModelSelections(
+                stored,
+                "session-$index",
+                ModelInput(providerID = "provider", modelID = "model-$index"),
+            )
+        }
+
+        val selections = Json.decodeFromString<LinkedHashMap<String, String>>(checkNotNull(stored))
+        assertEquals(MAX_SESSION_MODEL_SELECTIONS, selections.size)
+        assertFalse("session-0" in selections)
+        assertEquals("provider/model-1", selections["session-1"])
+    }
+
+    @Test
+    fun `malformed state recovers for lookup and next write`() {
+        assertNull(selectedModelForSession("not-json", "session"))
+        val model = ModelInput(providerID = "anthropic", modelID = "claude-3")
+
+        val recovered = updatedSessionModelSelections("not-json", "session", model)
+
+        assertEquals(model, selectedModelForSession(recovered, "session"))
+    }
+}

--- a/app/src/test/java/dev/blazelight/p4oc/core/datastore/SettingsDataStoreSelectedModelTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/core/datastore/SettingsDataStoreSelectedModelTest.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class SettingsDataStoreSelectedModelTest {
@@ -40,6 +41,25 @@ class SettingsDataStoreSelectedModelTest {
     }
 
     @Test
+    fun `composer selection key round trips through the same server workspace and session`() {
+        val server = ServerRef.fromEndpointKey("http://server-a")
+        val workspace = Workspace(server, "/repo-a")
+
+        val key = sessionComposerSelectionKey(workspace, "session-1")
+
+        val stored = updatedSessionComposerSelections(
+            null,
+            key,
+            SessionComposerSelection(model = ModelInput(providerID = "openai", modelID = "gpt-5")),
+        )
+
+        assertEquals(
+            ModelInput(providerID = "openai", modelID = "gpt-5"),
+            composerSelectionForSession(stored, key)?.model,
+        )
+    }
+
+    @Test
     fun `malformed composer state recovers for lookup and next write`() {
         assertNull(composerSelectionForSession("not-json", "session"))
         val selection = SessionComposerSelection(
@@ -53,49 +73,62 @@ class SettingsDataStoreSelectedModelTest {
     }
 
     @Test
-    fun `lookup returns stored model and null for unknown session`() {
-        val stored = """{"session-1":"anthropic/claude-3","session-2":"openai/gpt-4"}"""
-
-        assertEquals(
-            ModelInput(providerID = "anthropic", modelID = "claude-3"),
-            selectedModelForSession(stored, "session-1"),
+    fun `lookup returns stored selection and null for unknown key`() {
+        val selection = SessionComposerSelection(
+            model = ModelInput(providerID = "anthropic", modelID = "claude-3"),
+            variant = "high",
+            pendingServerSync = true,
         )
-        assertNull(selectedModelForSession(stored, "unknown"))
+        val stored = updatedSessionComposerSelections(null, "session-1", selection)
+
+        assertEquals(selection, composerSelectionForSession(stored, "session-1"))
+        assertNull(composerSelectionForSession(stored, "session-2"))
     }
 
     @Test
-    fun `model id containing slash round trips`() {
-        val model = ModelInput(providerID = "openrouter", modelID = "anthropic/claude-sonnet")
-
-        val stored = updatedSessionModelSelections(null, "session", model)
-
-        assertEquals(model, selectedModelForSession(stored, "session"))
-    }
-
-    @Test
-    fun `oldest selection is evicted when cap is exceeded`() {
+    fun `oldest composer selection is evicted when cap is exceeded`() {
         var stored: String? = null
-        repeat(MAX_SESSION_MODEL_SELECTIONS + 1) { index ->
-            stored = updatedSessionModelSelections(
+        repeat(MAX_SESSION_COMPOSER_SELECTIONS + 1) { index ->
+            stored = updatedSessionComposerSelections(
                 stored,
                 "session-$index",
-                ModelInput(providerID = "provider", modelID = "model-$index"),
+                SessionComposerSelection(
+                    model = ModelInput(providerID = "provider", modelID = "model-$index"),
+                ),
             )
         }
 
-        val selections = Json.decodeFromString<LinkedHashMap<String, String>>(checkNotNull(stored))
-        assertEquals(MAX_SESSION_MODEL_SELECTIONS, selections.size)
+        val selections =
+            Json.decodeFromString<LinkedHashMap<String, SessionComposerSelection>>(checkNotNull(stored))
+        assertEquals(MAX_SESSION_COMPOSER_SELECTIONS, selections.size)
         assertFalse("session-0" in selections)
-        assertEquals("provider/model-1", selections["session-1"])
+        assertTrue("session-1" in selections)
+        assertTrue("session-${MAX_SESSION_COMPOSER_SELECTIONS}" in selections)
     }
 
     @Test
-    fun `malformed state recovers for lookup and next write`() {
-        assertNull(selectedModelForSession("not-json", "session"))
-        val model = ModelInput(providerID = "anthropic", modelID = "claude-3")
+    fun `re-write moves an existing selection to the newest position`() {
+        var stored: String? = null
+        stored = updatedSessionComposerSelections(
+            stored,
+            "session-a",
+            SessionComposerSelection(model = ModelInput(providerID = "p", modelID = "a")),
+        )
+        stored = updatedSessionComposerSelections(
+            stored,
+            "session-b",
+            SessionComposerSelection(model = ModelInput(providerID = "p", modelID = "b")),
+        )
+        stored = updatedSessionComposerSelections(
+            stored,
+            "session-a",
+            SessionComposerSelection(model = ModelInput(providerID = "p", modelID = "a2")),
+        )
 
-        val recovered = updatedSessionModelSelections("not-json", "session", model)
-
-        assertEquals(model, selectedModelForSession(recovered, "session"))
+        val selections =
+            Json.decodeFromString<LinkedHashMap<String, SessionComposerSelection>>(checkNotNull(stored))
+        // Re-wrote session-a last, so it moves to the newest position and is evicted after session-b.
+        assertEquals(listOf("session-b", "session-a"), selections.keys.toList())
+        assertEquals("p/a2", selections["session-a"]?.let { "${it.model.providerID}/${it.model.modelID}" })
     }
 }

--- a/app/src/test/java/dev/blazelight/p4oc/ui/screens/chat/ChatViewModelDraftPersistenceTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/ui/screens/chat/ChatViewModelDraftPersistenceTest.kt
@@ -105,6 +105,8 @@ class ChatViewModelDraftPersistenceTest {
         every { settingsDataStore.notificationSettings } returns flowOf(NotificationSettings())
         coEvery { settingsDataStore.getSelectedAgentForSession(any()) } returns null
         coEvery { settingsDataStore.setSelectedAgentForSession(any(), any()) } returns Unit
+        coEvery { settingsDataStore.getComposerSelectionForSession(any(), any()) } returns null
+        coEvery { settingsDataStore.getSelectedModelForSession(any()) } returns null
 
         hapticFeedback = mockk(relaxed = true)
     }

--- a/app/src/test/java/dev/blazelight/p4oc/ui/screens/chat/ChatViewModelDraftPersistenceTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/ui/screens/chat/ChatViewModelDraftPersistenceTest.kt
@@ -106,7 +106,6 @@ class ChatViewModelDraftPersistenceTest {
         coEvery { settingsDataStore.getSelectedAgentForSession(any()) } returns null
         coEvery { settingsDataStore.setSelectedAgentForSession(any(), any()) } returns Unit
         coEvery { settingsDataStore.getComposerSelectionForSession(any(), any()) } returns null
-        coEvery { settingsDataStore.getSelectedModelForSession(any()) } returns null
 
         hapticFeedback = mockk(relaxed = true)
     }

--- a/app/src/test/java/dev/blazelight/p4oc/ui/screens/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/ui/screens/chat/ChatViewModelTest.kt
@@ -3,6 +3,7 @@ package dev.blazelight.p4oc.ui.screens.chat
 import androidx.lifecycle.SavedStateHandle
 import dev.blazelight.p4oc.core.datastore.ChatSettings
 import dev.blazelight.p4oc.core.datastore.NotificationSettings
+import dev.blazelight.p4oc.core.datastore.SessionComposerSelection
 import dev.blazelight.p4oc.core.datastore.SettingsDataStore
 import dev.blazelight.p4oc.core.datastore.VisualSettings
 import dev.blazelight.p4oc.core.haptic.HapticFeedback
@@ -50,7 +51,6 @@ import dev.blazelight.p4oc.domain.workspace.Workspace
 import dev.blazelight.p4oc.ui.components.chat.SelectedFile
 import dev.blazelight.p4oc.ui.navigation.Screen
 import dev.blazelight.p4oc.ui.screens.files.upload.UploadCoordinator
-import io.mockk.clearMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -137,13 +137,11 @@ class ChatViewModelTest {
         every { settingsDataStore.favoriteModels } returns flowOf(emptySet())
         every { settingsDataStore.recentModels } returns flowOf(emptyList())
         every { settingsDataStore.chatSettings } returns flowOf(ChatSettings())
+        every { settingsDataStore.notificationSettings } returns flowOf(NotificationSettings())
         every { settingsDataStore.visualSettings } returns flowOf(VisualSettings())
         coEvery { settingsDataStore.getComposerSelectionForSession(any(), any()) } returns null
-        coEvery { settingsDataStore.getSelectedModelForSession(any()) } returns null
-        coEvery { settingsDataStore.setSelectedModelForSession(any(), any()) } returns Unit
         coEvery { settingsDataStore.setComposerSelectionForSession(any(), any(), any()) } returns Unit
         coEvery { settingsDataStore.addRecentModel(any()) } returns Unit
-        every { settingsDataStore.notificationSettings } returns flowOf(NotificationSettings())
         coEvery { settingsDataStore.getSelectedAgentForSession(any()) } returns null
         coEvery { settingsDataStore.setSelectedAgentForSession(any(), any()) } returns Unit
 
@@ -894,6 +892,52 @@ class ChatViewModelTest {
     }
 
     @Test
+    fun sendMessage_acknowledgesCapturedModelVariant_notMutableStateAtSuccess() = runTest {
+        val sentModel = dev.blazelight.p4oc.data.remote.dto.ModelInput("openai", "gpt-5")
+        coEvery { api.getSession("session-1", any(), null) } returns sessionDto(
+            model = SessionModelDto(id = "gpt-5", providerID = "openai", variant = "high")
+        )
+        coEvery { api.getProviders(any(), null) } returns reasoningProviders()
+        val sendGate = CompletableDeferred<Unit>()
+        coEvery { api.sendMessageAsync(any(), any(), any(), null) } coAnswers {
+            sendGate.await()
+            Unit
+        }
+        val vm = createViewModel()
+
+        vm.updateInput("hello")
+        vm.sendMessage()
+        runCurrent()
+
+        // While the request is suspended in flight, the user changes the selection. The success
+        // acknowledgment carries the model/variant captured when the request was sent (high); the
+        // current pending record is now (gpt-5, low), so the ack is stale and must NOT flush the
+        // in-flight selection — and must not re-read mutable state to flush "low" as if it had
+        // been sent.
+        vm.modelAgentManager.selectReasoningEffort("low")
+        runCurrent()
+        sendGate.complete(Unit)
+        advanceUntilIdle()
+
+        // The newer pending (low) selection survives as pending; the stale ack flushes nothing.
+        assertEquals("low", vm.modelAgentManager.currentReasoningEffort())
+        coVerify(exactly = 1) {
+            settingsDataStore.setComposerSelectionForSession(
+                workspaceClient.workspace,
+                "session-1",
+                SessionComposerSelection(model = sentModel, variant = "low", pendingServerSync = true),
+            )
+        }
+        coVerify(exactly = 0) {
+            settingsDataStore.setComposerSelectionForSession(
+                workspaceClient.workspace,
+                "session-1",
+                SessionComposerSelection(model = sentModel, variant = "low", pendingServerSync = false),
+            )
+        }
+    }
+
+    @Test
     fun abortSession_clearsStreamingFlags_andBusyState() = runTest {
         val vm = createViewModel()
 
@@ -964,19 +1008,6 @@ class ChatViewModelTest {
         assertNull(vm.uiState.value.error)
     }
 
-    @Test
-    fun refreshAfterForeground_refetchesOpenSessionMetadataAndMessages() = runTest {
-        val vm = createViewModel()
-        clearMocks(api, answers = false, recordedCalls = true, childMocks = false)
-        coEvery { api.getSession("session-1", any(), null) } returns sessionDto()
-        coEvery { api.getMessages("session-1", any(), null, any(), null) } returns emptyList()
-
-        vm.refreshAfterForeground()
-        advanceUntilIdle()
-
-        coVerify(exactly = 1) { api.getSession("session-1", "/test", null) }
-        coVerify(exactly = 1) { api.getMessages("session-1", any(), null, "/test", null) }
-    }
 
     @Test
     fun loadCommands_failureKeepsBuiltIns_andAllowsRetryForWorkspaceCommands() = runTest {

--- a/app/src/test/java/dev/blazelight/p4oc/ui/screens/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/ui/screens/chat/ChatViewModelTest.kt
@@ -21,6 +21,7 @@ import dev.blazelight.p4oc.data.remote.dto.PartDto
 import dev.blazelight.p4oc.data.remote.dto.RevertSessionRequest
 import dev.blazelight.p4oc.data.remote.dto.SendMessageRequest
 import dev.blazelight.p4oc.data.remote.dto.SessionDto
+import dev.blazelight.p4oc.data.remote.dto.SessionModelDto
 import dev.blazelight.p4oc.data.remote.dto.SessionRevertDto
 import dev.blazelight.p4oc.data.remote.dto.SessionStatusDto
 import dev.blazelight.p4oc.data.remote.dto.TimeDto
@@ -49,6 +50,7 @@ import dev.blazelight.p4oc.domain.workspace.Workspace
 import dev.blazelight.p4oc.ui.components.chat.SelectedFile
 import dev.blazelight.p4oc.ui.navigation.Screen
 import dev.blazelight.p4oc.ui.screens.files.upload.UploadCoordinator
+import io.mockk.clearMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -136,6 +138,11 @@ class ChatViewModelTest {
         every { settingsDataStore.recentModels } returns flowOf(emptyList())
         every { settingsDataStore.chatSettings } returns flowOf(ChatSettings())
         every { settingsDataStore.visualSettings } returns flowOf(VisualSettings())
+        coEvery { settingsDataStore.getComposerSelectionForSession(any(), any()) } returns null
+        coEvery { settingsDataStore.getSelectedModelForSession(any()) } returns null
+        coEvery { settingsDataStore.setSelectedModelForSession(any(), any()) } returns Unit
+        coEvery { settingsDataStore.setComposerSelectionForSession(any(), any(), any()) } returns Unit
+        coEvery { settingsDataStore.addRecentModel(any()) } returns Unit
         every { settingsDataStore.notificationSettings } returns flowOf(NotificationSettings())
         coEvery { settingsDataStore.getSelectedAgentForSession(any()) } returns null
         coEvery { settingsDataStore.setSelectedAgentForSession(any(), any()) } returns Unit
@@ -868,6 +875,25 @@ class ChatViewModelTest {
     }
 
     @Test
+    fun sendMessage_sendsModelAndVariantRestoredFromServerSession() = runTest {
+        val model = dev.blazelight.p4oc.data.remote.dto.ModelInput("openai", "gpt-5")
+        coEvery { api.getSession("session-1", any(), null) } returns sessionDto(
+            model = SessionModelDto(id = "gpt-5", providerID = "openai", variant = "high")
+        )
+        coEvery { api.getProviders(any(), null) } returns reasoningProviders()
+        val request = slot<SendMessageRequest>()
+        coEvery { api.sendMessageAsync(any(), capture(request), any(), null) } returns Unit
+        val vm = createViewModel()
+
+        vm.updateInput("hello")
+        vm.sendMessage()
+        advanceUntilIdle()
+
+        assertEquals(model, request.captured.model)
+        assertEquals("high", request.captured.variant)
+    }
+
+    @Test
     fun abortSession_clearsStreamingFlags_andBusyState() = runTest {
         val vm = createViewModel()
 
@@ -936,6 +962,20 @@ class ChatViewModelTest {
 
         assertTrue(vm.sessionMissing.replayCache.isNotEmpty())
         assertNull(vm.uiState.value.error)
+    }
+
+    @Test
+    fun refreshAfterForeground_refetchesOpenSessionMetadataAndMessages() = runTest {
+        val vm = createViewModel()
+        clearMocks(api, answers = false, recordedCalls = true, childMocks = false)
+        coEvery { api.getSession("session-1", any(), null) } returns sessionDto()
+        coEvery { api.getMessages("session-1", any(), null, any(), null) } returns emptyList()
+
+        vm.refreshAfterForeground()
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { api.getSession("session-1", "/test", null) }
+        coVerify(exactly = 1) { api.getMessages("session-1", any(), null, "/test", null) }
     }
 
     @Test
@@ -1065,7 +1105,10 @@ class ChatViewModelTest {
     private fun ChatViewModel.currentMessages(): List<MessageWithParts> =
         messages.value
 
-    private fun sessionDto(revertMessageId: String? = null): SessionDto {
+    private fun sessionDto(
+        revertMessageId: String? = null,
+        model: SessionModelDto? = null,
+    ): SessionDto {
         return SessionDto(
             id = "session-1",
             projectID = "project-1",
@@ -1074,8 +1117,32 @@ class ChatViewModelTest {
             version = "1.0",
             time = TimeDto(created = 1, updated = 2),
             revert = revertMessageId?.let { SessionRevertDto(messageID = it) },
+            model = model,
         )
     }
+
+    private fun reasoningProviders() = dev.blazelight.p4oc.data.remote.dto.ProvidersResponseDto(
+        all = listOf(
+            dev.blazelight.p4oc.data.remote.dto.ProviderDto(
+                id = "openai",
+                name = "OpenAI",
+                source = "env",
+                models = mapOf(
+                    "gpt-5" to dev.blazelight.p4oc.data.remote.dto.ModelDto(
+                        id = "gpt-5",
+                        providerId = "openai",
+                        name = "GPT-5",
+                        variants = buildJsonObject {
+                            put("low", buildJsonObject {})
+                            put("high", buildJsonObject {})
+                        },
+                    )
+                ),
+            )
+        ),
+        default = mapOf("openai" to "gpt-5"),
+        connected = listOf("openai"),
+    )
 
     private fun userMessageDto(id: String, createdAt: Long): MessageWrapperDto {
         return MessageWrapperDto(

--- a/app/src/test/java/dev/blazelight/p4oc/ui/screens/chat/ModelAgentManagerTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/ui/screens/chat/ModelAgentManagerTest.kt
@@ -17,12 +17,14 @@ import dev.blazelight.p4oc.data.workspace.WorkspaceClient
 import dev.blazelight.p4oc.domain.server.ServerGeneration
 import dev.blazelight.p4oc.domain.server.ServerRef
 import dev.blazelight.p4oc.domain.workspace.Workspace
+import io.mockk.clearMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkObject
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
@@ -35,6 +37,7 @@ import org.junit.Before
 import org.junit.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
+@Suppress("LargeClass")
 class ModelAgentManagerTest {
 
     private val settingsDataStore: SettingsDataStore = mockk(relaxed = true)
@@ -299,7 +302,9 @@ class ModelAgentManagerTest {
     @Test
     fun `loadModels restores available model selected for this session before server default`() = runTest {
         val sessionModel = ModelInput(providerID = "anthropic", modelID = "claude-3")
-        coEvery { settingsDataStore.getSelectedModelForSession("session-1") } returns sessionModel
+        coEvery {
+            settingsDataStore.getComposerSelectionForSession(workspaceClient.workspace, "session-1")
+        } returns SessionComposerSelection(model = sessionModel, pendingServerSync = true)
         val providersResponse = ProvidersResponseDto(
             all = listOf(
                 ProviderDto(
@@ -329,8 +334,12 @@ class ModelAgentManagerTest {
 
     @Test
     fun `loadModels ignores unavailable model selected for this session`() = runTest {
-        coEvery { settingsDataStore.getSelectedModelForSession("session-1") } returns
-            ModelInput(providerID = "anthropic", modelID = "claude-3")
+        coEvery {
+            settingsDataStore.getComposerSelectionForSession(workspaceClient.workspace, "session-1")
+        } returns SessionComposerSelection(
+            model = ModelInput(providerID = "anthropic", modelID = "claude-3"),
+            pendingServerSync = true,
+        )
         val defaultModel = ModelInput(providerID = "openai", modelID = "gpt-4")
         coEvery { api.getProviders(any(), null) } returns ProvidersResponseDto(
             all = listOf(
@@ -360,7 +369,13 @@ class ModelAgentManagerTest {
         manager.selectModel(selected)
         advanceUntilIdle()
 
-        coVerify(exactly = 1) { settingsDataStore.setSelectedModelForSession("session-1", selected) }
+        coVerify(exactly = 1) {
+            settingsDataStore.setComposerSelectionForSession(
+                workspaceClient.workspace,
+                "session-1",
+                SessionComposerSelection(model = selected, variant = null, pendingServerSync = true),
+            )
+        }
         coVerify(exactly = 1) { settingsDataStore.addRecentModel(selected) }
     }
 
@@ -395,6 +410,32 @@ class ModelAgentManagerTest {
 
         assertEquals(localModel, manager.selectedModel.value)
         assertEquals("high", manager.currentReasoningEffort())
+    }
+
+    @Test
+    fun `fresh unsupported server variant normalizes to null and final record is synced`() = runTest {
+        val model = ModelInput(providerID = "openai", modelID = "gpt-5")
+        // No local persisted selection: getComposerSelectionForSession returns null by default.
+        coEvery { api.getProviders(any(), null) } returns reasoningProviders()
+        val manager = ModelAgentManager(workspaceClient, settingsDataStore, this, sessionId = "session-1")
+
+        manager.applyServerSessionModel(
+            SessionModelDto(id = "gpt-5", providerID = "openai", variant = "obsolete")
+        )
+        manager.loadModels()
+        advanceUntilIdle()
+
+        assertEquals(model, manager.selectedModel.value)
+        assertNull(manager.currentReasoningEffort())
+        // The final persisted record is the normalized, acknowledged (non-pending) selection;
+        // the raw unsupported server variant must never be written.
+        coVerify {
+            settingsDataStore.setComposerSelectionForSession(
+                workspaceClient.workspace,
+                "session-1",
+                SessionComposerSelection(model = model, variant = null, pendingServerSync = false),
+            )
+        }
     }
 
     @Test
@@ -599,6 +640,45 @@ class ModelAgentManagerTest {
     }
 
     @Test
+    fun `reselecting same model keeps reasoning effort and matching ack clears pending`() = runTest {
+        val model = ModelInput(providerID = "openai", modelID = "gpt-5")
+        coEvery { api.getProviders(any(), null) } returns reasoningProviders()
+        val manager = ModelAgentManager(workspaceClient, settingsDataStore, this, sessionId = "session-1")
+        manager.loadModels()
+        advanceUntilIdle()
+
+        manager.selectReasoningEffort("high")
+        advanceUntilIdle()
+
+        // Re-selecting the already-selected model from the composer must retain the effort,
+        // not silently drop it back to null in the pending record.
+        clearMocks(settingsDataStore, answers = false, recordedCalls = true)
+        manager.selectModel(model)
+        advanceUntilIdle()
+
+        assertEquals("high", manager.currentReasoningEffort())
+        coVerify(exactly = 1) {
+            settingsDataStore.setComposerSelectionForSession(
+                workspaceClient.workspace,
+                "session-1",
+                SessionComposerSelection(model = model, variant = "high", pendingServerSync = true),
+            )
+        }
+
+        // The exact sent variant acknowledges and flushes the pending record.
+        manager.markComposerSelectionSent(model, "high")
+        advanceUntilIdle()
+
+        coVerify {
+            settingsDataStore.setComposerSelectionForSession(
+                workspaceClient.workspace,
+                "session-1",
+                SessionComposerSelection(model = model, variant = "high", pendingServerSync = false),
+            )
+        }
+    }
+
+    @Test
     fun `loadModels selects default model when no recent`() = runTest {
         every { settingsDataStore.recentModels } returns flowOf(emptyList())
 
@@ -638,7 +718,7 @@ class ModelAgentManagerTest {
         runCurrent()
 
         val publishedModel = ModelInput(providerID = "anthropic", modelID = "claude-3")
-        coordinator.publishActiveModel(publishedModel)
+        coordinator.publishActiveModel(workspaceClient.workspace, workspaceClient.generation, publishedModel)
         runCurrent()
 
         assertEquals(publishedModel, manager.selectedModel.value)
@@ -653,7 +733,11 @@ class ModelAgentManagerTest {
         advanceUntilIdle()
         runCurrent()
 
-        coordinator.publishActiveModel(ModelInput(providerID = "anthropic", modelID = "claude-3"))
+        coordinator.publishActiveModel(
+            workspaceClient.workspace,
+            workspaceClient.generation,
+            ModelInput(providerID = "anthropic", modelID = "claude-3"),
+        )
         runCurrent()
 
         assertEquals(explicitModel, manager.selectedModel.value)
@@ -675,10 +759,72 @@ class ModelAgentManagerTest {
         advanceUntilIdle()
         runCurrent()
 
-        coordinator.publishActiveModel(ModelInput(providerID = "anthropic", modelID = "claude-3"))
+        coordinator.publishActiveModel(
+            workspaceClient.workspace,
+            workspaceClient.generation,
+            ModelInput(providerID = "anthropic", modelID = "claude-3"),
+        )
         runCurrent()
 
         assertEquals(ModelInput(providerID = "openai", modelID = "gpt-4"), manager.selectedModel.value)
+    }
+
+    @Test
+    fun `active model change from matching workspace and generation updates selection`() = runTest {
+        val coordinator = ModelSelectionCoordinator()
+        val manager = ModelAgentManager(workspaceClient, settingsDataStore, backgroundScope, null, coordinator)
+        advanceUntilIdle()
+        runCurrent()
+
+        val publishedModel = ModelInput(providerID = "anthropic", modelID = "claude-3")
+        coordinator.publishActiveModel(
+            workspaceClient.workspace,
+            workspaceClient.generation,
+            publishedModel,
+        )
+        runCurrent()
+
+        assertEquals(publishedModel, manager.selectedModel.value)
+    }
+
+    @Test
+    fun `active model change from a different workspace is rejected`() = runTest {
+        val coordinator = ModelSelectionCoordinator()
+        val manager = ModelAgentManager(workspaceClient, settingsDataStore, backgroundScope, null, coordinator)
+        advanceUntilIdle()
+        runCurrent()
+
+        val otherWorkspace = Workspace(
+            ServerRef.fromEndpointKey("http://test.local"),
+            "/other-workspace",
+        )
+        val publishedModel = ModelInput(providerID = "anthropic", modelID = "claude-3")
+        coordinator.publishActiveModel(
+            otherWorkspace,
+            workspaceClient.generation,
+            publishedModel,
+        )
+        runCurrent()
+
+        assertNull(manager.selectedModel.value)
+    }
+
+    @Test
+    fun `active model change from a stale generation is rejected`() = runTest {
+        val coordinator = ModelSelectionCoordinator()
+        val manager = ModelAgentManager(workspaceClient, settingsDataStore, backgroundScope, null, coordinator)
+        advanceUntilIdle()
+        runCurrent()
+
+        val publishedModel = ModelInput(providerID = "anthropic", modelID = "claude-3")
+        coordinator.publishActiveModel(
+            workspaceClient.workspace,
+            ServerGeneration(workspaceClient.generation.value - 1),
+            publishedModel,
+        )
+        runCurrent()
+
+        assertNull(manager.selectedModel.value)
     }
 
     // ── selectModel ─────────────────────────────────────────────────────────
@@ -693,5 +839,332 @@ class ModelAgentManagerTest {
 
         assertEquals(model, manager.selectedModel.value)
         coVerify { settingsDataStore.addRecentModel(model) }
+    }
+
+    @Test
+    fun `selectReasoningEffort persists normalized variant with pending sync`() = runTest {
+        val model = ModelInput(providerID = "openai", modelID = "gpt-5")
+        coEvery { api.getProviders(any(), null) } returns reasoningProviders()
+        val manager = ModelAgentManager(workspaceClient, settingsDataStore, this, sessionId = "session-1")
+        manager.loadModels()
+        advanceUntilIdle()
+
+        manager.selectReasoningEffort("high")
+        advanceUntilIdle()
+
+        assertEquals("high", manager.currentReasoningEffort())
+        coVerify(exactly = 1) {
+            settingsDataStore.setComposerSelectionForSession(
+                workspaceClient.workspace,
+                "session-1",
+                SessionComposerSelection(model = model, variant = "high", pendingServerSync = true),
+            )
+        }
+    }
+
+    @Test
+    fun `restored unsupported variant normalizes to null and persists pending`() = runTest {
+        val model = ModelInput(providerID = "openai", modelID = "gpt-5")
+        coEvery {
+            settingsDataStore.getComposerSelectionForSession(workspaceClient.workspace, "session-1")
+        } returns SessionComposerSelection(model = model, variant = "obsolete", pendingServerSync = true)
+        coEvery { api.getProviders(any(), null) } returns reasoningProviders()
+        val manager = ModelAgentManager(workspaceClient, settingsDataStore, this, sessionId = "session-1")
+
+        manager.loadModels()
+        advanceUntilIdle()
+
+        assertNull(manager.currentReasoningEffort())
+        coVerify(exactly = 1) {
+            settingsDataStore.setComposerSelectionForSession(
+                workspaceClient.workspace,
+                "session-1",
+                SessionComposerSelection(model = model, variant = null, pendingServerSync = true),
+            )
+        }
+    }
+
+    @Test
+    fun `selectAgent persists agent model selection with pending sync`() = runTest {
+        val agents = listOf(
+            makeAgent("build", mode = "primary", model = ModelRefDto(providerID = "openai", modelID = "gpt-5"))
+        )
+        coEvery { api.getAgents(any(), null) } returns agents
+        coEvery { api.getProviders(any(), null) } returns reasoningProviders()
+        val manager = ModelAgentManager(workspaceClient, settingsDataStore, this, sessionId = "session-1")
+        manager.loadAgents()
+        manager.loadModels()
+        advanceUntilIdle()
+
+        manager.selectAgent("build")
+        advanceUntilIdle()
+
+        val agentModel = ModelInput(providerID = "openai", modelID = "gpt-5")
+        coVerify(exactly = 1) {
+            settingsDataStore.setComposerSelectionForSession(
+                workspaceClient.workspace,
+                "session-1",
+                SessionComposerSelection(model = agentModel, variant = null, pendingServerSync = true),
+            )
+        }
+    }
+
+    @Test
+    fun `selectAgent with same model preserves retained reasoning effort`() = runTest {
+        val model = ModelInput(providerID = "openai", modelID = "gpt-5")
+        coEvery { api.getProviders(any(), null) } returns reasoningProviders()
+        coEvery { api.getAgents(any(), null) } returns listOf(
+            makeAgent("build", mode = "primary", model = ModelRefDto(providerID = "openai", modelID = "gpt-5"))
+        )
+        val manager = ModelAgentManager(workspaceClient, settingsDataStore, this, sessionId = "session-1")
+        manager.loadAgents()
+        manager.loadModels()
+        advanceUntilIdle()
+
+        // Select the model the agent's configured model already matches, keeping the effort.
+        manager.selectModel(model)
+        manager.selectReasoningEffort("high")
+        advanceUntilIdle()
+
+        clearMocks(settingsDataStore, answers = false, recordedCalls = true)
+        manager.selectAgent("build")
+        advanceUntilIdle()
+
+        assertEquals("high", manager.currentReasoningEffort())
+        coVerify(exactly = 1) {
+            settingsDataStore.setComposerSelectionForSession(
+                workspaceClient.workspace,
+                "session-1",
+                SessionComposerSelection(model = model, variant = "high", pendingServerSync = true),
+            )
+        }
+    }
+
+    @Test
+    fun `matching acknowledgment clears pending and allows later server authority`() = runTest {
+        val model = ModelInput(providerID = "openai", modelID = "gpt-5")
+        coEvery {
+            settingsDataStore.getComposerSelectionForSession(workspaceClient.workspace, "session-1")
+        } returns SessionComposerSelection(model = model, variant = "high", pendingServerSync = true)
+        coEvery { api.getProviders(any(), null) } returns reasoningProviders()
+        val manager = ModelAgentManager(workspaceClient, settingsDataStore, this, sessionId = "session-1")
+        manager.loadModels()
+        advanceUntilIdle()
+        assertEquals("high", manager.currentReasoningEffort())
+
+        // Matching ack flushes the pending local selection; the server now owns the value.
+        manager.markComposerSelectionSent(model, "high")
+        advanceUntilIdle()
+        manager.applyServerSessionModel(SessionModelDto(id = "gpt-5", providerID = "openai", variant = "low"))
+        advanceUntilIdle()
+
+        assertEquals("low", manager.currentReasoningEffort())
+        coVerify {
+            settingsDataStore.setComposerSelectionForSession(
+                workspaceClient.workspace,
+                "session-1",
+                SessionComposerSelection(model = model, variant = "high", pendingServerSync = false),
+            )
+        }
+    }
+
+    @Test
+    fun `stale acknowledgment preserves a newer pending selection`() = runTest {
+        val model = ModelInput(providerID = "openai", modelID = "gpt-5")
+        coEvery {
+            settingsDataStore.getComposerSelectionForSession(workspaceClient.workspace, "session-1")
+        } returns SessionComposerSelection(model = model, variant = "high", pendingServerSync = true)
+        coEvery { api.getProviders(any(), null) } returns reasoningProviders()
+        val manager = ModelAgentManager(workspaceClient, settingsDataStore, this, sessionId = "session-1")
+        manager.loadModels()
+        advanceUntilIdle()
+
+        // A newer explicit variant supersedes the pending record.
+        manager.selectReasoningEffort("low")
+        advanceUntilIdle()
+
+        // A stale ack for the earlier (high) selection must not flush the newer pending (low).
+        manager.markComposerSelectionSent(model, "high")
+        advanceUntilIdle()
+
+        assertEquals("low", manager.currentReasoningEffort())
+        coVerify(exactly = 1) {
+            settingsDataStore.setComposerSelectionForSession(
+                workspaceClient.workspace,
+                "session-1",
+                SessionComposerSelection(model = model, variant = "low", pendingServerSync = true),
+            )
+        }
+    }
+
+    @Test
+    fun `loadModels stale read does not clobber newer in-flight explicit selection`() = runTest {
+        val staleSelection = SessionComposerSelection(
+            model = ModelInput(providerID = "openai", modelID = "gpt-5"),
+            variant = "high",
+            pendingServerSync = true,
+        )
+        val readGate = CompletableDeferred<Unit>()
+        coEvery {
+            settingsDataStore.getComposerSelectionForSession(workspaceClient.workspace, "session-1")
+        } coAnswers {
+            readGate.await()
+            staleSelection
+        }
+        coEvery { api.getProviders(any(), null) } returns reasoningProviders()
+
+        val manager = ModelAgentManager(workspaceClient, settingsDataStore, this, sessionId = "session-1")
+
+        // Start loadModels; it reads providers, then blocks inside the persistence read.
+        manager.loadModels()
+        runCurrent()
+        assertFalse(readGate.isCompleted)
+
+        // While the stale read is suspended, the user picks a newer model + reasoning effort.
+        val newerModel = ModelInput(providerID = "openai", modelID = "gpt-5")
+        manager.selectModel(newerModel)
+        manager.selectReasoningEffort("low")
+        runCurrent()
+
+        // Release the stale storage read; it must not overwrite the newer in-memory selection.
+        readGate.complete(Unit)
+        advanceUntilIdle()
+
+        assertEquals(newerModel, manager.selectedModel.value)
+        assertEquals("low", manager.currentReasoningEffort())
+
+        // A later matching ack must correspond to the newer (low) selection, not the stale one.
+        manager.markComposerSelectionSent(newerModel, "low")
+        advanceUntilIdle()
+
+        assertEquals("low", manager.currentReasoningEffort())
+        coVerify(exactly = 1) {
+            settingsDataStore.setComposerSelectionForSession(
+                workspaceClient.workspace,
+                "session-1",
+                SessionComposerSelection(model = newerModel, variant = "low", pendingServerSync = false),
+            )
+        }
+    }
+
+    @Test
+    fun `newer selection cannot persist early and is the final completed write`() = runTest {
+        val modelA = ModelInput(providerID = "openai", modelID = "gpt-5")
+        val modelB = ModelInput(providerID = "openai", modelID = "gpt-4")
+        val firstWriteStarted = CompletableDeferred<Unit>()
+        val secondWriteStarted = CompletableDeferred<Unit>()
+        val firstWriteGate = CompletableDeferred<Unit>()
+        val secondWriteGate = CompletableDeferred<Unit>()
+        // A's write cannot start B's until it completes, so call order maps 1 -> A, 2 -> B.
+        val completionOrder = mutableListOf<ModelInput>()
+        var callCount = 0
+        coEvery {
+            settingsDataStore.setComposerSelectionForSession(any(), any(), any())
+        } coAnswers {
+            callCount++
+            when (callCount) {
+                1 -> {
+                    firstWriteStarted.complete(Unit)
+                    firstWriteGate.await()
+                    completionOrder.add(modelA)
+                }
+                2 -> {
+                    secondWriteStarted.complete(Unit)
+                    secondWriteGate.await()
+                    completionOrder.add(modelB)
+                }
+            }
+        }
+
+        val manager = ModelAgentManager(workspaceClient, settingsDataStore, this, sessionId = "session-1")
+
+        // First selection starts persisting and blocks mid-write (holds the serialization lock).
+        manager.selectModel(modelA)
+        runCurrent()
+        assertTrue(firstWriteStarted.isCompleted)
+
+        // A newer selection is made while the first write is blocked.
+        manager.selectModel(modelB)
+        runCurrent()
+        // It is queued behind the first write; it must not start (and therefore not complete) early.
+        assertFalse(secondWriteStarted.isCompleted)
+
+        // Release the first write; the newer one now proceeds but is held open for ordering proof.
+        firstWriteGate.complete(Unit)
+        runCurrent()
+        assertTrue(secondWriteStarted.isCompleted)
+        assertTrue(completionOrder == listOf(modelA))
+        assertFalse(secondWriteGate.isCompleted)
+
+        // Release the newer write; it completes last.
+        secondWriteGate.complete(Unit)
+        advanceUntilIdle()
+
+        assertEquals(listOf(modelA, modelB), completionOrder)
+        coVerify(exactly = 1) {
+            settingsDataStore.setComposerSelectionForSession(
+                workspaceClient.workspace,
+                "session-1",
+                SessionComposerSelection(model = modelB, variant = null, pendingServerSync = true),
+            )
+        }
+    }
+
+    @Test
+    fun `restored session selection survives unrelated coordinator change`() = runTest {
+        val coordinator = ModelSelectionCoordinator()
+        val model = ModelInput(providerID = "openai", modelID = "gpt-5")
+        coEvery {
+            settingsDataStore.getComposerSelectionForSession(workspaceClient.workspace, "session-1")
+        } returns SessionComposerSelection(model = model, variant = "high", pendingServerSync = true)
+        coEvery { api.getProviders(any(), null) } returns reasoningProviders()
+        val manager = ModelAgentManager(
+            workspaceClient,
+            settingsDataStore,
+            backgroundScope,
+            sessionId = "session-1",
+            modelSelectionCoordinator = coordinator,
+        )
+        manager.loadModels()
+        advanceUntilIdle()
+        runCurrent()
+        assertEquals(model, manager.selectedModel.value)
+
+        coordinator.publishActiveModel(
+            workspaceClient.workspace,
+            workspaceClient.generation,
+            ModelInput(providerID = "anthropic", modelID = "claude-3"),
+        )
+        runCurrent()
+
+        assertEquals(model, manager.selectedModel.value)
+    }
+
+    @Test
+    fun `coordinator events never replace server session selection`() = runTest {
+        val coordinator = ModelSelectionCoordinator()
+        val serverModel = ModelInput(providerID = "openai", modelID = "gpt-5")
+        coEvery { api.getProviders(any(), null) } returns reasoningProviders()
+        val manager = ModelAgentManager(
+            workspaceClient,
+            settingsDataStore,
+            backgroundScope,
+            sessionId = "session-1",
+            modelSelectionCoordinator = coordinator,
+        )
+        manager.applyServerSessionModel(SessionModelDto(id = "gpt-5", providerID = "openai", variant = "high"))
+        manager.loadModels()
+        advanceUntilIdle()
+        runCurrent()
+        assertEquals(serverModel, manager.selectedModel.value)
+
+        coordinator.publishActiveModel(
+            workspaceClient.workspace,
+            workspaceClient.generation,
+            ModelInput(providerID = "anthropic", modelID = "claude-3"),
+        )
+        runCurrent()
+
+        assertEquals(serverModel, manager.selectedModel.value)
     }
 }

--- a/app/src/test/java/dev/blazelight/p4oc/ui/screens/chat/ModelAgentManagerTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/ui/screens/chat/ModelAgentManagerTest.kt
@@ -1,5 +1,6 @@
 package dev.blazelight.p4oc.ui.screens.chat
 
+import dev.blazelight.p4oc.core.datastore.SessionComposerSelection
 import dev.blazelight.p4oc.core.datastore.SettingsDataStore
 import dev.blazelight.p4oc.core.log.AppLog
 import dev.blazelight.p4oc.core.network.ConnectionState
@@ -10,6 +11,7 @@ import dev.blazelight.p4oc.data.remote.dto.ModelInput
 import dev.blazelight.p4oc.data.remote.dto.ModelRefDto
 import dev.blazelight.p4oc.data.remote.dto.ProviderDto
 import dev.blazelight.p4oc.data.remote.dto.ProvidersResponseDto
+import dev.blazelight.p4oc.data.remote.dto.SessionModelDto
 import dev.blazelight.p4oc.data.server.ActiveServerApiProvider
 import dev.blazelight.p4oc.data.workspace.WorkspaceClient
 import dev.blazelight.p4oc.domain.server.ServerGeneration
@@ -53,6 +55,7 @@ class ModelAgentManagerTest {
         every { AppLog.e(any(), any<String>(), any()) } returns Unit
         every { settingsDataStore.favoriteModels } returns flowOf(emptySet())
         every { settingsDataStore.recentModels } returns flowOf(emptyList())
+        coEvery { settingsDataStore.getComposerSelectionForSession(any(), any()) } returns null
     }
 
     @After
@@ -292,6 +295,198 @@ class ModelAgentManagerTest {
 
         assertEquals(ModelInput(providerID = "openai", modelID = "gpt-4"), manager.selectedModel.value)
     }
+
+    @Test
+    fun `loadModels restores available model selected for this session before server default`() = runTest {
+        val sessionModel = ModelInput(providerID = "anthropic", modelID = "claude-3")
+        coEvery { settingsDataStore.getSelectedModelForSession("session-1") } returns sessionModel
+        val providersResponse = ProvidersResponseDto(
+            all = listOf(
+                ProviderDto(
+                    id = "anthropic",
+                    name = "Anthropic",
+                    source = "env",
+                    models = mapOf("claude-3" to makeModel("claude-3", "anthropic")),
+                ),
+                ProviderDto(
+                    id = "openai",
+                    name = "OpenAI",
+                    source = "env",
+                    models = mapOf("gpt-4" to makeModel("gpt-4", "openai")),
+                ),
+            ),
+            default = mapOf("openai" to "gpt-4"),
+            connected = listOf("anthropic", "openai"),
+        )
+        coEvery { api.getProviders(any(), null) } returns providersResponse
+
+        val manager = ModelAgentManager(workspaceClient, settingsDataStore, this, sessionId = "session-1")
+        manager.loadModels()
+        advanceUntilIdle()
+
+        assertEquals(sessionModel, manager.selectedModel.value)
+    }
+
+    @Test
+    fun `loadModels ignores unavailable model selected for this session`() = runTest {
+        coEvery { settingsDataStore.getSelectedModelForSession("session-1") } returns
+            ModelInput(providerID = "anthropic", modelID = "claude-3")
+        val defaultModel = ModelInput(providerID = "openai", modelID = "gpt-4")
+        coEvery { api.getProviders(any(), null) } returns ProvidersResponseDto(
+            all = listOf(
+                ProviderDto(
+                    id = "openai",
+                    name = "OpenAI",
+                    source = "env",
+                    models = mapOf("gpt-4" to makeModel("gpt-4", "openai")),
+                ),
+            ),
+            default = mapOf("openai" to "gpt-4"),
+            connected = listOf("openai"),
+        )
+
+        val manager = ModelAgentManager(workspaceClient, settingsDataStore, this, sessionId = "session-1")
+        manager.loadModels()
+        advanceUntilIdle()
+
+        assertEquals(defaultModel, manager.selectedModel.value)
+    }
+
+    @Test
+    fun `selectModel persists selection for this session`() = runTest {
+        val selected = ModelInput(providerID = "anthropic", modelID = "claude-3")
+        val manager = ModelAgentManager(workspaceClient, settingsDataStore, this, sessionId = "session-1")
+
+        manager.selectModel(selected)
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { settingsDataStore.setSelectedModelForSession("session-1", selected) }
+        coVerify(exactly = 1) { settingsDataStore.addRecentModel(selected) }
+    }
+
+    @Test
+    fun `loadModels restores persisted model and reasoning effort after manager recreation`() = runTest {
+        val model = ModelInput(providerID = "openai", modelID = "gpt-5")
+        coEvery {
+            settingsDataStore.getComposerSelectionForSession(workspaceClient.workspace, "session-1")
+        } returns SessionComposerSelection(model = model, variant = "high", pendingServerSync = true)
+        coEvery { api.getProviders(any(), null) } returns reasoningProviders()
+
+        val manager = ModelAgentManager(workspaceClient, settingsDataStore, this, sessionId = "session-1")
+        manager.loadModels()
+        advanceUntilIdle()
+
+        assertEquals(model, manager.selectedModel.value)
+        assertEquals("high", manager.currentReasoningEffort())
+    }
+
+    @Test
+    fun `server session model and variant override synced local selection`() = runTest {
+        val localModel = ModelInput(providerID = "openai", modelID = "gpt-5")
+        coEvery {
+            settingsDataStore.getComposerSelectionForSession(workspaceClient.workspace, "session-1")
+        } returns SessionComposerSelection(model = localModel, variant = "low", pendingServerSync = false)
+        coEvery { api.getProviders(any(), null) } returns reasoningProviders()
+        val manager = ModelAgentManager(workspaceClient, settingsDataStore, this, sessionId = "session-1")
+
+        manager.applyServerSessionModel(SessionModelDto(id = "gpt-5", providerID = "openai", variant = "high"))
+        manager.loadModels()
+        advanceUntilIdle()
+
+        assertEquals(localModel, manager.selectedModel.value)
+        assertEquals("high", manager.currentReasoningEffort())
+    }
+
+    @Test
+    fun `pending local selection wins over stale server session until sent`() = runTest {
+        val model = ModelInput(providerID = "openai", modelID = "gpt-5")
+        coEvery {
+            settingsDataStore.getComposerSelectionForSession(workspaceClient.workspace, "session-1")
+        } returns SessionComposerSelection(model = model, variant = "high", pendingServerSync = true)
+        coEvery { api.getProviders(any(), null) } returns reasoningProviders()
+        val manager = ModelAgentManager(workspaceClient, settingsDataStore, this, sessionId = "session-1")
+
+        manager.applyServerSessionModel(SessionModelDto(id = "gpt-5", providerID = "openai", variant = "low"))
+        manager.loadModels()
+        advanceUntilIdle()
+
+        assertEquals("high", manager.currentReasoningEffort())
+    }
+
+    @Test
+    fun `unsupported persisted reasoning effort is restored as default`() = runTest {
+        val model = ModelInput(providerID = "openai", modelID = "gpt-5")
+        coEvery {
+            settingsDataStore.getComposerSelectionForSession(workspaceClient.workspace, "session-1")
+        } returns SessionComposerSelection(model = model, variant = "obsolete", pendingServerSync = true)
+        coEvery { api.getProviders(any(), null) } returns reasoningProviders()
+        val manager = ModelAgentManager(workspaceClient, settingsDataStore, this, sessionId = "session-1")
+
+        manager.loadModels()
+        advanceUntilIdle()
+
+        assertEquals(model, manager.selectedModel.value)
+        assertNull(manager.currentReasoningEffort())
+    }
+
+    @Test
+    fun `loadModels skips disconnected provider default observed in OpenCode 1 18 16`() = runTest {
+        val providersResponse = ProvidersResponseDto(
+            all = listOf(
+                ProviderDto(
+                    id = "zhipuai",
+                    name = "Zhipu AI",
+                    source = "models.dev",
+                    models = mapOf(
+                        "glm-5v-turbo" to makeModel("glm-5v-turbo", "zhipuai")
+                    )
+                ),
+                ProviderDto(
+                    id = "opencode",
+                    name = "OpenCode",
+                    source = "env",
+                    models = mapOf(
+                        "big-pickle" to makeModel("big-pickle", "opencode")
+                    )
+                )
+            ),
+            default = linkedMapOf(
+                "zhipuai" to "glm-5v-turbo",
+                "opencode" to "big-pickle",
+            ),
+            connected = listOf("opencode")
+        )
+        coEvery { api.getProviders(any(), null) } returns providersResponse
+
+        val manager = ModelAgentManager(workspaceClient, settingsDataStore, this)
+        manager.loadModels()
+        advanceUntilIdle()
+
+        assertEquals(ModelInput(providerID = "opencode", modelID = "big-pickle"), manager.selectedModel.value)
+    }
+
+    private fun reasoningProviders() = ProvidersResponseDto(
+        all = listOf(
+            ProviderDto(
+                id = "openai",
+                name = "OpenAI",
+                source = "env",
+                models = mapOf(
+                    "gpt-5" to ModelDto(
+                        id = "gpt-5",
+                        providerId = "openai",
+                        name = "GPT-5",
+                        variants = kotlinx.serialization.json.buildJsonObject {
+                            put("low", kotlinx.serialization.json.buildJsonObject {})
+                            put("high", kotlinx.serialization.json.buildJsonObject {})
+                        },
+                    )
+                ),
+            )
+        ),
+        default = mapOf("openai" to "gpt-5"),
+        connected = listOf("openai"),
+    )
 
     @Test
     fun `loadModels keeps explicit user selected model when still available`() = runTest {

--- a/app/src/test/java/dev/blazelight/p4oc/ui/screens/settings/ModelControlsViewModelTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/ui/screens/settings/ModelControlsViewModelTest.kt
@@ -14,8 +14,10 @@ import dev.blazelight.p4oc.domain.server.ServerRef
 import dev.blazelight.p4oc.domain.server.WorkspaceKey
 import dev.blazelight.p4oc.domain.workspace.Workspace
 import dev.blazelight.p4oc.ui.screens.chat.ModelSelectionCoordinator
+import dev.blazelight.p4oc.ui.screens.chat.ScopedModelSelectionChange
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -44,6 +46,9 @@ class ModelControlsViewModelTest {
     @Before
     fun setUp() {
         Dispatchers.setMain(dispatcher)
+        every { workspaceClient.workspace } returns
+            Workspace(ServerRef.fromEndpointKey("http://test.local"), "/test")
+        every { workspaceClient.generation } returns ServerGeneration(2L)
     }
 
     @After
@@ -73,7 +78,11 @@ class ModelControlsViewModelTest {
     @Test
     fun selectModel_publishesCoordinatorChangeOnlyAfterSuccessfulApiUpdate() = runTest(dispatcher) {
         val coordinator = ModelSelectionCoordinator()
-        val publishedModels = mutableListOf<ModelInput>()
+        val workspace = Workspace(ServerRef.fromEndpointKey("http://test.local"), "/test")
+        val generation = ServerGeneration(2L)
+        every { workspaceClient.workspace } returns workspace
+        every { workspaceClient.generation } returns generation
+        val publishedModels = mutableListOf<ScopedModelSelectionChange>()
         val collectJob = backgroundScope.launch {
             coordinator.activeModelChanges.collect(publishedModels::add)
         }
@@ -87,12 +96,21 @@ class ModelControlsViewModelTest {
 
         viewModel.selectModel("claude-3")
         runCurrent()
-        assertEquals(emptyList<ModelInput>(), publishedModels)
+        assertEquals(emptyList<ScopedModelSelectionChange>(), publishedModels)
 
         viewModel.selectModel("gpt-4")
         runCurrent()
 
-        assertEquals(listOf(ModelInput(providerID = "openai", modelID = "gpt-4")), publishedModels)
+        assertEquals(
+            listOf(
+                ScopedModelSelectionChange(
+                    workspace = workspace,
+                    generation = generation,
+                    model = ModelInput(providerID = "openai", modelID = "gpt-4"),
+                )
+            ),
+            publishedModels,
+        )
         collectJob.cancel()
     }
 
@@ -225,9 +243,9 @@ class ModelControlsViewModelTest {
         val events = MutableSharedFlow<ScopedEvent>()
         val registry = mockk<ServerConnectionRegistry>()
         coEvery { workspaceClient.getProviders() } returns providersResponse()
-        io.mockk.every { workspaceClient.workspace } returns workspace
-        io.mockk.every { workspaceClient.generation } returns generation
-        io.mockk.every { registry.events(server) } returns events
+        every { workspaceClient.workspace } returns workspace
+        every { workspaceClient.generation } returns generation
+        every { registry.events(server) } returns events
         ModelControlsViewModel(workspaceClient, serverConnectionRegistry = registry)
         advanceUntilIdle()
         coVerify(exactly = 1) { workspaceClient.getProviders() }

--- a/app/src/test/java/dev/blazelight/p4oc/ui/screens/settings/ProviderConfigViewModelTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/ui/screens/settings/ProviderConfigViewModelTest.kt
@@ -8,9 +8,14 @@ import dev.blazelight.p4oc.data.remote.dto.ProviderAuthAuthorizeRequest
 import dev.blazelight.p4oc.data.remote.dto.ProviderDto
 import dev.blazelight.p4oc.data.remote.dto.ProvidersResponseDto
 import dev.blazelight.p4oc.data.workspace.WorkspaceClient
+import dev.blazelight.p4oc.domain.server.ServerGeneration
+import dev.blazelight.p4oc.domain.server.ServerRef
+import dev.blazelight.p4oc.domain.workspace.Workspace
 import dev.blazelight.p4oc.ui.screens.chat.ModelSelectionCoordinator
+import dev.blazelight.p4oc.ui.screens.chat.ScopedModelSelectionChange
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -35,6 +40,9 @@ class ProviderConfigViewModelTest {
     @Before
     fun setUp() {
         Dispatchers.setMain(dispatcher)
+        every { workspaceClient.workspace } returns
+            Workspace(ServerRef.fromEndpointKey("http://test.local"), "/test")
+        every { workspaceClient.generation } returns ServerGeneration(2L)
         coEvery { workspaceClient.getProviderAuthMethods() } returns emptyMap()
     }
 
@@ -64,7 +72,11 @@ class ProviderConfigViewModelTest {
     @Test
     fun setModel_publishesCoordinatorChangeOnlyAfterUpdateConfigSucceeds() = runTest(dispatcher) {
         val coordinator = ModelSelectionCoordinator()
-        val publishedModels = mutableListOf<ModelInput>()
+        val workspace = Workspace(ServerRef.fromEndpointKey("http://test.local"), "/test")
+        val generation = ServerGeneration(2L)
+        every { workspaceClient.workspace } returns workspace
+        every { workspaceClient.generation } returns generation
+        val publishedModels = mutableListOf<ScopedModelSelectionChange>()
         val collectJob = backgroundScope.launch {
             coordinator.activeModelChanges.collect(publishedModels::add)
         }
@@ -78,14 +90,23 @@ class ProviderConfigViewModelTest {
 
         viewModel.setModel("anthropic", "claude-3")
         runCurrent()
-        assertEquals(emptyList<ModelInput>(), publishedModels)
+        assertEquals(emptyList<ScopedModelSelectionChange>(), publishedModels)
 
         coEvery { workspaceClient.updateConfig(ConfigDto(model = "anthropic/claude-3")) } returns
             ConfigDto(model = "anthropic/claude-3")
         viewModel.setModel("anthropic", "claude-3")
         runCurrent()
 
-        assertEquals(listOf(ModelInput(providerID = "anthropic", modelID = "claude-3")), publishedModels)
+        assertEquals(
+            listOf(
+                ScopedModelSelectionChange(
+                    workspace = workspace,
+                    generation = generation,
+                    model = ModelInput(providerID = "anthropic", modelID = "claude-3"),
+                )
+            ),
+            publishedModels,
+        )
         collectJob.cancel()
     }
 


### PR DESCRIPTION
## Problem

The selected model and reasoning level were reset after reopening a session or restarting the app, and process-wide model updates could leak across workspaces.

## Changes

- Persist each session's model, reasoning variant, and pending-sync state under a server + workspace + session key.
- Prefer the model reported by the OpenCode session while preserving a newer unsent local selection.
- Acknowledge only the exact model + variant captured by a successful send, so an in-flight send cannot clear a newer selection.
- Preserve reasoning effort when re-selecting the same model or an agent configured for that model; persist explicit default selection.
- Normalize unsupported local and server variants before they are applied or persisted.
- Protect initialization from stale concurrent DataStore reads and serialize/coalesce composer writes so the newest selection is persisted last.
- Scope process-wide model-selection events by immutable `Workspace` and `ServerGeneration`, filtering unrelated tabs and stale connections.
- Retain the current Busy-event and response-reconciliation send path from `main`.
- Add regression coverage for restoration, scope isolation, precedence, exact acknowledgements, read/write races, coordinator isolation, and publisher payloads.

## Verification

- Focused PR suite: `SettingsDataStoreSelectedModelTest`, `ModelAgentManagerTest`, `ChatViewModelTest`, `ChatViewModelDraftPersistenceTest`, `ModelControlsViewModelTest`, and `ProviderConfigViewModelTest`
- Full unit suite: `./gradlew :app:testDebugUnitTest`
- Static analysis: `./gradlew :app:detekt`
- Debug build: `./gradlew :app:assembleDebug`
- Integrated patch whitespace: `git diff --check origin/main`

All commands passed on the rebased branch with Temurin 17.