### PR TITLE
Improve todo and reasoning presentation

### DIFF
--- a/app/src/main/java/dev/blazelight/p4oc/ui/components/chat/ChatMessage.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/components/chat/ChatMessage.kt
@@ -35,8 +35,8 @@ import dev.blazelight.p4oc.ui.theme.LocalOpenCodeTheme
 import dev.blazelight.p4oc.ui.theme.SemanticColors
 import dev.blazelight.p4oc.ui.theme.Sizing
 import dev.blazelight.p4oc.ui.theme.Spacing
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.contentOrNull
-import kotlinx.serialization.json.jsonPrimitive
 
 @Composable
 @Suppress("LongParameterList", "FunctionNaming")
@@ -561,8 +561,11 @@ private fun ReasoningPart(part: Part.Reasoning) {
 }
 
 internal fun reasoningDetailTitle(part: Part.Reasoning): String? {
-    val metadataTitle = listOf("title", "summary", "subject", "heading")
-        .firstNotNullOfOrNull { key -> part.metadata?.get(key)?.jsonPrimitive?.contentOrNull }
+    val metadataTitle = REASONING_TITLE_METADATA_KEYS
+        .firstNotNullOfOrNull { key ->
+            val value = part.metadata?.get(key) as? JsonPrimitive
+            if (value != null && value.isString) value.contentOrNull else null
+        }
         ?.trim()
         ?.takeIf { it.isNotBlank() }
     val source = metadataTitle ?: part.text.lineSequence()
@@ -572,7 +575,7 @@ internal fun reasoningDetailTitle(part: Part.Reasoning): String? {
         ?.trim()
     return source
         ?.stripReasoningTitleMarkdown()
-        ?.replace(Regex("\\s+"), " ")
+        ?.replace(REASONING_WHITESPACE_REGEX, " ")
         ?.take(REASONING_TITLE_MAX_CHARS)
         ?.takeIf { it.isNotBlank() && !it.equals("reasoning", ignoreCase = true) }
 }
@@ -582,6 +585,8 @@ private fun String.stripReasoningTitleMarkdown(): String =
         .replace("__", "")
 
 private const val REASONING_TITLE_MAX_CHARS = 80
+private val REASONING_TITLE_METADATA_KEYS = listOf("title", "summary", "subject", "heading")
+private val REASONING_WHITESPACE_REGEX = Regex("\\s+")
 
 @Composable
 private fun FilePart(part: Part.File) {

--- a/app/src/main/java/dev/blazelight/p4oc/ui/components/chat/ChatMessage.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/components/chat/ChatMessage.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import dev.blazelight.p4oc.R
 import dev.blazelight.p4oc.domain.model.*
@@ -34,6 +35,8 @@ import dev.blazelight.p4oc.ui.theme.LocalOpenCodeTheme
 import dev.blazelight.p4oc.ui.theme.SemanticColors
 import dev.blazelight.p4oc.ui.theme.Sizing
 import dev.blazelight.p4oc.ui.theme.Spacing
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
 
 @Composable
 @Suppress("LongParameterList", "FunctionNaming")
@@ -511,11 +514,16 @@ private fun ReasoningPart(part: Part.Reasoning) {
                     }
                 }
 
+                val detailTitle = reasoningDetailTitle(part)
                 Text(
-                    text = stringResource(R.string.models_reasoning),
+                    text = detailTitle?.let {
+                        stringResource(R.string.reasoning_with_title, it)
+                    } ?: stringResource(R.string.models_reasoning),
                     style = MaterialTheme.typography.labelSmall,
                     color = theme.warning,
-                    modifier = Modifier.weight(1f)
+                    modifier = Modifier.weight(1f),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
                 )
 
                 Icon(
@@ -551,6 +559,29 @@ private fun ReasoningPart(part: Part.Reasoning) {
         }
     }
 }
