### PR TITLE
Recover active chat after foreground resume

### DIFF
--- a/app/src/main/java/dev/blazelight/p4oc/core/network/ConnectionManager.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/core/network/ConnectionManager.kt
@@ -248,10 +248,7 @@ class ConnectionManager constructor(
 
     fun onAppForegrounded() {
         val connection = _connection.value ?: return
-        val state = _connectionState.value
-        if (state is ConnectionState.Connected || state is ConnectionState.Connecting) return
-
-        AppLog.d(TAG, "Refreshing SSE connection after foreground resume")
+        AppLog.d(TAG, "Restarting SSE connection after foreground resume")
         connection.eventSource.resetConsecutiveErrors()
         reconnectSse(reason = "app_foreground")
     }

--- a/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ChatScreen.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ChatScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.compose.LifecycleResumeEffect
 import dev.blazelight.p4oc.R
 import dev.blazelight.p4oc.core.network.ConnectionState
 import dev.blazelight.p4oc.domain.model.Part
@@ -151,6 +152,15 @@ fun ChatScreen(
         if (!uris.isNullOrEmpty()) {
             viewModel.filePickerManager.uploadAndAttach(uploadSource, uris.map { it.toString() })
         }
+    }
+
+    var hasCompletedInitialResume by rememberSaveable { mutableStateOf(false) }
+    LifecycleResumeEffect(isActiveTab) {
+        if (hasCompletedInitialResume && isActiveTab) {
+            viewModel.refreshAfterForeground()
+        }
+        hasCompletedInitialResume = true
+        onPauseOrDispose { }
     }
 
     // Notify parent when session is loaded

--- a/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ChatViewModel.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ChatViewModel.kt
@@ -273,6 +273,12 @@ class ChatViewModel constructor(
         _isActiveTab.value = false
     }
 
+    /** Reconciles REST-backed chat state after Android resumes from the background. */
+    fun refreshAfterForeground() {
+        loadSession()
+        loadMessages()
+    }
+
     fun updateInput(text: String) {
         persistInputText(text)
         _uiState.update { it.copy(inputText = text) }

--- a/app/src/main/java/dev/blazelight/p4oc/ui/tabs/MainTabScreen.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/tabs/MainTabScreen.kt
@@ -69,9 +69,9 @@ import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
@@ -411,10 +411,20 @@ private val rememberConnectSavedServer: @Composable (
 
 private val mainTabForegroundEffect: @Composable (ServerConnectionRegistry, LifecycleOwner) -> Unit =
     { serverConnectionRegistry, lifecycleOwner ->
-        LaunchedEffect(lifecycleOwner) {
-            lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                serverConnectionRegistry.onAppForegrounded()
+        DisposableEffect(serverConnectionRegistry, lifecycleOwner) {
+            var wasStopped = false
+            val observer = LifecycleEventObserver { _, event ->
+                when (event) {
+                    Lifecycle.Event.ON_STOP -> wasStopped = true
+                    Lifecycle.Event.ON_START -> if (wasStopped) {
+                        wasStopped = false
+                        serverConnectionRegistry.onAppForegrounded()
+                    }
+                    else -> Unit
+                }
             }
+            lifecycleOwner.lifecycle.addObserver(observer)
+            onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
         }
     }
 

--- a/app/src/test/java/dev/blazelight/p4oc/ui/screens/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/ui/screens/chat/ChatViewModelTest.kt
@@ -46,6 +46,7 @@ import dev.blazelight.p4oc.ui.navigation.Screen
 import dev.blazelight.p4oc.ui.screens.files.upload.UploadCoordinator
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -532,6 +533,20 @@ class ChatViewModelTest {
 
         assertTrue(vm.sessionMissing.replayCache.isNotEmpty())
         assertNull(vm.uiState.value.error)
+    }
+
+    @Test
+    fun refreshAfterForeground_refetchesOpenSessionMetadataAndMessages() = runTest {
+        val vm = createViewModel()
+        clearMocks(api, answers = false, recordedCalls = true, childMocks = false)
+        coEvery { api.getSession("session-1", any(), null) } returns sessionDto()
+        coEvery { api.getMessages("session-1", any(), null, any(), null) } returns emptyList()
+
+        vm.refreshAfterForeground()
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { api.getSession("session-1", "/test", null) }
+        coVerify(exactly = 1) { api.getMessages("session-1", any(), null, "/test", null) }
     }
 
     @Test


### PR DESCRIPTION
## Problem

After turning the screen off and back on, an open chat session could stop updating until the user left the session and opened it again.

## Changes

- Restart the SSE connection after the app actually returns from the background.
- Avoid an unnecessary reconnect during the initial app start.
- Reload the active session metadata and latest messages after resume.
- Keep the current messages visible while the refresh is running.
- Avoid extra REST requests from inactive tabs.
- Add coverage for refreshing an open session after resume.

Model persistence, UI changes, and the hardened build are not included.

## Verification

- `ChatViewModelTest`
- `ServerConnectionRegistryTest`
- `git diff --check`