### PR TITLE
Improve chat run recovery and failure feedback

### DIFF
--- a/app/src/main/java/dev/blazelight/p4oc/data/remote/mapper/Mappers.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/data/remote/mapper/Mappers.kt
@@ -690,6 +690,11 @@ class EventMapper constructor(
                         MessageError(
                             name = error.name,
                             message = (error.data?.get("message") as? JsonPrimitive)?.contentOrNull,
+                            statusCode = (error.data?.get("statusCode") as? JsonPrimitive)?.intOrNull,
+                            isRetryable = (error.data?.get("isRetryable") as? JsonPrimitive)
+                                ?.contentOrNull
+                                ?.toBooleanStrictOrNull()
+                                ?: false,
                             providerID = (error.data?.get("providerID") as? JsonPrimitive)?.contentOrNull,
                             responseBody = (error.data?.get("responseBody") as? JsonPrimitive)?.contentOrNull,
                         )

--- a/app/src/main/java/dev/blazelight/p4oc/data/session/SessionRepository.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/data/session/SessionRepository.kt
@@ -36,6 +36,14 @@ interface SessionRepository {
     /** Loads the newest [limit] messages and returns the number supplied by the server. */
     suspend fun loadMessages(sessionId: SessionId, limit: Int): Int
 
+    /**
+     * Reconciles the cached message state for [sessionId] against the server's authoritative REST
+     * window, using the same active-lease, revision-safe recovery algorithm as reconnect recovery.
+     * This is the single entry point for recovering missed terminal SSE updates after a successful
+     * async send. It is a no-op when the session has no active lease or has been deleted.
+     */
+    suspend fun reconcileMessages(sessionId: SessionId)
+
     fun sendMessageAsync(sessionId: SessionId, request: SendMessageRequest): Deferred<Result<Unit>>
 
     fun abortSession(sessionId: SessionId): Deferred<Result<Boolean>>

--- a/app/src/main/java/dev/blazelight/p4oc/data/session/SessionRepositoryImpl.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/data/session/SessionRepositoryImpl.kt
@@ -14,6 +14,7 @@ import dev.blazelight.p4oc.data.remote.mapper.mapQuestionRequestDtoToDomain
 import dev.blazelight.p4oc.data.workspace.SessionWorkspaceClient
 import dev.blazelight.p4oc.data.workspace.WorkspaceClient
 import dev.blazelight.p4oc.domain.model.Message
+import dev.blazelight.p4oc.domain.model.MessageError
 import dev.blazelight.p4oc.domain.model.MessageWithParts
 import dev.blazelight.p4oc.domain.model.OpenCodeEvent
 import dev.blazelight.p4oc.domain.model.Part
@@ -290,7 +291,7 @@ class SessionRepositoryImpl(
                 updateSession(event.sessionID) { state ->
                     state.copy(
                         status = event.status,
-                        error = null,
+                        error = if (event.status is SessionStatus.Busy) null else state.error,
                         responseCompletedToken = if (event.status.isTerminalIdle()) state.responseCompletedToken + 1 else state.responseCompletedToken,
                     )
                 }
@@ -300,7 +301,6 @@ class SessionRepositoryImpl(
                 updateSession(event.sessionID) { state ->
                     state.copy(
                         status = SessionStatus.Idle,
-                        error = null,
                         responseCompletedToken = state.responseCompletedToken + 1,
                     )
                 }
@@ -308,14 +308,10 @@ class SessionRepositoryImpl(
             }
             is OpenCodeEvent.SessionError -> {
                 val eventSessionId = event.sessionID ?: return
-                updateSession(eventSessionId) { state ->
-                    state.copy(
-                        status = SessionStatus.Idle,
-                        error = event.error,
-                        responseCompletedToken = state.responseCompletedToken + 1,
-                    )
-                }
-                clearStreamingFlags(SessionId(eventSessionId))
+                applySessionError(
+                    eventSessionId,
+                    event.error ?: MessageError(name = "UnknownError"),
+                )
             }
             is OpenCodeEvent.PermissionRequested -> {
                 updateOwnedSession(event.permission.sessionID) { state ->
@@ -345,7 +341,11 @@ class SessionRepositoryImpl(
             is OpenCodeEvent.QuestionReplied -> resolveQuestion(event.sessionID, event.requestID)
             is OpenCodeEvent.QuestionRejected -> resolveQuestion(event.sessionID, event.requestID)
             is OpenCodeEvent.TodoUpdated -> updateSession(event.sessionID) { it.copy(todos = event.todos) }
-            is OpenCodeEvent.MessageUpdated -> upsertMessage(event.message)
+            is OpenCodeEvent.MessageUpdated -> {
+                upsertMessage(event.message)
+                val assistant = event.message as? Message.Assistant
+                assistant?.error?.let { error -> applySessionError(assistant.sessionID, error) }
+            }
             is OpenCodeEvent.MessagePartUpdated -> upsertPart(event.part, event.delta)
             is OpenCodeEvent.MessagePartDelta -> applyPartDelta(event)
             is OpenCodeEvent.MessageRemoved -> removeMessage(event.sessionID, event.messageID)
@@ -730,6 +730,22 @@ class SessionRepositoryImpl(
 
     override fun abortSession(sessionId: SessionId): Deferred<Result<Boolean>> = scope.async {
         runMutationCatching { client.abortSession(sessionId.value) }
+    }
+
+    private fun applySessionError(sessionId: String, error: MessageError) {
+        updateSession(sessionId) { state ->
+            val alreadyApplied = state.status is SessionStatus.Idle && state.error == error
+            state.copy(
+                status = SessionStatus.Idle,
+                error = error,
+                responseCompletedToken = if (alreadyApplied) {
+                    state.responseCompletedToken
+                } else {
+                    state.responseCompletedToken + 1
+                },
+            )
+        }
+        clearStreamingFlags(SessionId(sessionId))
     }
 
     override fun clearStreamingFlags(sessionId: SessionId) {

--- a/app/src/main/java/dev/blazelight/p4oc/data/session/SessionRepositoryImpl.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/data/session/SessionRepositoryImpl.kt
@@ -112,6 +112,13 @@ class SessionRepositoryImpl(
     // consumer lease is still held by an open view.
     private val recoveryInvalidatedSessions = mutableSetOf<String>()
 
+    // Per-session lease/state-lifetime generation. Bumped ONLY on acquire, final release, and
+    // SessionDeleted (cleared on close) — never by ordinary message/part mutations — so it is the
+    // ownership token for recovery-bound pending question/permission reconciliation. Ordinary SSE
+    // message traffic racing a pending fetch must not invalidate pending recovery for the
+    // still-current lease; only a lease/state-lifetime change may.
+    private val sessionLeaseGenerations = mutableMapOf<String, Long>()
+
     // Shared boundary guarding per-session message state, consumer counts, revisions and loaded
     // limits. Held across capture, mutation+revision-bump, active-count checks, and replacement so
     // a lease release or SSE mutation cannot interleave and let a fetched window commit stale data.
@@ -271,7 +278,6 @@ class SessionRepositoryImpl(
             }
             is OpenCodeEvent.SessionDeleted -> {
                 removeSessionOwnership(event.session.id)
-                synchronized(sessionUiStates) { sessionUiStates.remove(event.session.id) }
                 synchronized(messageStateLock) {
                     messageStates.remove(event.session.id)?.value = emptyList()
                     // Treat deletion as a revisioned invalidation: remove the state but mark the
@@ -280,7 +286,14 @@ class SessionRepositoryImpl(
                     // recovery capture collide with the default `?: 0L` and resurrect the session.
                     recoveryInvalidatedSessions.add(event.session.id)
                     sessionRevisions[event.session.id] = (sessionRevisions[event.session.id] ?: 0L) + 1
+                    // Deletion ends the state lifetime: any in-flight recovery-bound pending
+                    // reconciliation loses ownership.
+                    sessionLeaseGenerations[event.session.id] = (sessionLeaseGenerations[event.session.id] ?: 0L) + 1
                     sessionLoadedLimits.remove(event.session.id)
+                    // UI-state removal happens inside the same critical section (nested order
+                    // messageStateLock -> sessionUiStates, matching releaseSession) so a guarded
+                    // recovery write can never recreate the entry between removal and invalidation.
+                    synchronized(sessionUiStates) { sessionUiStates.remove(event.session.id) }
                 }
             }
             is OpenCodeEvent.SessionUpdated -> {
@@ -289,19 +302,31 @@ class SessionRepositoryImpl(
             }
             is OpenCodeEvent.SessionStatusChanged -> {
                 updateSession(event.sessionID) { state ->
+                    val alreadyIdleWithError = state.status is SessionStatus.Idle && state.error != null
                     state.copy(
                         status = event.status,
                         error = if (event.status is SessionStatus.Busy) null else state.error,
-                        responseCompletedToken = if (event.status.isTerminalIdle()) state.responseCompletedToken + 1 else state.responseCompletedToken,
+                        // A trailing terminal status after an error already completed the run must
+                        // not fire a second completion (haptic/unread) for the same failure.
+                        responseCompletedToken = if (event.status.isTerminalIdle() && !alreadyIdleWithError) {
+                            state.responseCompletedToken + 1
+                        } else {
+                            state.responseCompletedToken
+                        },
                     )
                 }
                 if (event.status.isTerminalIdle()) clearStreamingFlags(SessionId(event.sessionID))
             }
             is OpenCodeEvent.SessionIdle -> {
                 updateSession(event.sessionID) { state ->
+                    val alreadyIdleWithError = state.status is SessionStatus.Idle && state.error != null
                     state.copy(
                         status = SessionStatus.Idle,
-                        responseCompletedToken = state.responseCompletedToken + 1,
+                        responseCompletedToken = if (alreadyIdleWithError) {
+                            state.responseCompletedToken
+                        } else {
+                            state.responseCompletedToken + 1
+                        },
                     )
                 }
                 clearStreamingFlags(SessionId(event.sessionID))
@@ -369,11 +394,18 @@ class SessionRepositoryImpl(
      * Fetches the list of pending questions from GET /question and sets
      * pendingQuestion on owned sessions that don't already have one.
      * Skips questions that were recently resolved (anti-resurrection).
+     *
+     * A non-null [leaseGeneration] marks a recovery-bound call: the fetch is skipped when
+     * ownership was already lost, and every UI-state write is re-checked atomically against the
+     * lease generation so a lease released (or released and reacquired) mid-fetch is never
+     * repopulated with stale state. Ordinary message traffic does not invalidate ownership.
      */
-    private suspend fun reconcilePendingQuestions(sessionId: String) {
+    private suspend fun reconcilePendingQuestions(sessionId: String, leaseGeneration: Long? = null) {
+        if (leaseGeneration != null && !ownsRecoveryLease(sessionId, leaseGeneration)) return
         AppLog.d(TAG, "reconcilePendingQuestions: fetching pending questions")
         val questionsToCheck = runCatching { fetchPendingQuestions(sessionId) }
             .getOrElse { error ->
+                if (error is CancellationException) throw error
                 AppLog.w(TAG, "Failed to fetch pending questions: ${error.javaClass.simpleName}")
                 return
             }
@@ -396,12 +428,15 @@ class SessionRepositoryImpl(
 
             // Mirror live question.asked handling: first pending question is shown,
             // additional recovered questions are queued behind it.
-            updateOwnedSession(questionDto.sessionID) { state ->
-                val question = mapQuestionRequestDtoToDomain(questionDto)
-                when {
-                    state.pendingQuestion?.id == question.id || state.queuedQuestions.any { it.id == question.id } -> state
-                    state.pendingQuestion == null -> state.copy(pendingQuestion = question)
-                    else -> state.copy(queuedQuestions = state.queuedQuestions + question)
+            withRecoveryOwnership(sessionId, leaseGeneration) {
+                updateOwnedSession(questionDto.sessionID) { state ->
+                    val question = mapQuestionRequestDtoToDomain(questionDto)
+                    when {
+                        state.pendingQuestion?.id == question.id ||
+                            state.queuedQuestions.any { it.id == question.id } -> state
+                        state.pendingQuestion == null -> state.copy(pendingQuestion = question)
+                        else -> state.copy(queuedQuestions = state.queuedQuestions + question)
+                    }
                 }
             }
         }
@@ -436,7 +471,7 @@ class SessionRepositoryImpl(
             }
             for (sessionId in active) {
                 try {
-                    recoverMessagesForSession(sessionId)
+                    reconcileMessages(SessionId(sessionId))
                 } catch (ce: CancellationException) {
                     throw ce
                 } catch (e: Exception) {
@@ -444,6 +479,17 @@ class SessionRepositoryImpl(
                 }
             }
         }
+    }
+
+    /**
+     * Reconciles the cached message state for a single session against the server's authoritative
+     * REST window. This is the shared primitive used both by reconnect recovery (for every actively
+     * leased session) and by post-send callers recovering a missed terminal SSE update. It reuses
+     * the same active-lease, revision-safe, remembered-window algorithm, so a second independent
+     * polling path is never introduced.
+     */
+    override suspend fun reconcileMessages(sessionId: SessionId) {
+        recoverMessagesForSession(sessionId.value)
     }
 
     private suspend fun recoverMessagesForSession(sessionId: String) {
@@ -467,24 +513,25 @@ class SessionRepositoryImpl(
     }
 
     private fun mergeRacedRecovery(sessionId: String, loaded: List<MessageWithParts>, limit: Int) {
-        val merged = synchronized(messageStateLock) {
+        val leaseGeneration = synchronized(messageStateLock) {
             // Recheck under the lock: a lease may have been released (count removed, state cleared)
             // between the recovery loop and here, so this merge must never recreate an inactive
-            // session that a subsequent lease would then inherit as stale data.
+            // session that a subsequent lease would then inherit as stale data. The current lease
+            // generation is captured as the ownership token for the follow-up pending
+            // reconciliation; the revision bump stays purely message-window race detection.
             if (!canRecover(sessionId) || loaded.isEmpty()) {
-                false
+                null
             } else {
                 mergeLoadedMessages(sessionId, loaded)
                 sessionLoadedLimits[sessionId] = maxOf(sessionLoadedLimits[sessionId] ?: 0, limit)
                 sessionRevisions[sessionId] = (sessionRevisions[sessionId] ?: 0L) + 1
-                true
+                sessionLeaseGenerations[sessionId] ?: 0L
             }
-        }
-        if (!merged) return
+        } ?: return
         AppLog.w(TAG, "Post-reconnect recovery raced SSE repeatedly; merged fetched state for $sessionId")
         scope.launch {
             try {
-                reconcileLoadedPendingState(sessionId, loaded)
+                reconcileLoadedPendingState(sessionId, loaded, leaseGeneration)
             } catch (ce: CancellationException) {
                 throw ce
             } catch (e: Exception) {
@@ -505,7 +552,9 @@ class SessionRepositoryImpl(
             .map { dto -> mapper.mapWrapperToDomain(dto) }
         val outcome = commitReplacementIfUnchanged(sessionId, attempt, loaded)
         if (outcome == CommitOutcome.Committed) {
-            reconcileLoadedPendingState(sessionId, loaded)
+            // The lease generation captured with the attempt is the ownership token: pending
+            // reconciliation may only touch UI state while that lease lifetime is still current.
+            reconcileLoadedPendingState(sessionId, loaded, attempt.leaseGeneration)
         }
         return RecoveryResult(outcome, loaded, attempt.limit)
     }
@@ -521,11 +570,39 @@ class SessionRepositoryImpl(
         return RecoveryAttempt(
             revision = sessionRevisions[sessionId] ?: 0L,
             limit = sessionLoadedLimits[sessionId] ?: DEFAULT_MESSAGE_HISTORY_LIMIT,
+            leaseGeneration = sessionLeaseGenerations[sessionId] ?: 0L,
         )
     }
 
     private fun canRecover(sessionId: String): Boolean =
         sessionId !in recoveryInvalidatedSessions && (sessionConsumerCounts[sessionId] ?: 0) > 0
+
+    /**
+     * True while [leaseGeneration] still owns the session's recovery: the session is actively
+     * leased, not invalidated, and its lease/state-lifetime generation is exactly the one the
+     * recovery captured. Acquire, final release, deletion, and release+reacquire each bump the
+     * generation, so stale recovery work can never pass this check again — while ordinary SSE
+     * message/part mutations (which bump only [sessionRevisions]) never invalidate pending
+     * recovery for the still-current lease.
+     */
+    private fun ownsRecoveryLease(sessionId: String, leaseGeneration: Long): Boolean =
+        synchronized(messageStateLock) {
+            canRecover(sessionId) && (sessionLeaseGenerations[sessionId] ?: 0L) == leaseGeneration
+        }
+
+    /**
+     * Runs [block] atomically under [messageStateLock] only while [leaseGeneration] still owns the
+     * session's recovery, so a lease release cannot interleave between the ownership check and a
+     * recovery-bound UI-state read/create/write. A null token means the caller is not
+     * recovery-bound and runs unguarded, preserving pre-existing behavior. Never call with a
+     * suspending or slow [block]; fetches must happen outside the lock.
+     */
+    private fun <T> withRecoveryOwnership(sessionId: String, leaseGeneration: Long?, block: () -> T): T? {
+        if (leaseGeneration == null) return block()
+        return synchronized(messageStateLock) {
+            if (ownsRecoveryLease(sessionId, leaseGeneration)) block() else null
+        }
+    }
 
     private fun commitReplacement(sessionId: String, attempt: RecoveryAttempt, loaded: List<MessageWithParts>) {
         replaceMessagesAuthoritatively(sessionId, loaded)
@@ -563,19 +640,24 @@ class SessionRepositoryImpl(
         messageState(sessionId).value = loaded
     }
 
-    private suspend fun reconcileLoadedPendingState(sessionId: String, loaded: List<MessageWithParts>) {
+    private suspend fun reconcileLoadedPendingState(
+        sessionId: String,
+        loaded: List<MessageWithParts>,
+        leaseGeneration: Long,
+    ) {
         val hasRunningQuestion = loaded.any { mwp ->
             mwp.parts.any { it is Part.Tool && it.isQuestionTool() && it.state is ToolState.Running }
         }
         if (hasRunningQuestion) {
-            reconcilePendingQuestions(sessionId)
+            reconcilePendingQuestions(sessionId, leaseGeneration)
         }
-        reconcilePendingPermissions(sessionId)
+        reconcilePendingPermissions(sessionId, leaseGeneration)
     }
 
     private data class RecoveryAttempt(
         val revision: Long,
         val limit: Int,
+        val leaseGeneration: Long,
     )
 
     override fun messages(sessionId: SessionId): StateFlow<List<MessageWithParts>> = messageState(
@@ -593,6 +675,9 @@ class SessionRepositoryImpl(
             // Bump the revision so a fetch still in flight from a previous lease can never commit
             // into this new lease.
             sessionRevisions[sessionId.value] = (sessionRevisions[sessionId.value] ?: 0L) + 1
+            // A new lease lifetime begins: pending reconciliation captured under a previous lease
+            // loses ownership and can never write into this one.
+            sessionLeaseGenerations[sessionId.value] = (sessionLeaseGenerations[sessionId.value] ?: 0L) + 1
             sessionConsumerCounts[sessionId.value] = sessionConsumerCounts.getOrDefault(sessionId.value, 0) + 1
         }
         val released = AtomicBoolean(false)
@@ -615,6 +700,8 @@ class SessionRepositoryImpl(
             // Bump rather than delete the revision so a fetch that captured the pre-release revision
             // cannot commit after the lease is gone.
             sessionRevisions[sessionId] = (sessionRevisions[sessionId] ?: 0L) + 1
+            // The state lifetime ends here: in-flight recovery-bound pending work loses ownership.
+            sessionLeaseGenerations[sessionId] = (sessionLeaseGenerations[sessionId] ?: 0L) + 1
             sessionLoadedLimits.remove(sessionId)
             recoveryInvalidatedSessions.remove(sessionId)
             synchronized(sessionUiStates) {
@@ -772,6 +859,7 @@ class SessionRepositoryImpl(
             sessionLoadedLimits.clear()
             sessionConsumerCounts.clear()
             recoveryInvalidatedSessions.clear()
+            sessionLeaseGenerations.clear()
         }
         synchronized(sessionUiStates) { sessionUiStates.clear() }
         synchronized(childToParentSessionIds) { childToParentSessionIds.clear() }
@@ -1093,30 +1181,40 @@ class SessionRepositoryImpl(
         sessionIds.forEach { sessionId -> reconcilePendingPermissions(sessionId) }
     }
 
-    private suspend fun reconcilePendingPermissions(sessionId: String) {
-        val pendingBeforeReconciliation = sessionUiStateFor(sessionId).value.pendingPermissionsByCallId
+    /**
+     * A non-null [leaseGeneration] marks a recovery-bound call; see [reconcilePendingQuestions].
+     * The initial snapshot read is also guarded because [sessionUiStateFor] creates state on
+     * demand, and a recovery that lost ownership must not recreate an evicted session's state.
+     */
+    private suspend fun reconcilePendingPermissions(sessionId: String, leaseGeneration: Long? = null) {
+        val pendingBeforeReconciliation = withRecoveryOwnership(sessionId, leaseGeneration) {
+            sessionUiStateFor(sessionId).value.pendingPermissionsByCallId
+        } ?: return
         val legacyPermissions = runCatching {
             client.listPermissions()
                 .filter { permission -> permission.sessionID == sessionId }
                 .map(PermissionMapper::mapToDomain)
-        }.getOrNull()
+        }.onFailure { if (it is CancellationException) throw it }.getOrNull()
         val permissions = if (!legacyPermissions.isNullOrEmpty()) {
             legacyPermissions
         } else {
             runCatching { client.listSessionPermissionsV2(sessionId).map(PermissionMapper::mapV2ToDomain) }
+                .onFailure { if (it is CancellationException) throw it }
                 .getOrNull()
                 ?: legacyPermissions
                 ?: return
         }
-        updateSession(sessionId) { state ->
-            val recovered = permissions.associateBy { permission -> permission.pendingPermissionKey() }
-            val concurrentlyRemovedKeys = pendingBeforeReconciliation.keys - state.pendingPermissionsByCallId.keys
-            val concurrentlyArrived = state.pendingPermissionsByCallId.filter { (key, permission) ->
-                pendingBeforeReconciliation[key] != permission
+        withRecoveryOwnership(sessionId, leaseGeneration) {
+            updateSession(sessionId) { state ->
+                val recovered = permissions.associateBy { permission -> permission.pendingPermissionKey() }
+                val concurrentlyRemovedKeys = pendingBeforeReconciliation.keys - state.pendingPermissionsByCallId.keys
+                val concurrentlyArrived = state.pendingPermissionsByCallId.filter { (key, permission) ->
+                    pendingBeforeReconciliation[key] != permission
+                }
+                state.copy(
+                    pendingPermissionsByCallId = (recovered - concurrentlyRemovedKeys) + concurrentlyArrived
+                )
             }
-            state.copy(
-                pendingPermissionsByCallId = (recovered - concurrentlyRemovedKeys) + concurrentlyArrived
-            )
         }
     }
 

--- a/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ChatScreen.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ChatScreen.kt
@@ -362,6 +362,7 @@ fun ChatScreen(
                         color = LocalOpenCodeTheme.current.border,
                         thickness = Sizing.strokeThin
                     )
+                    uiState.runNotice?.let { notice -> RunNoticeBanner(notice) }
                     ModelAgentSelectorBar(
                         availableAgents = availableAgents,
                         selectedAgent = selectedAgent,
@@ -704,6 +705,25 @@ internal fun latestAssistantContextUsage(messages: List<MessageWithParts>): Assi
             )
         }
     }
+
+@Composable
+@Suppress("FunctionNaming")
+private fun RunNoticeBanner(message: String) {
+    val theme = LocalOpenCodeTheme.current
+    Surface(
+        color = theme.warning.copy(alpha = 0.15f),
+        shape = RectangleShape,
+    ) {
+        Text(
+            text = "! $message",
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = Spacing.md, vertical = Spacing.sm),
+            style = MaterialTheme.typography.bodySmall,
+            color = theme.warning,
+        )
+    }
+}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ChatViewModel.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ChatViewModel.kt
@@ -32,6 +32,8 @@ import dev.blazelight.p4oc.ui.components.chat.SelectedFile
 import dev.blazelight.p4oc.ui.navigation.Screen
 import dev.blazelight.p4oc.ui.screens.files.upload.UploadCoordinator
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import kotlinx.serialization.SerializationException
@@ -171,9 +173,11 @@ class ChatViewModel constructor(
         const val TAG = "ChatViewModel"
         private const val INITIAL_HISTORY_LIMIT = 100
         private const val HISTORY_PAGE_SIZE = 100
+        private const val HTTP_TOO_MANY_REQUESTS = 429
         private const val KEY_DRAFT_TEXT = "chat_draft_text"
         private const val KEY_ATTACHED_FILES = "chat_attached_files"
         private const val COMMAND_CATALOG_REFRESH_DEBOUNCE_MS = 150L
+        private val RESPONSE_RECONCILIATION_DELAYS_MS = listOf(2_000L, 5_000L, 10_000L, 20_000L)
 
         // SavedState shares Android's Binder transaction budget with the rest of the Activity.
         private const val MAX_PERSISTED_DRAFT_CHARS = 64 * 1024
@@ -395,6 +399,7 @@ class ChatViewModel constructor(
     }
 
     private var lastResponseCompletedToken = 0L
+    private var responseReconciliationJob: Job? = null
 
     private fun applyRepositorySessionState(state: dev.blazelight.p4oc.data.session.SessionUiState) {
         dialogManager.setPermissionsByCallId(state.pendingPermissionsByCallId)
@@ -402,6 +407,7 @@ class ChatViewModel constructor(
 
         val isBusy = state.status is SessionStatus.Busy || state.status is SessionStatus.Retry
         val errorMessage = state.error?.takeUnless { it.isAborted() }?.toHumanMessage()
+        val runNotice = (state.status as? SessionStatus.Retry)?.toHumanMessage()
         _uiState.update {
             it.copy(
                 session = state.session ?: it.session,
@@ -409,10 +415,13 @@ class ChatViewModel constructor(
                 isSending = if (state.status != null) false else it.isSending,
                 todos = state.todos,
                 error = errorMessage ?: it.error,
+                runNotice = runNotice,
             )
         }
 
         if (state.responseCompletedToken > lastResponseCompletedToken) {
+            responseReconciliationJob?.cancel()
+            responseReconciliationJob = null
             lastResponseCompletedToken = state.responseCompletedToken
             if (state.error?.isAborted() != true) {
                 _hasUnreadResponse.value = !_isActiveTab.value
@@ -437,7 +446,7 @@ class ChatViewModel constructor(
             return
         }
 
-        _uiState.update { it.copy(isSending = true) }
+        _uiState.update { it.copy(isSending = true, error = null, runNotice = null) }
         viewModelScope.launch {
             val validatedFiles = filePickerManager.validateAttachedFiles()
             if (validatedFiles.any { !it.available }) {
@@ -450,6 +459,7 @@ class ChatViewModel constructor(
     }
 
     private suspend fun sendValidatedMessage(text: String, attachedFiles: List<SelectedFile>) {
+        val knownMessageIds = messages.value.mapTo(mutableSetOf()) { it.message.id }
         val selectedAgent = modelAgentManager.selectedAgent.value
         val selectedModel = modelAgentManager.selectedModel.value
         val selectedVariant = modelAgentManager.currentReasoningEffort()
@@ -467,7 +477,11 @@ class ChatViewModel constructor(
         val result = sessionRepository.sendMessageAsync(SessionId(sessionId), request).await().toApiResult()
         when (result) {
             is ApiResult.Success -> {
-                _uiState.update { it.copy(isSending = false, isBusy = true) }
+                sessionRepository.acceptEvent(
+                    OpenCodeEvent.SessionStatusChanged(sessionId, SessionStatus.Busy)
+                )
+                _uiState.update { it.copy(isSending = false, isBusy = true, runNotice = null) }
+                startResponseReconciliation(knownMessageIds)
                 AppLog.d(TAG, "sendMessage: Async call succeeded, waiting for SSE events")
             }
             is ApiResult.Error -> {
@@ -479,6 +493,81 @@ class ChatViewModel constructor(
                 }
                 updateInput(text)
                 filePickerManager.restoreAttachedFiles(attachedFiles)
+            }
+        }
+    }
+
+    private fun startResponseReconciliation(knownMessageIds: Set<String>) {
+        responseReconciliationJob?.cancel()
+        responseReconciliationJob = viewModelScope.launch {
+            var lastNewAssistant: MessageWithParts? = null
+            var observedRetry = false
+
+            RESPONSE_RECONCILIATION_DELAYS_MS.forEach { delayMs ->
+                delay(delayMs)
+                if (!_uiState.value.isBusy) return@launch
+
+                val status = runCatching {
+                    workspaceClient.getSessionStatuses(workspaceClient.workspace.directory)[sessionId]
+                }.getOrNull()?.let(SessionMapper::mapStatusToDomain)
+
+                if (status != null) {
+                    sessionRepository.acceptEvent(OpenCodeEvent.SessionStatusChanged(sessionId, status))
+                    observedRetry = observedRetry || status is SessionStatus.Retry
+                }
+
+                runCatching {
+                    sessionRepository.loadMessages(SessionId(sessionId), INITIAL_HISTORY_LIMIT)
+                }
+                lastNewAssistant = messages.value.asReversed().firstOrNull { messageWithParts ->
+                    messageWithParts.message.id !in knownMessageIds &&
+                        messageWithParts.message is Message.Assistant
+                } ?: lastNewAssistant
+
+                if (reconcileCompletedAssistant(lastNewAssistant, status)) return@launch
+            }
+
+            if (!_uiState.value.isBusy) return@launch
+            if (!observedRetry) {
+                _uiState.update {
+                    it.copy(
+                        runNotice = "No completion update was received. " +
+                            "The run may still be active; stop it before retrying.",
+                    )
+                }
+            }
+        }
+    }
+
+    private fun reconcileCompletedAssistant(
+        messageWithParts: MessageWithParts?,
+        status: SessionStatus?,
+    ): Boolean {
+        val assistant = messageWithParts?.message as? Message.Assistant
+        return when {
+            assistant == null -> false
+            assistant.error != null -> {
+                sessionRepository.acceptEvent(OpenCodeEvent.SessionError(sessionId, assistant.error))
+                true
+            }
+            assistant.completedAt == null && status !is SessionStatus.Idle -> false
+            messageWithParts.parts.isEmpty() -> {
+                sessionRepository.acceptEvent(
+                    OpenCodeEvent.SessionError(
+                        sessionId,
+                        MessageError(
+                            name = "EmptyResponseError",
+                            message = "The model completed without returning content",
+                        ),
+                    )
+                )
+                true
+            }
+            else -> {
+                sessionRepository.acceptEvent(
+                    OpenCodeEvent.SessionStatusChanged(sessionId, SessionStatus.Idle)
+                )
+                true
             }
         }
     }
@@ -781,8 +870,10 @@ class ChatViewModel constructor(
         viewModelScope.launch {
             when (val result = sessionRepository.abortSession(SessionId(sessionId)).await().toApiResult()) {
                 is ApiResult.Success -> {
+                    responseReconciliationJob?.cancel()
+                    responseReconciliationJob = null
                     sessionRepository.clearStreamingFlags(SessionId(sessionId))
-                    _uiState.update { it.copy(isBusy = false, isSending = false) }
+                    _uiState.update { it.copy(isBusy = false, isSending = false, runNotice = null) }
                 }
                 is ApiResult.Error -> _uiState.update {
                     it.copy(error = "Could not stop the run. Try again.")
@@ -792,14 +883,40 @@ class ChatViewModel constructor(
     }
 
     override fun onCleared() {
+        responseReconciliationJob?.cancel()
         sessionLease.close()
         super.onCleared()
     }
 
     private fun dev.blazelight.p4oc.domain.model.MessageError.toHumanMessage(): String = when {
         name == "ProviderAuthError" -> "Provider authentication required"
+        isUsageLimit() -> "Model usage limit reached. Try again later or choose another model."
+        name == "EmptyResponseError" ->
+            "The model returned no response. The provider may be unavailable or rate-limited."
         isRetryable -> "The request failed temporarily. Try again."
         else -> "The run failed. Try again."
+    }
+
+    private fun dev.blazelight.p4oc.domain.model.MessageError.isUsageLimit(): Boolean =
+        statusCode == HTTP_TOO_MANY_REQUESTS ||
+            message.containsUsageLimitMarker() ||
+            responseBody.containsUsageLimitMarker()
+
+    private fun SessionStatus.Retry.toHumanMessage(): String =
+        if (message.containsUsageLimitMarker()) {
+            "Model usage limit reached. OpenCode is retrying${attemptLabel()}."
+        } else {
+            "The model request failed temporarily. OpenCode is retrying${attemptLabel()}."
+        }
+
+    private fun SessionStatus.Retry.attemptLabel(): String =
+        if (attempt > 0) " (attempt $attempt)" else ""
+
+    private fun String?.containsUsageLimitMarker(): Boolean {
+        val normalized = this?.lowercase().orEmpty()
+        return "rate limit" in normalized || "rate-limit" in normalized ||
+            "too many requests" in normalized || "status 429" in normalized ||
+            "free usage exceeded" in normalized || "free limit" in normalized
     }
 
     private fun <T> Result<T>.toApiResult(): ApiResult<T> = fold(
@@ -823,6 +940,7 @@ data class ChatUiState(
     val isSending: Boolean = false,
     val isBusy: Boolean = false,
     val error: String? = null,
+    val runNotice: String? = null,
     val commands: List<Command> = emptyList(),
     val isLoadingCommands: Boolean = false,
     val hasLoadedWorkspaceCommands: Boolean = false,

--- a/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ChatViewModel.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ChatViewModel.kt
@@ -31,6 +31,7 @@ import dev.blazelight.p4oc.domain.session.SessionId
 import dev.blazelight.p4oc.ui.components.chat.SelectedFile
 import dev.blazelight.p4oc.ui.navigation.Screen
 import dev.blazelight.p4oc.ui.screens.files.upload.UploadCoordinator
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -178,6 +179,8 @@ class ChatViewModel constructor(
         private const val KEY_ATTACHED_FILES = "chat_attached_files"
         private const val COMMAND_CATALOG_REFRESH_DEBOUNCE_MS = 150L
         private val RESPONSE_RECONCILIATION_DELAYS_MS = listOf(2_000L, 5_000L, 10_000L, 20_000L)
+        private const val RUN_STALLED_NOTICE = "No completion update was received. " +
+            "The run may still be active; stop it before retrying."
 
         // SavedState shares Android's Binder transaction budget with the rest of the Activity.
         private const val MAX_PERSISTED_DRAFT_CHARS = 64 * 1024
@@ -399,27 +402,52 @@ class ChatViewModel constructor(
     }
 
     private var lastResponseCompletedToken = 0L
+    private var hasResponseTokenBaseline = false
     private var responseReconciliationJob: Job? = null
+
+    // True from the moment a send clears the previous run's UI error until the run is confirmed
+    // active (Busy/Retry) or reaches a genuine terminal boundary. While set, repository emissions
+    // that still carry the previous run's error (todos, permissions, session updates arriving
+    // before the synthetic Busy clears it) must not flicker that stale error back into the UI.
+    private var suppressStaleRunErrors = false
 
     private fun applyRepositorySessionState(state: dev.blazelight.p4oc.data.session.SessionUiState) {
         dialogManager.setPermissionsByCallId(state.pendingPermissionsByCallId)
         dialogManager.setPendingQuestion(state.pendingQuestion)
 
         val isBusy = state.status is SessionStatus.Busy || state.status is SessionStatus.Retry
+        val isTerminalTransition = hasResponseTokenBaseline &&
+            state.responseCompletedToken > lastResponseCompletedToken
+        if (!hasResponseTokenBaseline) {
+            // The first collected repository state is the subscription snapshot, not a fresh
+            // completion: adopt its token as the baseline so a token accumulated before this
+            // ViewModel attached (e.g. a run completed in another tab holding the same session)
+            // can never fire a spurious completion haptic/unread badge or act as a false
+            // terminal boundary for notices and the bounded poll.
+            hasResponseTokenBaseline = true
+            lastResponseCompletedToken = state.responseCompletedToken
+        }
+        if (isBusy || isTerminalTransition) {
+            // The run is confirmed active (its Busy transition already cleared the previous run's
+            // repository error) or has genuinely completed (a fresh terminal error is real, not
+            // stale). Either way, stale-error suppression for the in-flight send ends now, before
+            // the error below is computed.
+            suppressStaleRunErrors = false
+        }
         val errorMessage = state.error?.takeUnless { it.isAborted() }?.toHumanMessage()
-        val runNotice = (state.status as? SessionStatus.Retry)?.toHumanMessage()
+        val retryNotice = (state.status as? SessionStatus.Retry)?.toHumanMessage()
         _uiState.update {
             it.copy(
                 session = state.session ?: it.session,
                 isBusy = isBusy,
                 isSending = if (state.status != null) false else it.isSending,
                 todos = state.todos,
-                error = errorMessage ?: it.error,
-                runNotice = runNotice,
+                error = if (suppressStaleRunErrors) it.error else errorMessage ?: it.error,
+                runNotice = resolveRunNotice(it.runNotice, retryNotice, isTerminalTransition, isBusy),
             )
         }
 
-        if (state.responseCompletedToken > lastResponseCompletedToken) {
+        if (isTerminalTransition) {
             responseReconciliationJob?.cancel()
             responseReconciliationJob = null
             lastResponseCompletedToken = state.responseCompletedToken
@@ -435,6 +463,23 @@ class ChatViewModel constructor(
         hapticFeedback.vibrate(settings.vibrationPattern)
     }
 
+    private fun resolveRunNotice(
+        current: String?,
+        retryNotice: String?,
+        isTerminalTransition: Boolean,
+        isBusy: Boolean,
+    ): String? = when {
+        // A terminal boundary (completion, stop, or terminal error) retires any notice.
+        isTerminalTransition -> null
+        retryNotice != null -> retryNotice
+        // The bounded poll's stalled-run warning stays visible across unrelated repository
+        // emissions (todos, permissions, session updates) while the run remains busy; only
+        // send/stop/terminal boundaries clear it. A non-busy emission also retires it: the
+        // warning ("the run may still be active") is meaningless once the run is not running.
+        isBusy && current == RUN_STALLED_NOTICE -> current
+        else -> null
+    }
+
     // --- Message sending ---
 
     fun sendMessage() {
@@ -446,10 +491,16 @@ class ChatViewModel constructor(
             return
         }
 
+        // A replacement send must supersede any in-flight reconciliation from a prior send so the
+        // old poll can never reconcile the wrong assistant/status against the new run.
+        responseReconciliationJob?.cancel()
+        responseReconciliationJob = null
+        suppressStaleRunErrors = true
         _uiState.update { it.copy(isSending = true, error = null, runNotice = null) }
         viewModelScope.launch {
             val validatedFiles = filePickerManager.validateAttachedFiles()
             if (validatedFiles.any { !it.available }) {
+                suppressStaleRunErrors = false
                 _uiState.update { it.copy(error = UNAVAILABLE_ATTACHMENTS_ERROR, isSending = false) }
                 return@launch
             }
@@ -485,6 +536,7 @@ class ChatViewModel constructor(
                 AppLog.d(TAG, "sendMessage: Async call succeeded, waiting for SSE events")
             }
             is ApiResult.Error -> {
+                suppressStaleRunErrors = false
                 _uiState.update {
                     it.copy(
                         isSending = false,
@@ -509,15 +561,21 @@ class ChatViewModel constructor(
 
                 val status = runCatching {
                     workspaceClient.getSessionStatuses(workspaceClient.workspace.directory)[sessionId]
+                }.onFailure { error ->
+                    if (error is CancellationException) throw error
                 }.getOrNull()?.let(SessionMapper::mapStatusToDomain)
+                observedRetry = observedRetry || status is SessionStatus.Retry
 
-                if (status != null) {
-                    sessionRepository.acceptEvent(OpenCodeEvent.SessionStatusChanged(sessionId, status))
-                    observedRetry = observedRetry || status is SessionStatus.Retry
-                }
-
+                // Reconcile canonical messages BEFORE publishing any status. A terminal Idle
+                // published first bumps responseCompletedToken, whose collector cancels this very
+                // job while the recovery fetch is still in flight — the run then ends with the
+                // completed assistant reachable only via REST and no user-facing explanation.
+                // The repository's canonical active-lease, revision-safe recovery primitive is
+                // reused rather than a second message buffer or an unsafe overwrite path.
                 runCatching {
-                    sessionRepository.loadMessages(SessionId(sessionId), INITIAL_HISTORY_LIMIT)
+                    sessionRepository.reconcileMessages(SessionId(sessionId))
+                }.onFailure { error ->
+                    if (error is CancellationException) throw error
                 }
                 lastNewAssistant = messages.value.asReversed().firstOrNull { messageWithParts ->
                     messageWithParts.message.id !in knownMessageIds &&
@@ -525,16 +583,18 @@ class ChatViewModel constructor(
                 } ?: lastNewAssistant
 
                 if (reconcileCompletedAssistant(lastNewAssistant, status)) return@launch
+
+                // No assistant completed yet: only non-terminal statuses may be published. A REST
+                // Idle with no new assistant must not terminate the run (or cancel this poll);
+                // keep polling until an assistant appears or the bounded window is exhausted.
+                if (status is SessionStatus.Busy || status is SessionStatus.Retry) {
+                    sessionRepository.acceptEvent(OpenCodeEvent.SessionStatusChanged(sessionId, status))
+                }
             }
 
             if (!_uiState.value.isBusy) return@launch
             if (!observedRetry) {
-                _uiState.update {
-                    it.copy(
-                        runNotice = "No completion update was received. " +
-                            "The run may still be active; stop it before retrying.",
-                    )
-                }
+                _uiState.update { it.copy(runNotice = RUN_STALLED_NOTICE) }
             }
         }
     }
@@ -546,6 +606,12 @@ class ChatViewModel constructor(
         val assistant = messageWithParts?.message as? Message.Assistant
         return when {
             assistant == null -> false
+            // An authoritative Busy/Retry just fetched from REST means nothing terminal was
+            // missed: multi-step runs emit one assistant message per step, so a completed
+            // intermediate assistant mid-run must never synthesize a terminal Idle/Error (false
+            // completion haptic, unread badge, poll cancellation). The caller republishes the
+            // non-terminal status and keeps polling.
+            status is SessionStatus.Busy || status is SessionStatus.Retry -> false
             assistant.error != null -> {
                 sessionRepository.acceptEvent(OpenCodeEvent.SessionError(sessionId, assistant.error))
                 true

--- a/app/src/test/java/dev/blazelight/p4oc/core/network/OpenCodeEventSourceTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/core/network/OpenCodeEventSourceTest.kt
@@ -19,13 +19,13 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.json.Json
 import okhttp3.OkHttpClient
-import java.util.concurrent.atomic.AtomicInteger
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import java.util.concurrent.atomic.AtomicInteger
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class OpenCodeEventSourceTest {

--- a/app/src/test/java/dev/blazelight/p4oc/data/remote/mapper/EventMapperTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/data/remote/mapper/EventMapperTest.kt
@@ -474,6 +474,28 @@ class EventMapperTest {
         assertEquals("anthropic", (event as OpenCodeEvent.SessionError).error?.providerID)
     }
 
+    @Test
+    fun `maps session_error retry metadata for rate limit feedback`() {
+        val properties = buildJsonObject {
+            put("sessionID", "sess-1")
+            putJsonObject("error") {
+                put("name", "APIError")
+                putJsonObject("data") {
+                    put("message", "Rate limit exceeded")
+                    put("statusCode", 429)
+                    put("isRetryable", true)
+                }
+            }
+        }
+
+        val event = eventMapper.mapToEvent(EventDataDto(type = "session.error", properties = properties))
+
+        assertTrue(event is OpenCodeEvent.SessionError)
+        val error = (event as OpenCodeEvent.SessionError).error
+        assertEquals(429, error?.statusCode)
+        assertTrue(error?.isRetryable == true)
+    }
+
     // ── Unknown type ────────────────────────────────────────────────────────
 
     @Test

--- a/app/src/test/java/dev/blazelight/p4oc/data/remote/mapper/EventMapperTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/data/remote/mapper/EventMapperTest.kt
@@ -496,6 +496,26 @@ class EventMapperTest {
         assertTrue(error?.isRetryable == true)
     }
 
+    @Test
+    fun `maps session_error without retry metadata as non retryable`() {
+        val properties = buildJsonObject {
+            put("sessionID", "sess-1")
+            putJsonObject("error") {
+                put("name", "APIError")
+                putJsonObject("data") {
+                    put("message", "hard failure")
+                }
+            }
+        }
+
+        val event = eventMapper.mapToEvent(EventDataDto(type = "session.error", properties = properties))
+
+        assertTrue(event is OpenCodeEvent.SessionError)
+        val error = (event as OpenCodeEvent.SessionError).error
+        assertNull(error?.statusCode)
+        assertFalse(error?.isRetryable ?: true)
+    }
+
     // ── Unknown type ────────────────────────────────────────────────────────
 
     @Test

--- a/app/src/test/java/dev/blazelight/p4oc/data/session/SessionRepositoryImplTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/data/session/SessionRepositoryImplTest.kt
@@ -712,6 +712,74 @@ class SessionRepositoryImplTest {
     }
 
     @Test
+    fun `equivalent duplicate terminal error does not complete twice`() = runTest {
+        val repository =
+            SessionRepositoryImpl(FakeWorkspaceClient(), dispatcher = StandardTestDispatcher(testScheduler))
+        repository.acceptEvent(OpenCodeEvent.SessionStatusChanged("s1", SessionStatus.Busy))
+        val error = MessageError(name = "APIError", message = "Rate limit exceeded", statusCode = 429)
+
+        // The assistant message carries the error, then a separate session.error event reports the
+        // same failure. Both must converge on one terminal completion, not two.
+        repository.acceptEvent(OpenCodeEvent.MessageUpdated(assistantMessage("m1", "s1", error)))
+        repository.acceptEvent(OpenCodeEvent.SessionError("s1", error))
+
+        val state = repository.sessionUiState(SessionId("s1")).value
+        assertEquals(SessionStatus.Idle, state.status)
+        assertEquals(error, state.error)
+        assertEquals(1L, state.responseCompletedToken)
+    }
+
+    @Test
+    fun `fresh busy status clears a prior run error`() = runTest {
+        val repository =
+            SessionRepositoryImpl(FakeWorkspaceClient(), dispatcher = StandardTestDispatcher(testScheduler))
+        repository.acceptEvent(
+            OpenCodeEvent.SessionError("s1", MessageError(name = "APIError", message = "boom"))
+        )
+
+        repository.acceptEvent(OpenCodeEvent.SessionStatusChanged("s1", SessionStatus.Busy))
+
+        val state = repository.sessionUiState(SessionId("s1")).value
+        assertEquals(SessionStatus.Busy, state.status)
+        assertNull(state.error)
+    }
+
+    @Test
+    fun `terminal idle status preserves a just delivered error`() = runTest {
+        val repository =
+            SessionRepositoryImpl(FakeWorkspaceClient(), dispatcher = StandardTestDispatcher(testScheduler))
+        val error = MessageError(name = "APIError", message = "Rate limit exceeded", statusCode = 429)
+        repository.acceptEvent(OpenCodeEvent.SessionStatusChanged("s1", SessionStatus.Busy))
+
+        repository.acceptEvent(OpenCodeEvent.SessionError("s1", error))
+        // A trailing terminal idle/status update must not erase the error the user was just shown.
+        repository.acceptEvent(OpenCodeEvent.SessionStatusChanged("s1", SessionStatus.Idle))
+
+        val state = repository.sessionUiState(SessionId("s1")).value
+        assertEquals(SessionStatus.Idle, state.status)
+        assertEquals(error, state.error)
+        // The error already completed the run; the trailing Idle must neither erase the error nor
+        // fire a second completion (double haptic/unread badge).
+        assertEquals(1L, state.responseCompletedToken)
+    }
+
+    @Test
+    fun `trailing session idle event after a terminal error does not complete twice`() = runTest {
+        val repository =
+            SessionRepositoryImpl(FakeWorkspaceClient(), dispatcher = StandardTestDispatcher(testScheduler))
+        val error = MessageError(name = "APIError", message = "Rate limit exceeded", statusCode = 429)
+        repository.acceptEvent(OpenCodeEvent.SessionStatusChanged("s1", SessionStatus.Busy))
+        repository.acceptEvent(OpenCodeEvent.SessionError("s1", error))
+
+        repository.acceptEvent(OpenCodeEvent.SessionIdle("s1"))
+
+        val state = repository.sessionUiState(SessionId("s1")).value
+        assertEquals(SessionStatus.Idle, state.status)
+        assertEquals(error, state.error)
+        assertEquals(1L, state.responseCompletedToken)
+    }
+
+    @Test
     fun `permission request without callID is still exposed in session UI state`() = runTest {
         val client = FakeWorkspaceClient().apply {
             projects = emptyList()

--- a/app/src/test/java/dev/blazelight/p4oc/data/session/SessionRepositoryImplTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/data/session/SessionRepositoryImplTest.kt
@@ -697,6 +697,21 @@ class SessionRepositoryImplTest {
     }
 
     @Test
+    fun `assistant message error terminates busy session without separate session error event`() = runTest {
+        val repository =
+            SessionRepositoryImpl(FakeWorkspaceClient(), dispatcher = StandardTestDispatcher(testScheduler))
+        repository.acceptEvent(OpenCodeEvent.SessionStatusChanged("s1", SessionStatus.Busy))
+        val error = MessageError(name = "APIError", message = "Rate limit exceeded", statusCode = 429)
+
+        repository.acceptEvent(OpenCodeEvent.MessageUpdated(assistantMessage("m1", "s1", error)))
+
+        val state = repository.sessionUiState(SessionId("s1")).value
+        assertEquals(SessionStatus.Idle, state.status)
+        assertEquals(error, state.error)
+        assertEquals(1L, state.responseCompletedToken)
+    }
+
+    @Test
     fun `permission request without callID is still exposed in session UI state`() = runTest {
         val client = FakeWorkspaceClient().apply {
             projects = emptyList()
@@ -767,7 +782,11 @@ class SessionRepositoryImplTest {
         updatedAt = 1L,
     )
 
-    private fun assistantMessage(id: String, sessionId: String): Message.Assistant = Message.Assistant(
+    private fun assistantMessage(
+        id: String,
+        sessionId: String,
+        error: MessageError? = null,
+    ): Message.Assistant = Message.Assistant(
         id = id,
         sessionID = sessionId,
         createdAt = 1L,
@@ -778,6 +797,7 @@ class SessionRepositoryImplTest {
         agent = "assistant",
         cost = 0.0,
         tokens = TokenUsage(input = 0, output = 0),
+        error = error,
     )
 
     private fun textPart(id: String, messageId: String, sessionId: String, text: String): Part.Text = Part.Text(

--- a/app/src/test/java/dev/blazelight/p4oc/data/session/SessionRepositoryRecoveryTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/data/session/SessionRepositoryRecoveryTest.kt
@@ -6,6 +6,8 @@ import dev.blazelight.p4oc.data.remote.dto.MessageInfoDto
 import dev.blazelight.p4oc.data.remote.dto.MessageTimeDto
 import dev.blazelight.p4oc.data.remote.dto.MessageWrapperDto
 import dev.blazelight.p4oc.data.remote.dto.PartDto
+import dev.blazelight.p4oc.data.remote.dto.PermissionDto
+import dev.blazelight.p4oc.data.remote.dto.PermissionToolDto
 import dev.blazelight.p4oc.data.remote.mapper.MessageMapper
 import dev.blazelight.p4oc.data.server.ActiveServerApiProvider
 import dev.blazelight.p4oc.data.workspace.WorkspaceClient
@@ -23,10 +25,12 @@ import io.mockk.mockk
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -300,6 +304,135 @@ class SessionRepositoryRecoveryTest {
         assertTrue(repo.messages(sessionId).value.isEmpty())
     }
 
+    @Test
+    fun `reconcileMessages uses the remembered authoritative window for an active session`() = runTest {
+        val (repo, api, _) = repository(testScheduler)
+        val lease = repo.acquireSession(sessionId)
+        coEvery { api.getMessages("s1", 200, null, "/test", null) } returns (1L..200L)
+            .map { assistantWrapper("m$it", createdAt = it, partText = "x") }
+        repo.loadMessages(sessionId, 200)
+        advanceUntilIdle()
+
+        coEvery { api.getMessages("s1", 200, null, "/test", null) } returns (1L..200L)
+            .map { assistantWrapper("m$it", createdAt = it, partText = "reconciled") }
+
+        repo.reconcileMessages(sessionId)
+        advanceUntilIdle()
+
+        // The explicit entry point reuses the largest loaded window, never a default-100 call.
+        coVerify(exactly = 2) { api.getMessages("s1", 200, null, "/test", null) }
+        coVerify(exactly = 0) { api.getMessages("s1", 100, null, "/test", null) }
+        val part = repo.messages(sessionId).value.first().parts.single() as Part.Text
+        assertEquals("reconciled", part.text)
+        lease.close()
+    }
+
+    @Test
+    fun `reconcileMessages is a no-op after the lease is released`() = runTest {
+        val (repo, api, _) = repository(testScheduler)
+        val lease = repo.acquireSession(sessionId)
+        repo.acceptEvent(OpenCodeEvent.MessageUpdated(assistantMessage("m1", createdAt = 1)))
+        advanceUntilIdle()
+        lease.close()
+
+        coEvery { api.getMessages("s1", 100, null, "/test", null) } returns listOf(
+            assistantWrapper("m2", createdAt = 2, partText = "should-not-commit"),
+        )
+
+        repo.reconcileMessages(sessionId)
+        advanceUntilIdle()
+
+        // No active lease means no fetch and no state resurrection.
+        coVerify(exactly = 0) { api.getMessages(any(), any(), any(), any(), any()) }
+        assertTrue(repo.messages(sessionId).value.isEmpty())
+    }
+
+    @Test
+    fun `reconcileMessages is a no-op after the session is deleted`() = runTest {
+        val (repo, api, _) = repository(testScheduler)
+        repo.acquireSession(sessionId)
+        repo.acceptEvent(OpenCodeEvent.MessageUpdated(assistantMessage("m1", createdAt = 1)))
+        advanceUntilIdle()
+
+        repo.acceptEvent(OpenCodeEvent.SessionDeleted(session("s1")))
+        advanceUntilIdle()
+
+        coEvery { api.getMessages("s1", 100, null, "/test", null) } returns listOf(
+            assistantWrapper("m2", createdAt = 2, partText = "should-not-commit"),
+        )
+
+        repo.reconcileMessages(sessionId)
+        advanceUntilIdle()
+
+        // A deleted session must never be refetched or repopulated even while its lease is held.
+        coVerify(exactly = 0) { api.getMessages(any(), any(), any(), any(), any()) }
+        assertTrue(repo.messages(sessionId).value.isEmpty())
+    }
+
+    @Test
+    fun `release and reacquire during gated pending reconciliation does not resurrect stale permissions`() = runTest {
+        val (repo, api, _) = repository(testScheduler)
+        val firstLease = repo.acquireSession(sessionId)
+        coEvery { api.getMessages("s1", 100, null, "/test", null) } returns listOf(
+            assistantWrapper("m1", createdAt = 1, partText = "recovered"),
+        )
+        // Gate the recovery-bound permission fetch so the lease can flip while it is in flight.
+        val permissionGate = CompletableDeferred<Unit>()
+        coEvery { api.listPermissions("/test", null) } coAnswers {
+            permissionGate.await()
+            listOf(permissionDto("perm-stale"))
+        }
+
+        val recovery = launch { repo.reconcileMessages(sessionId) }
+        advanceUntilIdle()
+
+        // The message window has committed; recovery is now suspended in the gated permission
+        // fetch. Flip the lease underneath it.
+        firstLease.close()
+        val secondLease = repo.acquireSession(sessionId)
+
+        permissionGate.complete(Unit)
+        advanceUntilIdle()
+        recovery.join()
+
+        // The old recovery's pending work lost ownership at release; it must not recreate
+        // pending-permission UI state for the reopened lease.
+        assertTrue(repo.sessionUiState(sessionId).value.pendingPermissionsByCallId.isEmpty())
+        secondLease.close()
+    }
+
+    @Test
+    fun `sse mutation during gated pending reconciliation still delivers the permission to the current lease`() =
+        runTest {
+            val (repo, api, _) = repository(testScheduler)
+            val lease = repo.acquireSession(sessionId)
+            coEvery { api.getMessages("s1", 100, null, "/test", null) } returns listOf(
+                assistantWrapper("m1", createdAt = 1, partText = "recovered"),
+            )
+            // Gate the recovery-bound permission fetch so ordinary SSE traffic can land mid-flight.
+            val permissionGate = CompletableDeferred<Unit>()
+            coEvery { api.listPermissions("/test", null) } coAnswers {
+                permissionGate.await()
+                listOf(permissionDto("perm-live"))
+            }
+
+            val recovery = launch { repo.reconcileMessages(sessionId) }
+            advanceUntilIdle()
+
+            // An ordinary SSE message mutation arrives while the permission fetch is in flight. It
+            // bumps the message revision but must NOT invalidate pending recovery for the
+            // still-current lease — only a lease/state-lifetime change may do that.
+            repo.acceptEvent(OpenCodeEvent.MessageUpdated(assistantMessage("m2", createdAt = 2)))
+
+            permissionGate.complete(Unit)
+            advanceUntilIdle()
+            recovery.join()
+
+            // The lease never changed, so the recovered permission is delivered.
+            assertEquals(1, repo.sessionUiState(sessionId).value.pendingPermissionsByCallId.size)
+            lease.close()
+        }
+
     private fun session(id: String) = dev.blazelight.p4oc.domain.model.Session(
         id = id,
         projectID = "project-$id",
@@ -308,6 +441,16 @@ class SessionRepositoryRecoveryTest {
         version = "1",
         createdAt = 1L,
         updatedAt = 1L,
+    )
+
+    private fun permissionDto(id: String): PermissionDto = PermissionDto(
+        id = id,
+        permission = "bash",
+        patterns = emptyList(),
+        sessionID = "s1",
+        metadata = JsonObject(emptyMap()),
+        always = emptyList(),
+        tool = PermissionToolDto(messageID = "m1", callID = "call-$id"),
     )
 
     private fun repository(

--- a/app/src/test/java/dev/blazelight/p4oc/fakes/FakeSessionRepository.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/fakes/FakeSessionRepository.kt
@@ -63,6 +63,8 @@ class FakeSessionRepository(
 
     override suspend fun loadMessages(sessionId: SessionId, limit: Int): Int = 0
 
+    override suspend fun reconcileMessages(sessionId: SessionId) = Unit
+
     override fun sendMessageAsync(sessionId: SessionId, request: SendMessageRequest): Deferred<Result<Unit>> =
         CompletableDeferred(Result.success(Unit))
 

--- a/app/src/test/java/dev/blazelight/p4oc/ui/screens/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/ui/screens/chat/ChatViewModelTest.kt
@@ -21,12 +21,14 @@ import dev.blazelight.p4oc.data.remote.dto.RevertSessionRequest
 import dev.blazelight.p4oc.data.remote.dto.SendMessageRequest
 import dev.blazelight.p4oc.data.remote.dto.SessionDto
 import dev.blazelight.p4oc.data.remote.dto.SessionRevertDto
+import dev.blazelight.p4oc.data.remote.dto.SessionStatusDto
 import dev.blazelight.p4oc.data.remote.dto.TimeDto
 import dev.blazelight.p4oc.data.remote.mapper.MessageMapper
 import dev.blazelight.p4oc.data.server.ActiveServerApiProvider
 import dev.blazelight.p4oc.data.session.SessionRepositoryImpl
 import dev.blazelight.p4oc.data.workspace.WorkspaceClient
 import dev.blazelight.p4oc.domain.model.Message
+import dev.blazelight.p4oc.domain.model.MessageError
 import dev.blazelight.p4oc.domain.model.MessageWithParts
 import dev.blazelight.p4oc.domain.model.OpenCodeEvent
 import dev.blazelight.p4oc.domain.model.Part
@@ -81,6 +83,7 @@ import retrofit2.HttpException
 import retrofit2.Response
 
 @OptIn(ExperimentalCoroutinesApi::class)
+@Suppress("LargeClass")
 class ChatViewModelTest {
 
     @get:Rule
@@ -274,6 +277,49 @@ class ChatViewModelTest {
     }
 
     @Test
+    fun sessionStatusChanged_usageLimitRetry_explainsWhyRunIsWaiting() = runTest {
+        val vm = createViewModel()
+
+        emitEvent(
+            OpenCodeEvent.SessionStatusChanged(
+                "session-1",
+                SessionStatus.Retry(
+                    attempt = 2,
+                    message = "Free usage exceeded, subscribe to Go",
+                    next = 0L,
+                ),
+            )
+        )
+        advanceUntilIdle()
+
+        assertTrue(vm.uiState.value.isBusy)
+        assertEquals(
+            "Model usage limit reached. OpenCode is retrying (attempt 2).",
+            vm.uiState.value.runNotice,
+        )
+    }
+
+    @Test
+    fun sessionError_rateLimitExplainsFailure_andClearsBusyState() = runTest {
+        val vm = createViewModel()
+        emitEvent(OpenCodeEvent.SessionStatusChanged("session-1", SessionStatus.Busy))
+
+        emitEvent(
+            OpenCodeEvent.SessionError(
+                "session-1",
+                MessageError(name = "APIError", message = "Rate limit exceeded", statusCode = 429),
+            )
+        )
+        advanceUntilIdle()
+
+        assertFalse(vm.uiState.value.isBusy)
+        assertEquals(
+            "Model usage limit reached. Try again later or choose another model.",
+            vm.uiState.value.error,
+        )
+    }
+
+    @Test
     fun sessionStatusChanged_idle_clearsStreamingFlags() = runTest {
         val vm = createViewModel()
         emitEvent(OpenCodeEvent.MessageUpdated(assistantMessage(id = "m1", sessionId = "session-1", createdAt = 1)))
@@ -410,6 +456,33 @@ class ChatViewModelTest {
         assertEquals("", vm.uiState.value.inputText)
         assertFalse(vm.uiState.value.isSending)
         assertTrue(vm.uiState.value.isBusy)
+    }
+
+    @Test
+    fun sendMessage_reconcilesEmptyCompletedResponse_whenTerminalSseIsMissing() = runTest {
+        coEvery { api.getMessages("session-1", 100, null, "/test", null) } returnsMany listOf(
+            emptyList(),
+            listOf(
+                userMessageDto("user-new", createdAt = 10),
+                assistantMessageDto("assistant-empty", createdAt = 11, completedAt = 12),
+            ),
+        )
+        coEvery { api.getSessionStatuses("/test", null) } returns mapOf(
+            "session-1" to SessionStatusDto(type = "idle")
+        )
+        coEvery { api.sendMessageAsync(any(), any(), any(), null) } returns Unit
+        val vm = createViewModel()
+        vm.updateInput("hello")
+
+        vm.sendMessage()
+        advanceUntilIdle()
+
+        assertFalse(vm.uiState.value.isBusy)
+        assertEquals(
+            "The model returned no response. The provider may be unavailable or rate-limited.",
+            vm.uiState.value.error,
+        )
+        assertEquals(listOf("user-new", "assistant-empty"), vm.currentMessages().map { it.message.id })
     }
 
     @Test
@@ -686,12 +759,16 @@ class ChatViewModelTest {
         )
     }
 
-    private fun assistantMessageDto(id: String, createdAt: Long): MessageWrapperDto {
+    private fun assistantMessageDto(
+        id: String,
+        createdAt: Long,
+        completedAt: Long? = null,
+    ): MessageWrapperDto {
         return MessageWrapperDto(
             info = MessageInfoDto(
                 id = id,
                 sessionID = "session-1",
-                time = MessageTimeDto(created = createdAt),
+                time = MessageTimeDto(created = createdAt, completed = completedAt),
                 role = "assistant",
                 parentID = "",
                 providerID = "provider",

--- a/app/src/test/java/dev/blazelight/p4oc/ui/screens/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/ui/screens/chat/ChatViewModelTest.kt
@@ -17,6 +17,7 @@ import dev.blazelight.p4oc.data.remote.dto.MessageInfoDto
 import dev.blazelight.p4oc.data.remote.dto.MessageTimeDto
 import dev.blazelight.p4oc.data.remote.dto.MessageWrapperDto
 import dev.blazelight.p4oc.data.remote.dto.ModelRefDto
+import dev.blazelight.p4oc.data.remote.dto.PartDto
 import dev.blazelight.p4oc.data.remote.dto.RevertSessionRequest
 import dev.blazelight.p4oc.data.remote.dto.SendMessageRequest
 import dev.blazelight.p4oc.data.remote.dto.SessionDto
@@ -38,10 +39,12 @@ import dev.blazelight.p4oc.domain.model.QuestionRequest
 import dev.blazelight.p4oc.domain.model.Session
 import dev.blazelight.p4oc.domain.model.SessionPresence
 import dev.blazelight.p4oc.domain.model.SessionStatus
+import dev.blazelight.p4oc.domain.model.Todo
 import dev.blazelight.p4oc.domain.model.TokenUsage
 import dev.blazelight.p4oc.domain.server.ScopedEvent
 import dev.blazelight.p4oc.domain.server.ServerGeneration
 import dev.blazelight.p4oc.domain.server.ServerRef
+import dev.blazelight.p4oc.domain.session.SessionId
 import dev.blazelight.p4oc.domain.workspace.Workspace
 import dev.blazelight.p4oc.ui.components.chat.SelectedFile
 import dev.blazelight.p4oc.ui.navigation.Screen
@@ -52,7 +55,10 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.slot
+import io.mockk.spyk
 import io.mockk.unmockkObject
+import io.mockk.verify
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -62,8 +68,10 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import kotlinx.serialization.json.Json
@@ -486,6 +494,329 @@ class ChatViewModelTest {
     }
 
     @Test
+    fun sendMessage_restIdleStatus_doesNotCancelItsOwnMessageRecovery() = runTest {
+        // Physical failure sequence: the run's terminal SSE is missed, REST status already says
+        // Idle, and the completed-but-empty assistant exists only behind the canonical message
+        // fetch. Gate that fetch so the poll is suspended inside it with the Idle status in hand.
+        val messagesGate = CompletableDeferred<Unit>()
+        var messageCalls = 0
+        coEvery { api.getSessionStatuses("/test", null) } returns mapOf(
+            "session-1" to SessionStatusDto(type = "idle")
+        )
+        coEvery { api.getMessages("session-1", 100, null, "/test", null) } coAnswers {
+            messageCalls += 1
+            if (messageCalls == 1) {
+                // The ViewModel's initial history load: nothing on the server yet.
+                emptyList()
+            } else {
+                // The poll's canonical reconciliation fetch: held open so the test can observe
+                // whether the poll survives having already seen the REST Idle status.
+                messagesGate.await()
+                listOf(
+                    userMessageDto("user-new", createdAt = 10),
+                    assistantMessageDto("assistant-empty", createdAt = 11, completedAt = 12),
+                )
+            }
+        }
+        coEvery { api.sendMessageAsync(any(), any(), any(), null) } returns Unit
+        val vm = createViewModel()
+        vm.updateInput("hello")
+
+        vm.sendMessage()
+        runCurrent()
+        advanceTimeBy(2_000)
+        runCurrent()
+        // The poll must be suspended inside the gated reconciliation fetch with the run still
+        // busy. On the pre-fix order the REST Idle was published before this fetch, so by now the
+        // responseCompletedToken collector has applied Idle (isBusy=false) and cancelled the poll
+        // while it sits at the gate — completing the gate would import nothing.
+        assertEquals(2, messageCalls)
+        assertTrue(vm.uiState.value.isBusy)
+        messagesGate.complete(Unit)
+        advanceUntilIdle()
+
+        assertFalse(vm.uiState.value.isBusy)
+        assertEquals(
+            "The model returned no response. The provider may be unavailable or rate-limited.",
+            vm.uiState.value.error,
+        )
+        assertEquals(listOf("user-new", "assistant-empty"), vm.currentMessages().map { it.message.id })
+    }
+
+    @Test
+    fun sendMessage_cancelsReconciliation_whenRunCompletesViaSse() = runTest {
+        coEvery { api.getMessages("session-1", 100, null, "/test", null) } returns emptyList()
+        coEvery { api.getSessionStatuses("/test", null) } returns mapOf(
+            "session-1" to SessionStatusDto(type = "busy")
+        )
+        coEvery { api.sendMessageAsync(any(), any(), any(), null) } returns Unit
+        val vm = createViewModel()
+        vm.updateInput("hello")
+
+        vm.sendMessage()
+        // Let the send coroutine start the bounded poll, then advance past the first delay so the
+        // first reconciliation iteration runs.
+        runCurrent()
+        advanceTimeBy(2_000)
+        runCurrent()
+        coVerify(exactly = 1) { api.getSessionStatuses("/test", null) }
+
+        // A terminal SSE event completes the run and must cancel the in-flight poll.
+        emitEvent(OpenCodeEvent.SessionStatusChanged("session-1", SessionStatus.Idle))
+        advanceUntilIdle()
+
+        // No further reconciliation iterations run after the run completes.
+        coVerify(exactly = 1) { api.getSessionStatuses("/test", null) }
+        assertFalse(vm.uiState.value.isBusy)
+    }
+
+    @Test
+    fun sendMessage_replacementSend_cancelsPriorReconciliation() = runTest {
+        val gate = CompletableDeferred<Unit>()
+        var statusCalls = 0
+        coEvery { api.getSessionStatuses("/test", null) } coAnswers {
+            statusCalls += 1
+            if (statusCalls == 1) gate.await()
+            mapOf("session-1" to SessionStatusDto(type = "busy"))
+        }
+        coEvery { api.getMessages("session-1", 100, null, "/test", null) } returns emptyList()
+        coEvery { api.sendMessageAsync(any(), any(), any(), null) } returns Unit
+        val vm = createViewModel()
+        vm.updateInput("hello")
+
+        // First send starts a poll whose first status lookup blocks on the gate.
+        vm.sendMessage()
+        runCurrent()
+        advanceTimeBy(2_000)
+        runCurrent()
+        assertEquals(1, statusCalls)
+
+        // A replacement send must cancel the in-flight poll at the send boundary.
+        vm.updateInput("hello")
+        vm.sendMessage()
+        runCurrent()
+        gate.complete(Unit)
+        advanceUntilIdle()
+
+        // The old poll was cancelled: it never resumes to a second status lookup. Only the
+        // replacement poll's four bounded iterations run (plus the one blocked call).
+        assertEquals(5, statusCalls)
+    }
+
+    @Test
+    fun sendMessage_pollInvokesRepositoryReconcileMessages() = runTest {
+        val repo = spyk(
+            SessionRepositoryImpl(
+                workspaceClient,
+                messageMapper,
+                dispatcher = StandardTestDispatcher(testScheduler),
+            )
+        )
+        coEvery { repo.reconcileMessages(SessionId("session-1")) } returns Unit
+        coEvery { api.getSessionStatuses("/test", null) } returns mapOf(
+            "session-1" to SessionStatusDto(type = "busy")
+        )
+        coEvery { api.getMessages("session-1", 100, null, "/test", null) } returns emptyList()
+        coEvery { api.sendMessageAsync(any(), any(), any(), null) } returns Unit
+        val vm = createViewModel(repository = repo)
+        vm.updateInput("hello")
+
+        vm.sendMessage()
+        advanceUntilIdle()
+
+        // The bounded poll drives the shared repository recovery primitive directly, not a second
+        // message buffer or an unsafe overwrite path.
+        coVerify(atLeast = 1) { repo.reconcileMessages(SessionId("session-1")) }
+    }
+
+    @Test
+    fun sendMessage_completedIntermediateAssistantWhileBusy_doesNotSynthesizeCompletion() = runTest {
+        coEvery { api.getMessages("session-1", 100, null, "/test", null) } returnsMany listOf(
+            emptyList(),
+            listOf(
+                userMessageDto("user-new", createdAt = 10),
+                assistantMessageDto(
+                    "assistant-step",
+                    createdAt = 11,
+                    completedAt = 12,
+                    parts = listOf(
+                        PartDto(
+                            id = "p-step",
+                            sessionID = "session-1",
+                            messageID = "assistant-step",
+                            type = "text",
+                            text = "intermediate step output",
+                        )
+                    ),
+                ),
+            ),
+        )
+        coEvery { api.getSessionStatuses("/test", null) } returns mapOf(
+            "session-1" to SessionStatusDto(type = "busy")
+        )
+        coEvery { api.sendMessageAsync(any(), any(), any(), null) } returns Unit
+        val vm = createViewModel()
+        vm.updateInput("hello")
+
+        vm.sendMessage()
+        advanceUntilIdle()
+
+        // The authoritative REST status is still Busy, so the completed assistant is an
+        // intermediate step of a multi-step run: no synthesized terminal Idle, no completion
+        // haptic, and the bounded poll runs its full four-iteration window instead of
+        // cancelling itself mid-run.
+        assertTrue(vm.uiState.value.isBusy)
+        assertNull(vm.uiState.value.error)
+        verify(exactly = 0) { hapticFeedback.vibrate(any()) }
+        coVerify(exactly = 4) { api.getSessionStatuses("/test", null) }
+    }
+
+    @Test
+    fun runStalledWarning_survivesUnrelatedRepositoryEmissions_untilTerminalBoundary() = runTest {
+        coEvery { api.getMessages("session-1", 100, null, "/test", null) } returns emptyList()
+        coEvery { api.getSessionStatuses("/test", null) } returns mapOf(
+            "session-1" to SessionStatusDto(type = "busy")
+        )
+        coEvery { api.sendMessageAsync(any(), any(), any(), null) } returns Unit
+        val vm = createViewModel()
+        vm.updateInput("hello")
+
+        vm.sendMessage()
+        advanceUntilIdle()
+
+        val warning = "No completion update was received. The run may still be active; stop it before retrying."
+        assertEquals(warning, vm.uiState.value.runNotice)
+
+        // An unrelated repository emission while the run is still busy (todo progress) must not
+        // erase the stalled-run warning.
+        emitEvent(
+            OpenCodeEvent.TodoUpdated(
+                "session-1",
+                listOf(Todo(id = "t1", content = "step", status = "pending", priority = "medium")),
+            )
+        )
+        flushMessages()
+        assertEquals(warning, vm.uiState.value.runNotice)
+        assertTrue(vm.uiState.value.isBusy)
+
+        // The real terminal event finally arrives: the boundary clears the warning.
+        emitEvent(OpenCodeEvent.SessionStatusChanged("session-1", SessionStatus.Idle))
+        flushMessages()
+        assertNull(vm.uiState.value.runNotice)
+        assertFalse(vm.uiState.value.isBusy)
+    }
+
+    @Test
+    fun retryNotice_persistsAcrossUnrelatedEmissions_andClearsWhenRunResumesBusy() = runTest {
+        val vm = createViewModel()
+
+        emitEvent(
+            OpenCodeEvent.SessionStatusChanged(
+                "session-1",
+                SessionStatus.Retry(attempt = 1, message = "Rate limit exceeded", next = 0L),
+            )
+        )
+        flushMessages()
+        assertEquals(
+            "Model usage limit reached. OpenCode is retrying (attempt 1).",
+            vm.uiState.value.runNotice,
+        )
+
+        // An unrelated emission while the status is still Retry recomputes the same notice —
+        // the Retry status, not stickiness, is its source of truth.
+        emitEvent(
+            OpenCodeEvent.TodoUpdated(
+                "session-1",
+                listOf(Todo(id = "t1", content = "step", status = "pending", priority = "medium")),
+            )
+        )
+        flushMessages()
+        assertEquals(
+            "Model usage limit reached. OpenCode is retrying (attempt 1).",
+            vm.uiState.value.runNotice,
+        )
+
+        // The retry succeeds and the run resumes: a transient Retry notice must not stick.
+        emitEvent(OpenCodeEvent.SessionStatusChanged("session-1", SessionStatus.Busy))
+        flushMessages()
+        assertNull(vm.uiState.value.runNotice)
+        assertTrue(vm.uiState.value.isBusy)
+    }
+
+    @Test
+    fun preexistingCompletionToken_doesNotFireSpuriousCompletionOnAttach() = runTest {
+        val repo = SessionRepositoryImpl(
+            workspaceClient,
+            messageMapper,
+            dispatcher = StandardTestDispatcher(testScheduler),
+        )
+        // A run in this session completed before this ViewModel attached (e.g. another tab
+        // holding the same session state), so the repository token is already nonzero.
+        repo.acceptEvent(OpenCodeEvent.SessionStatusChanged("session-1", SessionStatus.Busy))
+        repo.acceptEvent(OpenCodeEvent.SessionIdle("session-1"))
+
+        val vm = createViewModel(repository = repo)
+
+        // The subscription snapshot is a baseline, not a fresh completion: no haptic, no unread.
+        verify(exactly = 0) { hapticFeedback.vibrate(any()) }
+        assertFalse(vm.uiState.value.isBusy)
+        assertFalse(vm.hasUnreadResponse.value)
+    }
+
+    @Test
+    fun sendMessage_staleRunError_doesNotFlickerBackDuringGatedSend() = runTest {
+        coEvery { api.getMessages("session-1", 100, null, "/test", null) } returns emptyList()
+        coEvery { api.getSessionStatuses("/test", null) } returns mapOf(
+            "session-1" to SessionStatusDto(type = "busy")
+        )
+        val sendGate = CompletableDeferred<Unit>()
+        coEvery { api.sendMessageAsync(any(), any(), any(), null) } coAnswers { sendGate.await() }
+        val vm = createViewModel()
+        emitEvent(
+            OpenCodeEvent.SessionError(
+                "session-1",
+                MessageError(name = "APIError", message = "Rate limit exceeded", statusCode = 429),
+            )
+        )
+        flushMessages()
+        assertEquals(
+            "Model usage limit reached. Try again later or choose another model.",
+            vm.uiState.value.error,
+        )
+
+        vm.updateInput("hello")
+        vm.sendMessage()
+        flushMessages()
+        assertNull(vm.uiState.value.error)
+
+        // Repository emissions while the send is still in flight carry the previous run's error;
+        // it must not flicker back before the synthetic Busy clears it — including after the
+        // first emission has already reset isSending.
+        emitEvent(
+            OpenCodeEvent.TodoUpdated(
+                "session-1",
+                listOf(Todo(id = "t1", content = "first", status = "pending", priority = "medium")),
+            )
+        )
+        flushMessages()
+        assertNull(vm.uiState.value.error)
+        emitEvent(
+            OpenCodeEvent.TodoUpdated(
+                "session-1",
+                listOf(Todo(id = "t2", content = "second", status = "pending", priority = "medium")),
+            )
+        )
+        flushMessages()
+        assertNull(vm.uiState.value.error)
+
+        // The gated send completes: the synthetic Busy clears the repository error for real.
+        sendGate.complete(Unit)
+        advanceUntilIdle()
+        assertNull(vm.uiState.value.error)
+        assertTrue(vm.uiState.value.isBusy)
+    }
+
+    @Test
     fun sendMessage_restoresInput_onApiError() = runTest {
         val vm = createViewModel()
 
@@ -686,13 +1017,14 @@ class ChatViewModelTest {
         }
 
     private fun TestScope.createViewModel(
-        savedStateHandle: SavedStateHandle = SavedStateHandle(mapOf(Screen.Chat.ARG_SESSION_ID to "session-1"))
-    ): ChatViewModel {
-        sessionRepository = SessionRepositoryImpl(
+        savedStateHandle: SavedStateHandle = SavedStateHandle(mapOf(Screen.Chat.ARG_SESSION_ID to "session-1")),
+        repository: SessionRepositoryImpl = SessionRepositoryImpl(
             workspaceClient,
             messageMapper,
             dispatcher = StandardTestDispatcher(testScheduler),
-        )
+        ),
+    ): ChatViewModel {
+        sessionRepository = repository
         val fileRepository = testFileRepository()
         val vm = ChatViewModel(
             savedStateHandle = savedStateHandle,
@@ -763,6 +1095,7 @@ class ChatViewModelTest {
         id: String,
         createdAt: Long,
         completedAt: Long? = null,
+        parts: List<PartDto> = emptyList(),
     ): MessageWrapperDto {
         return MessageWrapperDto(
             info = MessageInfoDto(
@@ -776,7 +1109,7 @@ class ChatViewModelTest {
                 agent = "assistant",
                 mode = "chat",
             ),
-            parts = emptyList(),
+            parts = parts,
         )
     }
 


### PR DESCRIPTION
## Problem

A chat run can remain visually busy when terminal SSE state is missed, while provider retry/rate-limit failures are reduced to generic errors. Completed assistant messages with no content can also leave the user without a clear explanation.

## Changes

- Preserve `statusCode` and `isRetryable` from `session.error` events.
- Surface retry/rate-limit state as a non-terminal warning with the retry attempt.
- Convert assistant-message errors into terminal repository state even when a separate `session.error` event is missing, while deduplicating equivalent terminal delivery.
- Run bounded post-send status/message reconciliation at 2s, 5s, 10s, and 20s after a successful async send.
- Reuse PR #36's canonical repository-owned, revision-safe message recovery through `SessionRepository.reconcileMessages`; no parallel message buffer or competing overwrite path is introduced.
- Keep recovery scoped to the exact workspace client and actively leased session. Message revisions guard REST/SSE content races; a separate lease generation prevents released, deleted, or reacquired sessions from accepting stale pending-question/permission results.
- Reconcile REST messages before publishing terminal REST status, so an `idle` result cannot cancel its own missed-message recovery.
- Treat explicit REST `busy`/`retry` as authoritative over completed intermediate assistants, avoiding false mid-run completion.
- Detect completed assistant messages with no content and show a human-readable failure.
- Preserve stalled-run feedback across unrelated repository emissions and prevent a previous run's error from flickering back during a new send.
- Preserve coroutine cancellation: `CancellationException` is rethrown at all new isolation boundaries.
- Cancel reconciliation on genuine completion, stop, replacement send, and ViewModel destruction.

This PR remains limited to run recovery and user-facing failure feedback. It does not add foreground recovery, SSE watchdogs, model persistence, apply-patch UI, hardened-build work, or raw provider/protocol payload display.

## Verification

Focused recovery/feedback suite:

- `EventMapperTest`: 22 tests
- `SessionRepositoryImplTest`: 34 tests
- `SessionRepositoryRecoveryTest`: 16 tests
- `SessionRepositoryProviderTest`: 16 tests
- `ChatViewModelTest`: 36 tests
- Total: 124 tests, 0 failures, 0 errors, 0 skipped

Final integrated verification on Java 17:

- `./gradlew :app:compileDebugKotlin :app:testDebugUnitTest :app:detekt :app:assembleDebug`
- 812 unit tests across 104 classes: 0 failures, 0 errors, 1 skipped
- `git diff --check origin/main`
- Final reviewer verdict: ship; no blocking findings

## Physical-device synthetic recovery smoke

Validated the final reviewed debug APK explicitly on Samsung `SM_A155F` (`R58X70XHB9P`):

- Installed `dev.blazelight.p4oc.debug` with an explicit device serial.
- Used a temporary header/body-redacted authenticated pass-through proxy that intercepted only the prompt terminal outcome: it accepted the async send without emitting terminal SSE, then returned REST `idle` plus a completed assistant with no parts.
- Observed the bounded poll fetch status and canonical messages, then observed the human-readable UI error: `The model returned no response. The provider may be unavailable or rate-limited.`
- The result appeared in the same open chat without navigating away or reopening it.
- Crash buffer remained empty and the app process remained alive.
- Stopped and removed the proxy and temporary files; restored Samsung reverse mapping to device 4098 → host 4098.

This is synthetic missed-terminal recovery validation layered over the saved authenticated connection, not a real provider completion/failure run. An unauthenticated host health probe returned HTTP 401; no stored credential was read, exported, printed, or logged.