+
+internal fun reasoningDetailTitle(part: Part.Reasoning): String? {
+    val metadataTitle = listOf("title", "summary", "subject", "heading")
+        .firstNotNullOfOrNull { key -> part.metadata?.get(key)?.jsonPrimitive?.contentOrNull }
+        ?.trim()
+        ?.takeIf { it.isNotBlank() }
+    val source = metadataTitle ?: part.text.lineSequence()
+        .map(String::trim)
+        .firstOrNull { it.isNotBlank() }
+        ?.trimStart('#')
+        ?.trim()
+    return source
+        ?.stripReasoningTitleMarkdown()
+        ?.replace(Regex("\\s+"), " ")
+        ?.take(REASONING_TITLE_MAX_CHARS)
+        ?.takeIf { it.isNotBlank() && !it.equals("reasoning", ignoreCase = true) }
+}
+
+private fun String.stripReasoningTitleMarkdown(): String =
+    replace("**", "")
+        .replace("__", "")
+
+private const val REASONING_TITLE_MAX_CHARS = 80
 
 @Composable
 private fun FilePart(part: Part.File) {

--- a/app/src/main/java/dev/blazelight/p4oc/ui/components/toolwidgets/ExpandedWidgets.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/components/toolwidgets/ExpandedWidgets.kt
@@ -580,7 +580,8 @@ fun TaskWidgetExpanded(
 // ============== Shared Components ==============
 
 @Composable
-private fun PendingApprovalButtons(
+@Suppress("FunctionNaming")
+internal fun PendingApprovalButtons(
     onApprove: () -> Unit,
     onDeny: () -> Unit
 ) {
@@ -614,7 +615,7 @@ private fun PendingApprovalButtons(
 // ============== Helper Functions ==============
 
 @Composable
-private fun getStateIconColor(
+internal fun getStateIconColor(
     state: ToolState,
     theme: dev.blazelight.p4oc.ui.theme.opencode.OpenCodeTheme
 ): Pair<String, androidx.compose.ui.graphics.Color> {

--- a/app/src/main/java/dev/blazelight/p4oc/ui/components/toolwidgets/TodoToolWidget.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/components/toolwidgets/TodoToolWidget.kt
@@ -5,73 +5,157 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextDecoration
+import dev.blazelight.p4oc.R
 import dev.blazelight.p4oc.domain.model.Part
 import dev.blazelight.p4oc.domain.model.Todo
+import dev.blazelight.p4oc.domain.model.ToolState
+import dev.blazelight.p4oc.ui.components.TuiLoadingIndicator
 import dev.blazelight.p4oc.ui.components.todo.TODO_STATUS_CANCELLED
 import dev.blazelight.p4oc.ui.components.todo.TODO_STATUS_COMPLETED
 import dev.blazelight.p4oc.ui.components.todo.TODO_STATUS_IN_PROGRESS
+import dev.blazelight.p4oc.ui.components.todo.TODO_STATUS_PENDING
+import dev.blazelight.p4oc.ui.components.todo.todoStatusLabelRes
 import dev.blazelight.p4oc.ui.theme.LocalOpenCodeTheme
 import dev.blazelight.p4oc.ui.theme.SemanticColors
 import dev.blazelight.p4oc.ui.theme.Spacing
 import dev.blazelight.p4oc.ui.theme.TuiCodeFontSize
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.contentOrNull
-import kotlinx.serialization.json.jsonPrimitive
 
-internal fun todosFromToolInput(input: JsonObject): List<Todo>? {
-    val values = input["todos"] as? JsonArray ?: return null
-    return values.mapIndexedNotNull { index, element ->
-        val item = element as? JsonObject ?: return@mapIndexedNotNull null
-        val content = item["content"]?.jsonPrimitive?.contentOrNull
-            ?.takeIf { it.isNotBlank() }
-            ?: return@mapIndexedNotNull null
-        Todo(
-            id = item["id"]?.jsonPrimitive?.contentOrNull ?: "tool-todo-$index",
+/**
+ * Resolves the todo list for a tool part. Precedence:
+ * 1. `todos` in the tool input (fails closed if malformed)
+ * 2. `todos` in state metadata (Running/Completed/Error). A present key — even
+ *    `todos: JsonNull` — is authoritative and fails closed if it cannot be
+ *    parsed; only an absent key may fall through to the Completed output.
+ * 3. For a Completed tool, the exact output parsed as a JSON array (fails
+ *    closed on invalid JSON/type)
+ *
+ * Returns null only when no authoritative source is present or a present
+ * source is malformed. A malformed authoritative source never silently falls
+ * through to the output.
+ */
+internal fun todosFromTool(tool: Part.Tool): List<Todo>? {
+    val state = tool.state
+    val metadataTodos = state.todoMetadata?.get("todos")
+    return when {
+        state.input.containsKey("todos") -> todosFromElement(state.input["todos"])
+        // A present metadata key — even `todos: JsonNull` — is authoritative and fails closed;
+        // only an absent key (metadataTodos == null) may fall through to the Completed output.
+        metadataTodos != null -> todosFromElement(metadataTodos)
+        state is ToolState.Completed -> todosFromOutput(state.output)
+        else -> null
+    }
+}
+
+internal fun todosFromToolInput(input: JsonObject): List<Todo>? = todosFromElement(input["todos"])
+
+private fun todosFromOutput(output: String): List<Todo>? {
+    val element = runCatching { Json.parseToJsonElement(output.trim()) }.getOrNull() ?: return null
+    return todosFromElement(element)
+}
+
+@Suppress("ReturnCount") // fail-closed partial-list parse: any malformed element aborts the whole list
+private fun todosFromElement(element: JsonElement?): List<Todo>? {
+    val values = element as? JsonArray ?: return null
+    val todos = ArrayList<Todo>(values.size)
+    for ((index, value) in values.withIndex()) {
+        val item = value as? JsonObject ?: return null
+        val content = jsonString(item, "content")?.takeIf { it.isNotBlank() } ?: return null
+        todos += Todo(
+            id = jsonStringOrDefault(item, "id") { "tool-todo-$index" } ?: return null,
             content = content,
-            status = item["status"]?.jsonPrimitive?.contentOrNull ?: "pending",
-            priority = item["priority"]?.jsonPrimitive?.contentOrNull ?: "medium",
+            status = jsonStringOrDefault(item, "status") { TODO_STATUS_PENDING } ?: return null,
+            priority = jsonStringOrDefault(item, "priority") { TODO_PRIORITY_MEDIUM } ?: return null,
         )
     }
+    return todos
 }
 
 internal fun todoCompactDescription(tool: Part.Tool): String {
-    val todos = todosFromToolInput(tool.state.input) ?: return tool.toolName
-    val completed = todos.count { it.status == TODO_STATUS_COMPLETED || it.status == TODO_STATUS_CANCELLED }
+    val todos = todosFromTool(tool)
+    return todoItemsForDisplay(tool.state, todos)?.let(::todoCountLabel) ?: tool.toolName
+}
+
+/** Formats a progress label matching [dev.blazelight.p4oc.ui.components.todo.TodoTrackerSheet]: completed only. */
+internal fun todoCountLabel(todos: List<Todo>): String {
+    val completed = todos.count { it.status == TODO_STATUS_COMPLETED }
     return "Todos $completed/${todos.size}"
 }
 
+/**
+ * The list eligible for presentation in the expanded widget. A `ToolState.Error` may resolve
+ * attempted-but-not-persisted input todos at the resolver level, but those must never be shown as
+ * if they were persisted, so this derivation drops them for failed tools. Non-error states pass the
+ * resolved list through unchanged (null stays null).
+ */
+internal fun todoItemsForDisplay(state: ToolState, resolvedTodos: List<Todo>?): List<Todo>? =
+    resolvedTodos.takeUnless { state is ToolState.Error }
+
+private fun jsonString(obj: JsonObject, key: String): String? =
+    (obj[key] as? JsonPrimitive)
+        ?.takeIf { it.isString }
+        ?.contentOrNull
+
+/**
+ * Returns [defaultValue] when [key] is absent or JSON null, the string value when it is a string
+ * primitive, or null (failing the whole parse) when it is present but malformed (number, boolean,
+ * object, array).
+ */
+private inline fun jsonStringOrDefault(obj: JsonObject, key: String, defaultValue: () -> String): String? =
+    when (val value = obj[key]) {
+        null, is JsonNull -> defaultValue()
+        is JsonPrimitive -> if (value.isString) value.contentOrNull else null
+        else -> null
+    }
+
+/** Metadata exposed by Running/Completed/Error states; Pending has none. */
+private val ToolState.todoMetadata: JsonObject?
+    get() = when (this) {
+        is ToolState.Running -> metadata
+        is ToolState.Completed -> metadata
+        is ToolState.Error -> metadata
+        is ToolState.Pending -> null
+    }
+
+private const val TODO_PRIORITY_MEDIUM = "medium"
+
 @Composable
-@Suppress("FunctionNaming")
+@Suppress("FunctionNaming", "LongParameterList")
 internal fun TodoWidgetExpanded(
     tool: Part.Tool,
     onClick: (() -> Unit)?,
+    showApprovalActions: Boolean,
+    approvalRequestId: String = tool.callID,
+    onToolApprove: (String) -> Unit,
+    onToolDeny: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val todos = todosFromToolInput(tool.state.input)
-    if (todos == null) {
-        DefaultWidgetExpanded(
-            tool = tool,
-            onClick = onClick,
-            showApprovalActions = false,
-            onToolApprove = {},
-            onToolDeny = {},
-            modifier = modifier,
-        )
-        return
-    }
-
     val theme = LocalOpenCodeTheme.current
+    val state = tool.state
+    val resolvedTodos = remember(tool.callID, tool.state) { todosFromTool(tool) }
+    val displayTodos = todoItemsForDisplay(state, resolvedTodos)
+
     Column(
         modifier = modifier
             .then(if (onClick != null) Modifier.clickable(role = Role.Button, onClick = onClick) else Modifier)
@@ -79,15 +163,100 @@ internal fun TodoWidgetExpanded(
             .padding(Spacing.md),
         verticalArrangement = Arrangement.spacedBy(Spacing.sm),
     ) {
+        TodoWidgetHeader(tool = tool, state = state, todos = displayTodos)
+
+        when {
+            state is ToolState.Error -> {
+                // Failed: input todos were attempted but not persisted, so showing them would be
+                // misleading. Render only the human-readable notice (never raw protocol/stack text).
+                Text(
+                    text = stringResource(R.string.todo_tool_failed),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = theme.error,
+                )
+            }
+            displayTodos != null && displayTodos.isNotEmpty() -> {
+                displayTodos.forEach { todo -> TodoToolRow(todo) }
+            }
+            displayTodos != null -> {
+                // Valid but empty list: a human-readable empty state instead of a bare 0/0 body.
+                Text(
+                    text = stringResource(R.string.no_active_todos),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = theme.textMuted,
+                )
+            }
+            state is ToolState.Completed -> {
+                // Malformed/unknown completed todo payload: fail closed with a readable notice.
+                Text(
+                    text = stringResource(R.string.todo_list_unavailable),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = theme.textMuted,
+                )
+            }
+            else -> {
+                // Pending/Running with no list yet: the header already conveys state; surface the
+                // running title without falsely claiming the payload is malformed.
+                val runningTitle = (state as? ToolState.Running)?.title
+                if (runningTitle != null) {
+                    Text(
+                        text = runningTitle,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = theme.textMuted,
+                    )
+                }
+            }
+        }
+
+        if (showApprovalActions) {
+            PendingApprovalButtons(
+                onApprove = { onToolApprove(approvalRequestId) },
+                onDeny = { onToolDeny(approvalRequestId) },
+            )
+        }
+    }
+}
+
+@Composable
+@Suppress("FunctionNaming")
+private fun TodoWidgetHeader(
+    tool: Part.Tool,
+    state: ToolState,
+    todos: List<Todo>?,
+) {
+    val theme = LocalOpenCodeTheme.current
+    val (icon, color) = getStateIconColor(state, theme)
+    val statusDesc = when (state) {
+        is ToolState.Running -> stringResource(R.string.cd_agent_running)
+        is ToolState.Pending -> stringResource(R.string.cd_tool_status)
+        is ToolState.Error -> stringResource(R.string.cd_agent_failed)
+        is ToolState.Completed -> stringResource(R.string.cd_agent_completed)
+    }
+
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
         Text(
-            text = todoCompactDescription(tool),
+            text = icon,
+            style = MaterialTheme.typography.labelMedium,
+            color = color,
+            modifier = Modifier.semantics {
+                contentDescription = statusDesc
+            },
+        )
+        Text(
+            text = if (todos == null) tool.toolName else todoCountLabel(todos),
             style = MaterialTheme.typography.labelMedium.copy(
                 fontFamily = FontFamily.Monospace,
                 fontSize = TuiCodeFontSize.lg,
             ),
             color = theme.text,
         )
-        todos.forEach { todo -> TodoToolRow(todo) }
+        Spacer(Modifier.weight(1f))
+        if (state is ToolState.Running) {
+            TuiLoadingIndicator()
+        }
     }
 }
 
@@ -95,14 +264,10 @@ internal fun TodoWidgetExpanded(
 @Suppress("FunctionNaming")
 private fun TodoToolRow(todo: Todo) {
     val theme = LocalOpenCodeTheme.current
+    val statusLabel = stringResource(todoStatusLabelRes(todo.status))
     val completed = todo.status == TODO_STATUS_COMPLETED
     val cancelled = todo.status == TODO_STATUS_CANCELLED
-    val statusColor = when (todo.status) {
-        TODO_STATUS_IN_PROGRESS -> SemanticColors.Todo.inProgress
-        TODO_STATUS_COMPLETED -> SemanticColors.Todo.completed
-        TODO_STATUS_CANCELLED -> SemanticColors.Todo.cancelled
-        else -> SemanticColors.Todo.pending
-    }
+    val statusColor = SemanticColors.Todo.forStatus(todo.status)
     val marker = when (todo.status) {
         TODO_STATUS_IN_PROGRESS -> "▶"
         TODO_STATUS_COMPLETED -> "✓"
@@ -118,7 +283,14 @@ private fun TodoToolRow(todo: Todo) {
         horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
         verticalAlignment = Alignment.Top,
     ) {
-        Text(marker, color = statusColor, style = MaterialTheme.typography.labelMedium)
+        Text(
+            text = marker,
+            color = statusColor,
+            style = MaterialTheme.typography.labelMedium,
+            modifier = Modifier.semantics {
+                contentDescription = statusLabel
+            },
+        )
         Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(Spacing.xxs)) {
             Text(
                 text = todo.content,

--- a/app/src/main/java/dev/blazelight/p4oc/ui/components/toolwidgets/TodoToolWidget.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/components/toolwidgets/TodoToolWidget.kt
@@ -1,0 +1,136 @@
+package dev.blazelight.p4oc.ui.components.toolwidgets
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextDecoration
+import dev.blazelight.p4oc.domain.model.Part
+import dev.blazelight.p4oc.domain.model.Todo
+import dev.blazelight.p4oc.ui.components.todo.TODO_STATUS_CANCELLED
+import dev.blazelight.p4oc.ui.components.todo.TODO_STATUS_COMPLETED
+import dev.blazelight.p4oc.ui.components.todo.TODO_STATUS_IN_PROGRESS
+import dev.blazelight.p4oc.ui.theme.LocalOpenCodeTheme
+import dev.blazelight.p4oc.ui.theme.SemanticColors
+import dev.blazelight.p4oc.ui.theme.Spacing
+import dev.blazelight.p4oc.ui.theme.TuiCodeFontSize
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
+
+internal fun todosFromToolInput(input: JsonObject): List<Todo>? {
+    val values = input["todos"] as? JsonArray ?: return null
+    return values.mapIndexedNotNull { index, element ->
+        val item = element as? JsonObject ?: return@mapIndexedNotNull null
+        val content = item["content"]?.jsonPrimitive?.contentOrNull
+            ?.takeIf { it.isNotBlank() }
+            ?: return@mapIndexedNotNull null
+        Todo(
+            id = item["id"]?.jsonPrimitive?.contentOrNull ?: "tool-todo-$index",
+            content = content,
+            status = item["status"]?.jsonPrimitive?.contentOrNull ?: "pending",
+            priority = item["priority"]?.jsonPrimitive?.contentOrNull ?: "medium",
+        )
+    }
+}
+
+internal fun todoCompactDescription(tool: Part.Tool): String {
+    val todos = todosFromToolInput(tool.state.input) ?: return tool.toolName
+    val completed = todos.count { it.status == TODO_STATUS_COMPLETED || it.status == TODO_STATUS_CANCELLED }
+    return "Todos $completed/${todos.size}"
+}
+
+@Composable
+@Suppress("FunctionNaming")
+internal fun TodoWidgetExpanded(
+    tool: Part.Tool,
+    onClick: (() -> Unit)?,
+    modifier: Modifier = Modifier,
+) {
+    val todos = todosFromToolInput(tool.state.input)
+    if (todos == null) {
+        DefaultWidgetExpanded(
+            tool = tool,
+            onClick = onClick,
+            showApprovalActions = false,
+            onToolApprove = {},
+            onToolDeny = {},
+            modifier = modifier,
+        )
+        return
+    }
+
+    val theme = LocalOpenCodeTheme.current
+    Column(
+        modifier = modifier
+            .then(if (onClick != null) Modifier.clickable(role = Role.Button, onClick = onClick) else Modifier)
+            .background(theme.backgroundPanel.copy(alpha = 0.5f))
+            .padding(Spacing.md),
+        verticalArrangement = Arrangement.spacedBy(Spacing.sm),
+    ) {
+        Text(
+            text = todoCompactDescription(tool),
+            style = MaterialTheme.typography.labelMedium.copy(
+                fontFamily = FontFamily.Monospace,
+                fontSize = TuiCodeFontSize.lg,
+            ),
+            color = theme.text,
+        )
+        todos.forEach { todo -> TodoToolRow(todo) }
+    }
+}
+
+@Composable
+@Suppress("FunctionNaming")
+private fun TodoToolRow(todo: Todo) {
+    val theme = LocalOpenCodeTheme.current
+    val completed = todo.status == TODO_STATUS_COMPLETED
+    val cancelled = todo.status == TODO_STATUS_CANCELLED
+    val statusColor = when (todo.status) {
+        TODO_STATUS_IN_PROGRESS -> SemanticColors.Todo.inProgress
+        TODO_STATUS_COMPLETED -> SemanticColors.Todo.completed
+        TODO_STATUS_CANCELLED -> SemanticColors.Todo.cancelled
+        else -> SemanticColors.Todo.pending
+    }
+    val marker = when (todo.status) {
+        TODO_STATUS_IN_PROGRESS -> "▶"
+        TODO_STATUS_COMPLETED -> "✓"
+        TODO_STATUS_CANCELLED -> "×"
+        else -> "○"
+    }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(theme.backgroundElement)
+            .padding(Spacing.sm),
+        horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+        verticalAlignment = Alignment.Top,
+    ) {
+        Text(marker, color = statusColor, style = MaterialTheme.typography.labelMedium)
+        Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(Spacing.xxs)) {
+            Text(
+                text = todo.content,
+                style = MaterialTheme.typography.bodySmall,
+                color = if (completed || cancelled) theme.textMuted else theme.text,
+                textDecoration = if (completed || cancelled) TextDecoration.LineThrough else null,
+            )
+            Text(
+                text = "[${todo.priority.uppercase()}]",
+                style = MaterialTheme.typography.labelSmall,
+                color = SemanticColors.Todo.forPriority(todo.priority),
+            )
+        }
+    }
+}

--- a/app/src/main/java/dev/blazelight/p4oc/ui/components/toolwidgets/ToolCallWidget.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/components/toolwidgets/ToolCallWidget.kt
@@ -242,6 +242,11 @@ fun ToolCallExpanded(
             onOpenSubSession = onOpenSubSession,
             modifier = modifier
         )
+        "todowrite", "todoread" -> TodoWidgetExpanded(
+            tool = tool,
+            onClick = onClick,
+            modifier = modifier,
+        )
         else -> DefaultWidgetExpanded(
             tool = tool,
             onClick = onClick,
@@ -285,6 +290,7 @@ internal fun getToolCompactDescription(tool: Part.Tool): String {
         name in GLOB_TOOLS -> patternDescription("glob", input, "file_mask") ?: tool.toolName
         name in GREP_TOOLS -> patternDescription("grep", input, "substring_pattern", 40, quoted = true)
             ?: tool.toolName
+        name in listOf("todowrite", "todoread") -> todoCompactDescription(tool)
         else -> tool.toolName
     }
 }

--- a/app/src/main/java/dev/blazelight/p4oc/ui/components/toolwidgets/ToolCallWidget.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/components/toolwidgets/ToolCallWidget.kt
@@ -242,9 +242,13 @@ fun ToolCallExpanded(
             onOpenSubSession = onOpenSubSession,
             modifier = modifier
         )
-        "todowrite", "todoread" -> TodoWidgetExpanded(
+        in TODO_TOOLS -> TodoWidgetExpanded(
             tool = tool,
             onClick = onClick,
+            showApprovalActions = showApprovalActions,
+            approvalRequestId = approvalRequestId,
+            onToolApprove = onToolApprove,
+            onToolDeny = onToolDeny,
             modifier = modifier,
         )
         else -> DefaultWidgetExpanded(
@@ -290,7 +294,7 @@ internal fun getToolCompactDescription(tool: Part.Tool): String {
         name in GLOB_TOOLS -> patternDescription("glob", input, "file_mask") ?: tool.toolName
         name in GREP_TOOLS -> patternDescription("grep", input, "substring_pattern", 40, quoted = true)
             ?: tool.toolName
-        name in listOf("todowrite", "todoread") -> todoCompactDescription(tool)
+        name in TODO_TOOLS -> todoCompactDescription(tool)
         else -> tool.toolName
     }
 }
@@ -301,6 +305,7 @@ private val EDIT_TOOLS = setOf("edit", "morph_edit_file", "serena_replace_conten
 private val WRITE_TOOLS = setOf("write", "serena_create_text_file")
 private val GLOB_TOOLS = setOf("glob", "find", "serena_find_file")
 private val GREP_TOOLS = setOf("grep", "search", "serena_search_for_pattern")
+private val TODO_TOOLS = setOf("todowrite", "todoread")
 
 private fun shellDescription(tool: Part.Tool, input: JsonObject): String {
     val command = extractParam(input, "command")?.trim()?.takeIf(String::isNotEmpty)?.take(60)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -520,6 +520,7 @@
     <string name="models_context_format">Context: %s</string>
     <string name="models_tools">Tools</string>
     <string name="models_reasoning">Reasoning</string>
+    <string name="reasoning_with_title">Reasoning · %1$s</string>
     <string name="models_load_failed_title">Could not load models</string>
     <string name="models_load_failed_description">Check the server connection, then try again.</string>
     <string name="models_empty_title">No models available</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -749,6 +749,8 @@
     <string name="todo_status_unknown">unknown</string>
     <string name="no_active_todos">No active todos</string>
     <string name="agent_no_tasks">The agent hasn\'t created any tasks yet</string>
+    <string name="todo_list_unavailable">Todo list could not be read</string>
+    <string name="todo_tool_failed">Todo tool failed</string>
     
     <!-- Context Usage Display -->
     <string name="context_usage">Context Usage</string>

--- a/app/src/test/java/dev/blazelight/p4oc/ui/components/chat/ReasoningTitleTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/ui/components/chat/ReasoningTitleTest.kt
@@ -1,6 +1,8 @@
 package dev.blazelight.p4oc.ui.components.chat
 
 import dev.blazelight.p4oc.domain.model.Part
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import org.junit.Assert.assertEquals
@@ -30,6 +32,30 @@ class ReasoningTitleTest {
 
         assertEquals("Adding full tests and formatting fixes", reasoningDetailTitle(part))
         assertEquals("**Adding full tests and formatting fixes**\nMore detail", part.text)
+    }
+
+    @Test
+    fun `falls back to first reasoning line when metadata title is not a string`() {
+        val part = reasoning(
+            text = "## Comparing server and local state\nMore detail",
+            metadata = buildJsonObject {
+                put("title", buildJsonArray { add(JsonPrimitive("nested")) })
+            },
+        )
+
+        assertEquals("Comparing server and local state", reasoningDetailTitle(part))
+    }
+
+    @Test
+    fun `falls back to first reasoning line when metadata title is a number`() {
+        val part = reasoning(
+            text = "Resolving auth handshake",
+            metadata = buildJsonObject {
+                put("title", JsonPrimitive(42))
+            },
+        )
+
+        assertEquals("Resolving auth handshake", reasoningDetailTitle(part))
     }
 
     private fun reasoning(

--- a/app/src/test/java/dev/blazelight/p4oc/ui/components/chat/ReasoningTitleTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/ui/components/chat/ReasoningTitleTest.kt
@@ -1,0 +1,45 @@
+package dev.blazelight.p4oc.ui.components.chat
+
+import dev.blazelight.p4oc.domain.model.Part
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ReasoningTitleTest {
+    @Test
+    fun `prefers server metadata title`() {
+        val part = reasoning(
+            text = "Fallback first line",
+            metadata = buildJsonObject { put("title", "Checking session persistence") },
+        )
+
+        assertEquals("Checking session persistence", reasoningDetailTitle(part))
+    }
+
+    @Test
+    fun `uses cleaned first meaningful reasoning line as fallback`() {
+        val part = reasoning(text = "\n## Comparing server and local state\nMore detail")
+
+        assertEquals("Comparing server and local state", reasoningDetailTitle(part))
+    }
+
+    @Test
+    fun `removes bold markers from collapsed title only`() {
+        val part = reasoning(text = "**Adding full tests and formatting fixes**\nMore detail")
+
+        assertEquals("Adding full tests and formatting fixes", reasoningDetailTitle(part))
+        assertEquals("**Adding full tests and formatting fixes**\nMore detail", part.text)
+    }
+
+    private fun reasoning(
+        text: String,
+        metadata: kotlinx.serialization.json.JsonObject? = null,
+    ) = Part.Reasoning(
+        id = "part",
+        sessionID = "session",
+        messageID = "message",
+        text = text,
+        metadata = metadata,
+    )
+}

--- a/app/src/test/java/dev/blazelight/p4oc/ui/components/toolwidgets/TodoToolWidgetTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/ui/components/toolwidgets/TodoToolWidgetTest.kt
@@ -1,7 +1,13 @@
 package dev.blazelight.p4oc.ui.components.toolwidgets
 
 import dev.blazelight.p4oc.domain.model.Part
+import dev.blazelight.p4oc.domain.model.Todo
 import dev.blazelight.p4oc.domain.model.ToolState
+import dev.blazelight.p4oc.ui.components.todo.TODO_STATUS_CANCELLED
+import dev.blazelight.p4oc.ui.components.todo.TODO_STATUS_COMPLETED
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
@@ -45,6 +51,407 @@ class TodoToolWidgetTest {
     fun `returns null when input does not contain todo array`() {
         assertNull(todosFromToolInput(buildJsonObject { put("content", "not a list") }))
     }
+
+    @Test
+    fun `returns null when a todo content field is a nested object`() {
+        val input = buildJsonObject {
+            put(
+                "todos",
+                buildJsonArray {
+                    add(
+                        buildJsonObject {
+                            put("content", buildJsonObject { put("text", "nested") })
+                        }
+                    )
+                }
+            )
+        }
+
+        assertNull(todosFromToolInput(input))
+    }
+
+    @Test
+    fun `returns null when a todo array element is not an object`() {
+        val input = buildJsonObject {
+            put(
+                "todos",
+                buildJsonArray {
+                    add(JsonPrimitive("plain string"))
+                }
+            )
+        }
+
+        assertNull(todosFromToolInput(input))
+    }
+
+    @Test
+    fun `returns null when a todo content field is numeric`() {
+        val input = buildJsonObject {
+            put(
+                "todos",
+                buildJsonArray {
+                    add(
+                        buildJsonObject {
+                            put("content", JsonPrimitive(42))
+                        }
+                    )
+                }
+            )
+        }
+
+        assertNull(todosFromToolInput(input))
+    }
+
+    @Test
+    fun `returns null when a todo optional field is numeric`() {
+        val input = buildJsonObject {
+            put(
+                "todos",
+                buildJsonArray {
+                    add(
+                        buildJsonObject {
+                            put("content", "Valid content")
+                            put("status", JsonPrimitive(7))
+                        }
+                    )
+                }
+            )
+        }
+
+        assertNull(todosFromToolInput(input))
+    }
+
+    @Test
+    fun `absent or null optional fields fall back to defaults`() {
+        val input = buildJsonObject {
+            put(
+                "todos",
+                buildJsonArray {
+                    add(
+                        buildJsonObject {
+                            put("content", "No optional fields")
+                        }
+                    )
+                    add(
+                        buildJsonObject {
+                            put("content", "Null optional fields")
+                            put("id", JsonNull)
+                            put("status", JsonNull)
+                            put("priority", JsonNull)
+                        }
+                    )
+                }
+            )
+        }
+
+        val todos = todosFromToolInput(input).orEmpty()
+
+        assertEquals(2, todos.size)
+        assertEquals("tool-todo-0", todos[0].id)
+        assertEquals("pending", todos[0].status)
+        assertEquals("medium", todos[0].priority)
+        assertEquals("tool-todo-1", todos[1].id)
+        assertEquals("pending", todos[1].status)
+        assertEquals("medium", todos[1].priority)
+    }
+
+    @Test
+    fun `malformed elements make compact description fall back to tool name`() {
+        val malformed = buildJsonObject {
+            put(
+                "todos",
+                buildJsonArray {
+                    add(
+                        buildJsonObject {
+                            put("content", "First valid")
+                        }
+                    )
+                    add(
+                        buildJsonObject {
+                            put("content", buildJsonObject { put("text", "nested") })
+                        }
+                    )
+                }
+            )
+        }
+
+        assertEquals("todowrite", todoCompactDescription(tool(malformed)))
+    }
+
+    @Test
+    fun `todoread completed with empty input parses todo array output`() {
+        val input = buildJsonObject { }
+        val output = buildJsonArray {
+            add(
+                buildJsonObject {
+                    put("content", "Read todos")
+                    put("status", "completed")
+                }
+            )
+            add(
+                buildJsonObject {
+                    put("content", "Sync state")
+                    put("priority", "high")
+                }
+            )
+        }
+        val part = todoReadTool(input, output.toString())
+
+        val todos = todosFromTool(part).orEmpty()
+
+        assertEquals(2, todos.size)
+        assertEquals("Read todos", todos.first().content)
+        assertEquals(TODO_STATUS_COMPLETED, todos.first().status)
+        assertEquals("high", todos.last().priority)
+        assertEquals("Todos 1/2", todoCompactDescription(part))
+    }
+
+    @Test
+    fun `malformed authoritative input does not fall through to valid output`() {
+        val input = buildJsonObject {
+            put(
+                "todos",
+                buildJsonArray {
+                    add(
+                        buildJsonObject {
+                            put("content", buildJsonObject { put("text", "nested") })
+                        }
+                    )
+                }
+            )
+        }
+        val part = todoReadTool(input, "[{\"content\":\"Valid from output\"}]")
+
+        assertNull(todosFromTool(part))
+        assertEquals("todoread", todoCompactDescription(part))
+    }
+
+    @Test
+    fun `invalid output json fails closed`() {
+        val part = todoReadTool(buildJsonObject { }, "not json at all")
+
+        assertNull(todosFromTool(part))
+        assertEquals("todoread", todoCompactDescription(part))
+    }
+
+    @Test
+    fun `todoread completed with metadata todos source renders the list`() {
+        val metadata = buildJsonObject {
+            put(
+                "todos",
+                buildJsonArray {
+                    add(
+                        buildJsonObject {
+                            put("content", "Metadata todo")
+                            put("status", "in_progress")
+                        }
+                    )
+                    add(
+                        buildJsonObject {
+                            put("content", "Metadata done")
+                            put("status", "completed")
+                        }
+                    )
+                }
+            )
+        }
+        val part = Part.Tool(
+            id = "part",
+            sessionID = "session",
+            messageID = "message",
+            callID = "call",
+            toolName = "todoread",
+            state = ToolState.Completed(
+                input = buildJsonObject { },
+                output = "[{\"content\":\"From output\"}]",
+                title = "Todo list",
+                startedAt = 1,
+                endedAt = 2,
+                metadata = metadata,
+            ),
+        )
+
+        val todos = todosFromTool(part).orEmpty()
+
+        assertEquals(2, todos.size)
+        assertEquals("Metadata todo", todos.first().content)
+        assertEquals("Metadata done", todos.last().content)
+        assertEquals("Todos 1/2", todoCompactDescription(part))
+    }
+
+    @Test
+    fun `running metadata todos source resolves the list`() {
+        val metadata = buildJsonObject {
+            put(
+                "todos",
+                buildJsonArray {
+                    add(
+                        buildJsonObject {
+                            put("content", "In-flight todo")
+                            put("status", "in_progress")
+                        }
+                    )
+                }
+            )
+        }
+        val part = Part.Tool(
+            id = "part",
+            sessionID = "session",
+            messageID = "message",
+            callID = "call",
+            toolName = "todowrite",
+            state = ToolState.Running(
+                input = buildJsonObject { },
+                title = "Updating todos",
+                startedAt = 1,
+                metadata = metadata,
+            ),
+        )
+
+        val todos = todosFromTool(part).orEmpty()
+
+        assertEquals(1, todos.size)
+        assertEquals("In-flight todo", todos.first().content)
+        assertEquals("Todos 0/1", todoCountLabel(todos))
+    }
+
+    @Test
+    fun `metadata todos null key fails closed and does not fall through to output`() {
+        val metadata = buildJsonObject {
+            put("todos", JsonNull)
+        }
+        val part = Part.Tool(
+            id = "part",
+            sessionID = "session",
+            messageID = "message",
+            callID = "call",
+            toolName = "todoread",
+            state = ToolState.Completed(
+                input = buildJsonObject { },
+                output = "[{\"content\":\"Valid from output\"}]",
+                title = "Todo list",
+                startedAt = 1,
+                endedAt = 2,
+                metadata = metadata,
+            ),
+        )
+
+        assertNull(todosFromTool(part))
+        assertEquals("todoread", todoCompactDescription(part))
+    }
+
+    @Test
+    fun `cancelled todos do not count toward progress`() {
+        val todos = listOf(
+            Todo(
+                id = "t0",
+                content = "Completed",
+                status = TODO_STATUS_COMPLETED,
+                priority = "medium",
+            ),
+            Todo(
+                id = "t1",
+                content = "Cancelled",
+                status = TODO_STATUS_CANCELLED,
+                priority = "medium",
+            ),
+            Todo(
+                id = "t2",
+                content = "Pending",
+                status = "pending",
+                priority = "medium",
+            ),
+        )
+
+        assertEquals("Todos 1/3", todoCountLabel(todos))
+    }
+
+    @Test
+    fun `error resolves attempted input todos but does not present them as persisted`() {
+        val input = buildJsonObject {
+            put(
+                "todos",
+                buildJsonArray {
+                    add(
+                        buildJsonObject {
+                            put("content", "Attempted but not persisted")
+                            put("status", "in_progress")
+                        }
+                    )
+                }
+            )
+        }
+        val part = Part.Tool(
+            id = "part",
+            sessionID = "session",
+            messageID = "message",
+            callID = "call",
+            toolName = "todowrite",
+            state = ToolState.Error(
+                input = input,
+                error = "some raw protocol/stack text that must never surface",
+                startedAt = 1,
+                endedAt = 2,
+            ),
+        )
+
+        val resolved = todosFromTool(part).orEmpty()
+        assertEquals(1, resolved.size)
+        assertEquals("Attempted but not persisted", resolved.first().content)
+
+        assertNull(todoItemsForDisplay(part.state, resolved))
+        // Compact presentation also hides attempted/unpersisted todo progress for a failed tool.
+        assertEquals("todowrite", todoCompactDescription(part))
+    }
+
+    @Test
+    fun `malformed metadata todos does not fall through to valid output`() {
+        val metadata = buildJsonObject {
+            put(
+                "todos",
+                buildJsonArray {
+                    add(
+                        buildJsonObject {
+                            put("content", JsonPrimitive(5))
+                        }
+                    )
+                }
+            )
+        }
+        val part = Part.Tool(
+            id = "part",
+            sessionID = "session",
+            messageID = "message",
+            callID = "call",
+            toolName = "todoread",
+            state = ToolState.Completed(
+                input = buildJsonObject { },
+                output = "[{\"content\":\"Valid from output\"}]",
+                title = "Todo list",
+                startedAt = 1,
+                endedAt = 2,
+                metadata = metadata,
+            ),
+        )
+
+        assertNull(todosFromTool(part))
+        assertEquals("todoread", todoCompactDescription(part))
+    }
+
+    private fun todoReadTool(input: JsonObject, output: String) = Part.Tool(
+        id = "part",
+        sessionID = "session",
+        messageID = "message",
+        callID = "call",
+        toolName = "todoread",
+        state = ToolState.Completed(
+            input = input,
+            output = output,
+            title = "Todo list",
+            startedAt = 1,
+            endedAt = 2,
+        ),
+    )
 
     private fun tool(input: kotlinx.serialization.json.JsonObject) = Part.Tool(
         id = "part",

--- a/app/src/test/java/dev/blazelight/p4oc/ui/components/toolwidgets/TodoToolWidgetTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/ui/components/toolwidgets/TodoToolWidgetTest.kt
@@ -1,0 +1,63 @@
+package dev.blazelight.p4oc.ui.components.toolwidgets
+
+import dev.blazelight.p4oc.domain.model.Part
+import dev.blazelight.p4oc.domain.model.ToolState
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class TodoToolWidgetTest {
+    @Test
+    fun `parses todo write input without ids and applies safe defaults`() {
+        val input = buildJsonObject {
+            put(
+                "todos",
+                buildJsonArray {
+                    add(
+                        buildJsonObject {
+                            put("content", "Check persistence")
+                            put("status", "in_progress")
+                            put("priority", "high")
+                        }
+                    )
+                    add(
+                        buildJsonObject {
+                            put("content", "Run tests")
+                            put("status", "completed")
+                        }
+                    )
+                }
+            )
+        }
+
+        val todos = todosFromToolInput(input).orEmpty()
+
+        assertEquals(2, todos.size)
+        assertEquals("tool-todo-0", todos.first().id)
+        assertEquals("medium", todos.last().priority)
+        assertEquals("Todos 1/2", todoCompactDescription(tool(input)))
+    }
+
+    @Test
+    fun `returns null when input does not contain todo array`() {
+        assertNull(todosFromToolInput(buildJsonObject { put("content", "not a list") }))
+    }
+
+    private fun tool(input: kotlinx.serialization.json.JsonObject) = Part.Tool(
+        id = "part",
+        sessionID = "session",
+        messageID = "message",
+        callID = "call",
+        toolName = "todowrite",
+        state = ToolState.Completed(
+            input = input,
+            output = "[]",
+            title = "Updated todo list",
+            startedAt = 1,
+            endedAt = 2,
+        ),
+    )
+}


### PR DESCRIPTION
## Changes

Make todo and reasoning blocks easier and safer to read in chat.

- Render `todowrite` and historical `todoread` payloads as structured task lists.
- Resolve todos in authoritative order: input, state metadata, then completed JSON-array output.
- Fail closed on malformed authoritative payloads and show human-readable fallbacks instead of raw protocol JSON.
- Show tool run/error state, task status, priority, completed-only progress, and an explicit empty state.
- Keep failed write attempts out of compact and expanded persisted-task summaries.
- Preserve approval actions for direct pending todo widgets.
- Show a short contextual title for collapsed reasoning blocks from string metadata or the first meaningful reasoning line.
- Keep expanded reasoning Markdown unchanged.

Model persistence, foreground recovery, the apply-patch widget, and the hardened build are not included.

## Verification

- `./gradlew :app:testDebugUnitTest --tests dev.blazelight.p4oc.ui.components.toolwidgets.TodoToolWidgetTest --tests dev.blazelight.p4oc.ui.components.chat.ReasoningTitleTest --tests dev.blazelight.p4oc.ui.components.toolwidgets.ToolCallWidgetTest`
- `./gradlew :app:testDebugUnitTest :app:detekt :app:assembleDebug`
- `git diff --check origin/main`

No device testing was performed.