### PR TITLE
Improve chat loading and Markdown readability

### DIFF
--- a/app/detekt-baseline.xml
+++ b/app/detekt-baseline.xml
@@ -201,7 +201,8 @@
     <ID>FunctionNaming:StreamingMarkdown.kt$@Composable private fun MarkdownParagraph(text: String, colors: MarkdownRenderColors)</ID>
     <ID>FunctionNaming:StreamingMarkdown.kt$@Composable private fun MarkdownQuote(lines: List&lt;String&gt;, colors: MarkdownRenderColors)</ID>
     <ID>FunctionNaming:StreamingMarkdown.kt$@Composable private fun MarkdownTableBlock(rows: List&lt;List&lt;String&gt;&gt;, colors: MarkdownRenderColors)</ID>
-    <ID>FunctionNaming:StreamingMarkdown.kt$@Composable private fun MarkdownText( text: AnnotatedString, style: TextStyle, colors: MarkdownRenderColors, modifier: Modifier = Modifier, )</ID>
+    <ID>FunctionNaming:StreamingMarkdown.kt$@Composable private fun MarkdownText( text: AnnotatedString, style: TextStyle, color: androidx.compose.ui.graphics.Color, modifier: Modifier = Modifier, )</ID>
+    <ID>FunctionNaming:StreamingMarkdown.kt$@Composable private fun MarkdownBlockView( block: MarkdownBlock, colors: MarkdownRenderColors, highlighter: Highlights.Builder, )</ID>
     <ID>FunctionNaming:SyntaxHighlightedCode.kt$@Composable fun SyntaxHighlightedCode( code: String, filename: String, modifier: Modifier = Modifier, showLineNumbers: Boolean = true, fontSize: Int = 12, selectable: Boolean = false, )</ID>
     <ID>FunctionNaming:TabBar.kt$@Composable fun TabBar( tabs: List&lt;TabInstance&gt;, activeTabId: String?, tabTitles: Map&lt;String, String&gt;, tabIcons: Map&lt;String, ImageVector&gt;, tabConnectionStates: Map&lt;String, SessionConnectionState&gt;, onTabClick: (String) -&gt; Unit, onTabClose: (String) -&gt; Unit, onAddClick: () -&gt; Unit, modifier: Modifier = Modifier )</ID>
     <ID>FunctionNaming:TabBar.kt$@Composable private fun TabIndicator( title: String, icon: ImageVector, connectionState: SessionConnectionState?, isActive: Boolean, closeable: Boolean = true, onClick: () -&gt; Unit, onClose: () -&gt; Unit, modifier: Modifier = Modifier )</ID>

--- a/app/src/main/java/dev/blazelight/p4oc/ui/components/chat/StreamingMarkdown.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/components/chat/StreamingMarkdown.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withLink
 import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.blazelight.p4oc.ui.theme.LocalOpenCodeTheme
@@ -158,33 +159,7 @@ private fun MarkdownText(
 @Composable
 private fun MarkdownList(items: List<MarkdownListItem>, colors: MarkdownRenderColors) {
     val markerStyle = MaterialTheme.typography.bodyMedium.copy(lineHeight = 20.sp)
-    val textMeasurer = rememberTextMeasurer()
-    val density = LocalDensity.current
-    // One marker column per block keeps mixed bullet/number runs aligned and lets wrapped item
-    // text stay flush with its first line. The widest displayed marker (see [displayListMarker])
-    // sets the column by measured text width, so it scales with the font and never clips
-    // `1.`/`10.`/`100.`, while pathological markers cannot create an unbounded gutter.
-    val markerWidth = remember(items, markerStyle, textMeasurer, density.density, density.fontScale) {
-        val bulletPx = textMeasurer.measure(
-            text = AnnotatedString(MARKER_BULLET),
-            style = markerStyle,
-            softWrap = false,
-        ).size.width
-        val widestMarkerPx = items.maxOfOrNull { item ->
-            textMeasurer.measure(
-                text = AnnotatedString(displayListMarker(item.marker)),
-                style = markerStyle,
-                softWrap = false,
-            ).size.width
-        }
-        with(density) {
-            maxOf(
-                bulletPx.toFloat(),
-                widestMarkerPx?.toFloat() ?: 0f,
-                Spacing.md.toPx(),
-            ).roundToInt().toDp()
-        }
-    }
+    val markerWidth = rememberListMarkerWidth(items, markerStyle)
     Column(
         modifier = Modifier.padding(horizontal = Spacing.xs),
         verticalArrangement = Arrangement.spacedBy(Spacing.xxs),
@@ -217,6 +192,37 @@ private fun MarkdownList(items: List<MarkdownListItem>, colors: MarkdownRenderCo
                     modifier = Modifier.weight(1f),
                 )
             }
+        }
+    }
+}
+
+// One marker column per block keeps mixed bullet/number runs aligned and lets wrapped item
+// text stay flush with its first line. The widest displayed marker (see [displayListMarker])
+// sets the column by measured text width, so it scales with the font and never clips
+// `1.`/`10.`/`100.`, while pathological markers cannot create an unbounded gutter.
+@Composable
+private fun rememberListMarkerWidth(items: List<MarkdownListItem>, markerStyle: TextStyle): Dp {
+    val textMeasurer = rememberTextMeasurer()
+    val density = LocalDensity.current
+    return remember(items, markerStyle, textMeasurer, density.density, density.fontScale) {
+        val bulletPx = textMeasurer.measure(
+            text = AnnotatedString(MARKER_BULLET),
+            style = markerStyle,
+            softWrap = false,
+        ).size.width
+        val widestMarkerPx = items.maxOfOrNull { item ->
+            textMeasurer.measure(
+                text = AnnotatedString(displayListMarker(item.marker)),
+                style = markerStyle,
+                softWrap = false,
+            ).size.width
+        }
+        with(density) {
+            maxOf(
+                bulletPx.toFloat(),
+                widestMarkerPx?.toFloat() ?: 0f,
+                Spacing.md.toPx(),
+            ).roundToInt().toDp()
         }
     }
 }

--- a/app/src/main/java/dev/blazelight/p4oc/ui/components/chat/StreamingMarkdown.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/components/chat/StreamingMarkdown.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.LinkAnnotation
@@ -32,6 +33,7 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.withLink
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
@@ -60,8 +62,13 @@ fun StreamingMarkdown(
 ) {
     val isDarkTheme = isSystemInDarkTheme()
     val theme = LocalOpenCodeTheme.current
+    val contentColor = if (useTertiaryColors) theme.success else theme.markdownText
     val colors = MarkdownRenderColors(
-        text = if (useTertiaryColors) theme.success else theme.markdownText,
+        text = contentColor,
+        heading = if (useTertiaryColors) contentColor else theme.markdownHeading,
+        strong = if (useTertiaryColors) contentColor else theme.markdownStrong,
+        listMarker = if (useTertiaryColors) contentColor else theme.markdownListItem,
+        listEnumeration = if (useTertiaryColors) contentColor else theme.markdownListEnumeration,
         muted = theme.textMuted,
         border = theme.border,
         codeBackground = theme.backgroundElement,
@@ -86,6 +93,8 @@ fun StreamingMarkdown(
                             text = inlineMarkdown(block.text, colors),
                             style = headingStyle(block.level),
                             colors = colors,
+                            color = colors.heading,
+                            modifier = Modifier.padding(top = Spacing.xs),
                         )
                         is MarkdownBlock.ListBlock -> MarkdownList(block.items, colors)
                         is MarkdownBlock.Quote -> MarkdownQuote(block.lines, colors)
@@ -114,24 +123,42 @@ private fun MarkdownText(
     style: TextStyle,
     colors: MarkdownRenderColors,
     modifier: Modifier = Modifier,
+    color: androidx.compose.ui.graphics.Color = colors.text,
 ) {
     Text(
         text = text,
         style = style,
-        color = colors.text,
+        color = color,
         modifier = modifier.fillMaxWidth(),
     )
 }
 
 @Composable
 private fun MarkdownList(items: List<MarkdownListItem>, colors: MarkdownRenderColors) {
-    Column(verticalArrangement = Arrangement.spacedBy(Spacing.xxs)) {
-        items.forEach { item ->
-            Row(horizontalArrangement = Arrangement.spacedBy(Spacing.sm)) {
+    val markerWidth = if (items.any { it.ordered }) Spacing.xl else Spacing.md
+    Column(
+        modifier = Modifier.padding(horizontal = Spacing.xs),
+        verticalArrangement = Arrangement.spacedBy(Spacing.xxs),
+    ) {
+        items.forEachIndexed { index, item ->
+            val startsTopLevelSection = item.indentLevel == 0 &&
+                items.getOrNull(index - 1)?.indentLevel?.let { it > 0 } == true
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(
+                        start = Spacing.lg * item.indentLevel,
+                        top = if (startsTopLevelSection) Spacing.md else Spacing.none,
+                    ),
+                horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+                verticalAlignment = Alignment.Top,
+            ) {
                 Text(
                     text = item.marker,
                     style = MaterialTheme.typography.bodyMedium.copy(lineHeight = 20.sp),
-                    color = colors.muted,
+                    color = if (item.ordered) colors.listEnumeration else colors.listMarker,
+                    textAlign = TextAlign.End,
+                    modifier = Modifier.width(markerWidth),
                 )
                 Text(
                     text = inlineMarkdown(item.text, colors),
@@ -337,7 +364,9 @@ private fun inlineMarkdown(text: String, colors: MarkdownRenderColors): Annotate
                     break
                 }
                 withStyle(SpanStyle(fontWeight = FontWeight.Bold)) {
-                    append(text.substring(boldStart + 2, end))
+                    withStyle(SpanStyle(color = colors.strong)) {
+                        append(text.substring(boldStart + 2, end))
+                    }
                 }
                 index = end + 2
             }
@@ -412,6 +441,10 @@ private fun tableCellWidth(contentLength: Int) = when {
 
 private data class MarkdownRenderColors(
     val text: androidx.compose.ui.graphics.Color,
+    val heading: androidx.compose.ui.graphics.Color,
+    val strong: androidx.compose.ui.graphics.Color,
+    val listMarker: androidx.compose.ui.graphics.Color,
+    val listEnumeration: androidx.compose.ui.graphics.Color,
     val muted: androidx.compose.ui.graphics.Color,
     val border: androidx.compose.ui.graphics.Color,
     val codeBackground: androidx.compose.ui.graphics.Color,
@@ -557,21 +590,42 @@ private fun isHorizontalRule(trimmed: String): Boolean {
     return trimmed.all { it == '-' } || trimmed.all { it == '*' } || trimmed.all { it == '_' }
 }
 
-internal data class MarkdownListItem(val marker: String, val text: String)
+internal data class MarkdownListItem(
+    val marker: String,
+    val text: String,
+    val indentLevel: Int = 0,
+    val ordered: Boolean = false,
+)
 
-private data class ListItem(val ordered: Boolean, val marker: String, val text: String) {
-    fun toMarkdownListItem(): MarkdownListItem = MarkdownListItem(marker = marker, text = text)
+private data class ListItem(
+    val ordered: Boolean,
+    val marker: String,
+    val text: String,
+    val indentLevel: Int,
+) {
+    fun toMarkdownListItem(): MarkdownListItem = MarkdownListItem(
+        marker = marker,
+        text = text,
+        indentLevel = indentLevel,
+        ordered = ordered,
+    )
 }
 
 private fun parseListItem(line: String): ListItem? {
+    val leadingSpaces = line.takeWhile { it == ' ' }.length
+    val indentLevel = leadingSpaces / MARKDOWN_LIST_INDENT_SPACES
     val trimmed = line.trimStart()
-    if (trimmed.startsWith("- ") || trimmed.startsWith("* ")) return ListItem(false, "•", trimmed.drop(2).trim())
+    if (trimmed.startsWith("- ") || trimmed.startsWith("* ")) {
+        return ListItem(false, "•", trimmed.drop(2).trim(), indentLevel)
+    }
     val dot = trimmed.indexOf(". ")
     if (dot > 0 && trimmed.take(dot).all { it.isDigit() }) {
-        return ListItem(true, trimmed.take(dot + 1), trimmed.drop(dot + 2).trim())
+        return ListItem(true, trimmed.take(dot + 1), trimmed.drop(dot + 2).trim(), indentLevel)
     }
     return null
 }
+
+private const val MARKDOWN_LIST_INDENT_SPACES = 2
 
 private data class ParsedTable(val rows: List<List<String>>, val nextIndex: Int)
 

--- a/app/src/main/java/dev/blazelight/p4oc/ui/components/chat/StreamingMarkdown.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/components/chat/StreamingMarkdown.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
@@ -32,8 +33,9 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withLink
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
@@ -45,6 +47,7 @@ import dev.snipme.highlights.Highlights
 import dev.snipme.highlights.model.ColorHighlight
 import dev.snipme.highlights.model.SyntaxLanguage
 import dev.snipme.highlights.model.SyntaxThemes
+import kotlin.math.roundToInt
 
 /**
  * Chat-oriented markdown renderer.
@@ -62,19 +65,7 @@ fun StreamingMarkdown(
 ) {
     val isDarkTheme = isSystemInDarkTheme()
     val theme = LocalOpenCodeTheme.current
-    val contentColor = if (useTertiaryColors) theme.success else theme.markdownText
-    val colors = MarkdownRenderColors(
-        text = contentColor,
-        heading = if (useTertiaryColors) contentColor else theme.markdownHeading,
-        strong = if (useTertiaryColors) contentColor else theme.markdownStrong,
-        listMarker = if (useTertiaryColors) contentColor else theme.markdownListItem,
-        listEnumeration = if (useTertiaryColors) contentColor else theme.markdownListEnumeration,
-        muted = theme.textMuted,
-        border = theme.border,
-        codeBackground = theme.backgroundElement,
-        inlineCodeBackground = theme.backgroundPanel,
-        link = theme.info,
-    )
+    val colors = markdownRenderColors(theme, useTertiaryColors)
     val highlighter = remember(isDarkTheme) {
         Highlights.Builder().theme(SyntaxThemes.atom(darkMode = isDarkTheme))
     }
@@ -87,21 +78,7 @@ fun StreamingMarkdown(
         ) {
             blocks.forEach { block ->
                 key(block.key) {
-                    when (block) {
-                        is MarkdownBlock.Paragraph -> MarkdownParagraph(block.lines.joinToString("\n"), colors)
-                        is MarkdownBlock.Heading -> MarkdownText(
-                            text = inlineMarkdown(block.text, colors),
-                            style = headingStyle(block.level),
-                            colors = colors,
-                            color = colors.heading,
-                            modifier = Modifier.padding(top = Spacing.xs),
-                        )
-                        is MarkdownBlock.ListBlock -> MarkdownList(block.items, colors)
-                        is MarkdownBlock.Quote -> MarkdownQuote(block.lines, colors)
-                        is MarkdownBlock.CodeFence -> CodeFenceBlock(block.code, block.language, highlighter, colors)
-                        is MarkdownBlock.Table -> MarkdownTableBlock(block.rows, colors)
-                        is MarkdownBlock.Rule -> HorizontalRule(colors)
-                    }
+                    MarkdownBlockView(block, colors, highlighter)
                 }
             }
         }
@@ -109,11 +86,57 @@ fun StreamingMarkdown(
 }
 
 @Composable
+private fun MarkdownBlockView(
+    block: MarkdownBlock,
+    colors: MarkdownRenderColors,
+    highlighter: Highlights.Builder,
+) {
+    when (block) {
+        is MarkdownBlock.Paragraph -> MarkdownParagraph(block.lines.joinToString("\n"), colors)
+        is MarkdownBlock.Heading -> MarkdownText(
+            text = inlineMarkdown(block.text, colors),
+            style = headingStyle(block.level),
+            color = colors.heading,
+            modifier = Modifier.padding(top = Spacing.xs),
+        )
+        is MarkdownBlock.ListBlock -> MarkdownList(block.items, colors)
+        is MarkdownBlock.Quote -> MarkdownQuote(block.lines, colors)
+        is MarkdownBlock.CodeFence -> CodeFenceBlock(block.code, block.language, highlighter, colors)
+        is MarkdownBlock.Table -> MarkdownTableBlock(block.rows, colors)
+        is MarkdownBlock.Rule -> HorizontalRule(colors)
+    }
+}
+
+/**
+ * Builds the renderer palette. Tertiary content (reasoning) is intentionally monochrome: every
+ * foreground token collapses to the single content color, while surfaces and structural rules keep
+ * their neutral theme values.
+ */
+private fun markdownRenderColors(
+    theme: dev.blazelight.p4oc.ui.theme.opencode.OpenCodeTheme,
+    useTertiaryColors: Boolean,
+): MarkdownRenderColors {
+    val contentColor = if (useTertiaryColors) theme.success else theme.markdownText
+    return MarkdownRenderColors(
+        text = contentColor,
+        heading = if (useTertiaryColors) contentColor else theme.markdownHeading,
+        strong = if (useTertiaryColors) contentColor else theme.markdownStrong,
+        listMarker = if (useTertiaryColors) contentColor else theme.markdownListItem,
+        listEnumeration = if (useTertiaryColors) contentColor else theme.markdownListEnumeration,
+        muted = if (useTertiaryColors) contentColor else theme.textMuted,
+        border = theme.border,
+        codeBackground = theme.backgroundElement,
+        inlineCodeBackground = theme.backgroundPanel,
+        link = if (useTertiaryColors) contentColor else theme.info,
+    )
+}
+
+@Composable
 private fun MarkdownParagraph(text: String, colors: MarkdownRenderColors) {
     MarkdownText(
         text = inlineMarkdown(text.trim(), colors),
         style = MaterialTheme.typography.bodyMedium.copy(lineHeight = 20.sp),
-        colors = colors,
+        color = colors.text,
     )
 }
 
@@ -121,9 +144,8 @@ private fun MarkdownParagraph(text: String, colors: MarkdownRenderColors) {
 private fun MarkdownText(
     text: AnnotatedString,
     style: TextStyle,
-    colors: MarkdownRenderColors,
+    color: androidx.compose.ui.graphics.Color,
     modifier: Modifier = Modifier,
-    color: androidx.compose.ui.graphics.Color = colors.text,
 ) {
     Text(
         text = text,
@@ -135,29 +157,52 @@ private fun MarkdownText(
 
 @Composable
 private fun MarkdownList(items: List<MarkdownListItem>, colors: MarkdownRenderColors) {
-    val markerWidth = if (items.any { it.ordered }) Spacing.xl else Spacing.md
+    val markerStyle = MaterialTheme.typography.bodyMedium.copy(lineHeight = 20.sp)
+    val textMeasurer = rememberTextMeasurer()
+    val density = LocalDensity.current
+    // One marker column per block keeps mixed bullet/number runs aligned and lets wrapped item
+    // text stay flush with its first line. The widest marker (bounded to its trailing six
+    // characters) sets the column by measured text width, so it scales with the font and never
+    // clips `1.`/`10.`/`100.`, while pathological markers cannot create an unbounded gutter.
+    val markerWidth = remember(items, markerStyle, density.density, density.fontScale) {
+        val bulletPx = textMeasurer.measure(
+            text = AnnotatedString(MARKER_BULLET),
+            style = markerStyle,
+        ).size.width
+        val widestMarkerPx = items.maxOfOrNull { item ->
+            textMeasurer.measure(
+                text = AnnotatedString(item.marker.takeLast(MARKER_MEASURE_MAX_CHARS)),
+                style = markerStyle,
+            ).size.width
+        }
+        val minWidthPx = with(density) { Spacing.md.toPx() }.roundToInt()
+        with(density) {
+            maxOf(bulletPx, widestMarkerPx ?: 0, minWidthPx).toDp()
+        }
+    }
     Column(
         modifier = Modifier.padding(horizontal = Spacing.xs),
         verticalArrangement = Arrangement.spacedBy(Spacing.xxs),
     ) {
         items.forEachIndexed { index, item ->
-            val startsTopLevelSection = item.indentLevel == 0 &&
-                items.getOrNull(index - 1)?.indentLevel?.let { it > 0 } == true
+            val indentStep = item.indentLevel.coerceAtMost(MAX_VISUAL_INDENT_LEVELS)
+            val returnsToTopLevel = indentStep == 0 && (items.getOrNull(index - 1)?.indentLevel ?: 0) > 0
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(
-                        start = Spacing.lg * item.indentLevel,
-                        top = if (startsTopLevelSection) Spacing.md else Spacing.none,
+                        start = Spacing.lg * indentStep,
+                        top = if (returnsToTopLevel) Spacing.md else Spacing.none,
                     ),
                 horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
                 verticalAlignment = Alignment.Top,
             ) {
                 Text(
                     text = item.marker,
-                    style = MaterialTheme.typography.bodyMedium.copy(lineHeight = 20.sp),
+                    style = markerStyle,
                     color = if (item.ordered) colors.listEnumeration else colors.listMarker,
                     textAlign = TextAlign.End,
+                    softWrap = false,
                     modifier = Modifier.width(markerWidth),
                 )
                 Text(
@@ -363,10 +408,8 @@ private fun inlineMarkdown(text: String, colors: MarkdownRenderColors): Annotate
                     appendInline(text.substring(boldStart), colors)
                     break
                 }
-                withStyle(SpanStyle(fontWeight = FontWeight.Bold)) {
-                    withStyle(SpanStyle(color = colors.strong)) {
-                        append(text.substring(boldStart + 2, end))
-                    }
+                withStyle(SpanStyle(fontWeight = FontWeight.Bold, color = colors.strong)) {
+                    append(text.substring(boldStart + 2, end))
                 }
                 index = end + 2
             }
@@ -439,6 +482,15 @@ private fun tableCellWidth(contentLength: Int) = when {
     else -> 320.dp
 }
 
+/** Characters of a list marker used to bound measurement, so huge source numbers cannot widen the column. */
+private const val MARKER_MEASURE_MAX_CHARS = 6
+
+/** Bullet glyph measured as the list-marker floor so narrow runs never shrink the shared column. */
+private const val MARKER_BULLET = "•"
+
+/** Maximum visual indentation steps rendered for nested lists, keeping the gutter bounded on phones. */
+private const val MAX_VISUAL_INDENT_LEVELS = 4
+
 private data class MarkdownRenderColors(
     val text: androidx.compose.ui.graphics.Color,
     val heading: androidx.compose.ui.graphics.Color,
@@ -463,7 +515,7 @@ internal sealed interface MarkdownBlock {
         override val key = "h:$startLine"
     }
 
-    data class ListBlock(val startLine: Int, val ordered: Boolean, val items: List<MarkdownListItem>) : MarkdownBlock {
+    data class ListBlock(val startLine: Int, val items: List<MarkdownListItem>) : MarkdownBlock {
         override val key = "l:$startLine"
     }
 
@@ -533,16 +585,15 @@ internal fun parseMarkdownBlocks(text: String): List<MarkdownBlock> {
         }
 
         parseListItem(line)?.let { firstItem ->
-            val ordered = firstItem.ordered
-            val items = mutableListOf(firstItem.toMarkdownListItem())
+            val items = mutableListOf(firstItem)
             index++
             while (index < lines.size) {
                 val next = parseListItem(lines[index])
-                if (next == null || next.ordered != ordered) break
-                items += next.toMarkdownListItem()
+                if (next == null) break
+                items += next
                 index++
             }
-            blocks += MarkdownBlock.ListBlock(startLine, ordered, items)
+            blocks += MarkdownBlock.ListBlock(startLine, normalizeListIndents(items))
             continue
         }
 
@@ -601,9 +652,9 @@ private data class ListItem(
     val ordered: Boolean,
     val marker: String,
     val text: String,
-    val indentLevel: Int,
+    val leadingIndentWidth: Int,
 ) {
-    fun toMarkdownListItem(): MarkdownListItem = MarkdownListItem(
+    fun toMarkdownListItem(indentLevel: Int): MarkdownListItem = MarkdownListItem(
         marker = marker,
         text = text,
         indentLevel = indentLevel,
@@ -611,21 +662,46 @@ private data class ListItem(
     )
 }
 
+/**
+ * Normalize a contiguous list run's raw leading-indentation widths into semantic indentation
+ * levels. Each leading space counts one and each leading tab counts [TAB_INDENT_WIDTH], so tab
+ * indentation is recognized as hierarchy instead of being silently flattened.
+ * The first visible item is level 0; any greater indentation than the current level opens exactly
+ * one child level, equal indentation stays, and dedenting returns to a prior/lower level. This
+ * makes the model independent of the source indent width (two vs four spaces) and of skipped
+ * levels, so a stream fragment beginning mid-list still maps its first item to 0.
+ */
+private fun normalizeListIndents(items: List<ListItem>): List<MarkdownListItem> {
+    val stack = mutableListOf<Int>()
+    return items.map { item ->
+        val indent = item.leadingIndentWidth
+        while (stack.isNotEmpty() && stack.last() > indent) {
+            stack.removeAt(stack.size - 1)
+        }
+        if (stack.isEmpty() || stack.last() < indent) {
+            stack.add(indent)
+        }
+        item.toMarkdownListItem(indentLevel = stack.size - 1)
+    }
+}
+
+private const val TAB_INDENT_WIDTH = 4
+
+private fun leadingIndentWidth(line: String): Int =
+    line.takeWhile { it == ' ' || it == '\t' }.sumOf { if (it == '\t') TAB_INDENT_WIDTH else 1 }
+
 private fun parseListItem(line: String): ListItem? {
-    val leadingSpaces = line.takeWhile { it == ' ' }.length
-    val indentLevel = leadingSpaces / MARKDOWN_LIST_INDENT_SPACES
+    val leadingIndentWidth = leadingIndentWidth(line)
     val trimmed = line.trimStart()
     if (trimmed.startsWith("- ") || trimmed.startsWith("* ")) {
-        return ListItem(false, "•", trimmed.drop(2).trim(), indentLevel)
+        return ListItem(false, "•", trimmed.drop(2).trim(), leadingIndentWidth)
     }
     val dot = trimmed.indexOf(". ")
     if (dot > 0 && trimmed.take(dot).all { it.isDigit() }) {
-        return ListItem(true, trimmed.take(dot + 1), trimmed.drop(dot + 2).trim(), indentLevel)
+        return ListItem(true, trimmed.take(dot + 1), trimmed.drop(dot + 2).trim(), leadingIndentWidth)
     }
     return null
 }
-
-private const val MARKDOWN_LIST_INDENT_SPACES = 2
 
 private data class ParsedTable(val rows: List<List<String>>, val nextIndex: Int)
 

--- a/app/src/main/java/dev/blazelight/p4oc/ui/components/chat/StreamingMarkdown.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/components/chat/StreamingMarkdown.kt
@@ -161,23 +161,28 @@ private fun MarkdownList(items: List<MarkdownListItem>, colors: MarkdownRenderCo
     val textMeasurer = rememberTextMeasurer()
     val density = LocalDensity.current
     // One marker column per block keeps mixed bullet/number runs aligned and lets wrapped item
-    // text stay flush with its first line. The widest marker (bounded to its trailing six
-    // characters) sets the column by measured text width, so it scales with the font and never
-    // clips `1.`/`10.`/`100.`, while pathological markers cannot create an unbounded gutter.
-    val markerWidth = remember(items, markerStyle, density.density, density.fontScale) {
+    // text stay flush with its first line. The widest displayed marker (see [displayListMarker])
+    // sets the column by measured text width, so it scales with the font and never clips
+    // `1.`/`10.`/`100.`, while pathological markers cannot create an unbounded gutter.
+    val markerWidth = remember(items, markerStyle, textMeasurer, density.density, density.fontScale) {
         val bulletPx = textMeasurer.measure(
             text = AnnotatedString(MARKER_BULLET),
             style = markerStyle,
+            softWrap = false,
         ).size.width
         val widestMarkerPx = items.maxOfOrNull { item ->
             textMeasurer.measure(
-                text = AnnotatedString(item.marker.takeLast(MARKER_MEASURE_MAX_CHARS)),
+                text = AnnotatedString(displayListMarker(item.marker)),
                 style = markerStyle,
+                softWrap = false,
             ).size.width
         }
-        val minWidthPx = with(density) { Spacing.md.toPx() }.roundToInt()
         with(density) {
-            maxOf(bulletPx, widestMarkerPx ?: 0, minWidthPx).toDp()
+            maxOf(
+                bulletPx.toFloat(),
+                widestMarkerPx?.toFloat() ?: 0f,
+                Spacing.md.toPx(),
+            ).roundToInt().toDp()
         }
     }
     Column(
@@ -198,7 +203,7 @@ private fun MarkdownList(items: List<MarkdownListItem>, colors: MarkdownRenderCo
                 verticalAlignment = Alignment.Top,
             ) {
                 Text(
-                    text = item.marker,
+                    text = displayListMarker(item.marker),
                     style = markerStyle,
                     color = if (item.ordered) colors.listEnumeration else colors.listMarker,
                     textAlign = TextAlign.End,
@@ -482,8 +487,24 @@ private fun tableCellWidth(contentLength: Int) = when {
     else -> 320.dp
 }
 
-/** Characters of a list marker used to bound measurement, so huge source numbers cannot widen the column. */
-private const val MARKER_MEASURE_MAX_CHARS = 6
+/** Characters of a displayed list marker, so huge source numbers cannot widen the column. */
+private const val MARKER_DISPLAY_MAX_CHARS = 6
+
+/** Ellipsis glyph used to truncate an over-long ordered marker before rendering/measurement. */
+private const val MARKER_ELLIPSIS = "…"
+
+/**
+ * Returns the exact string that will be measured and rendered for [marker]. Markers of at most
+ * [MARKER_DISPLAY_MAX_CHARS] characters are unchanged; longer markers become an ellipsis plus
+ * their trailing characters so the measured column matches what is drawn. The full original
+ * marker remains available on [MarkdownListItem].
+ */
+internal fun displayListMarker(marker: String): String =
+    if (marker.length <= MARKER_DISPLAY_MAX_CHARS) {
+        marker
+    } else {
+        MARKER_ELLIPSIS + marker.takeLast(MARKER_DISPLAY_MAX_CHARS - 1)
+    }
 
 /** Bullet glyph measured as the list-marker floor so narrow runs never shrink the shared column. */
 private const val MARKER_BULLET = "•"

--- a/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ChatScreen.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ChatScreen.kt
@@ -608,7 +608,10 @@ fun ChatScreen(
                 }
                 if (uiState.isLoading || activeLoadSteps.isNotEmpty()) {
                     TuiLoadingScreen(
-                        modifier = Modifier.align(Alignment.Center),
+                        modifier = Modifier
+                            .matchParentSize()
+                            .background(LocalOpenCodeTheme.current.background)
+                            .testTag("chat_loading_overlay"),
                         text = activeLoadSteps.ifEmpty { listOf("Loading session") }.joinToString("\n")
                     )
                 }

--- a/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ChatScreen.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ChatScreen.kt
@@ -24,6 +24,8 @@ import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -104,6 +106,29 @@ internal fun hasChatContent(
     hasPendingQuestion: Boolean,
     hasSessionPendingPermissions: Boolean,
 ): Boolean = hasMessages || isBusy || hasPendingQuestion || hasSessionPendingPermissions
+
+internal enum class ChatLoadingOverlay {
+    None,
+    Transparent,
+    Opaque,
+}
+
+/**
+ * Presentation seam for the chat loading indicator. An opaque full-bleed overlay is shown only
+ * while the session messages themselves are loading over an empty transcript, so cached or
+ * populated content stays visible. Incidental in-session steps (slash commands, todos, file
+ * picker) render a small transparent centered indicator regardless of content; when there is no
+ * loading activity at all no overlay is shown.
+ */
+internal fun chatLoadingOverlay(
+    isMessageLoading: Boolean,
+    hasActiveLoadSteps: Boolean,
+    hasContent: Boolean,
+): ChatLoadingOverlay = when {
+    !isMessageLoading && !hasActiveLoadSteps -> ChatLoadingOverlay.None
+    isMessageLoading && !hasContent -> ChatLoadingOverlay.Opaque
+    else -> ChatLoadingOverlay.Transparent
+}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -606,12 +631,27 @@ fun ChatScreen(
                     addAll(uiState.loadingSteps)
                     if (isPickerLoading) add("Loading files")
                 }
-                if (uiState.isLoading || activeLoadSteps.isNotEmpty()) {
+                val overlayPresentation = chatLoadingOverlay(
+                    isMessageLoading = uiState.isLoading,
+                    hasActiveLoadSteps = activeLoadSteps.isNotEmpty(),
+                    hasContent = hasContent,
+                )
+                if (overlayPresentation != ChatLoadingOverlay.None) {
+                    val loadingDescription = stringResource(R.string.cd_loading)
+                    val modifier = when (overlayPresentation) {
+                        ChatLoadingOverlay.Opaque ->
+                            Modifier
+                                .matchParentSize()
+                                .background(LocalOpenCodeTheme.current.background)
+                        ChatLoadingOverlay.Transparent ->
+                            Modifier
+                                .align(Alignment.Center)
+                        ChatLoadingOverlay.None -> Modifier
+                    }
                     TuiLoadingScreen(
-                        modifier = Modifier
-                            .matchParentSize()
-                            .background(LocalOpenCodeTheme.current.background)
-                            .testTag("chat_loading_overlay"),
+                        modifier = modifier
+                            .testTag("chat_loading_overlay")
+                            .semantics { contentDescription = loadingDescription },
                         text = activeLoadSteps.ifEmpty { listOf("Loading session") }.joinToString("\n")
                     )
                 }

--- a/app/src/test/java/dev/blazelight/p4oc/ui/components/chat/StreamingMarkdownParserTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/ui/components/chat/StreamingMarkdownParserTest.kt
@@ -118,4 +118,135 @@ class StreamingMarkdownParserTest {
             list.items,
         )
     }
+
+    @Test
+    fun `keeps mixed ordered and unordered nesting in one list run`() {
+        val blocks = parseMarkdownBlocks(
+            """
+            1. Parent
+               - Child
+               - Another child
+            2. Parent
+            """.trimIndent()
+        )
+
+        assertEquals(1, blocks.size)
+        val list = blocks.single() as MarkdownBlock.ListBlock
+        assertEquals(
+            listOf(
+                MarkdownListItem("1.", "Parent", indentLevel = 0, ordered = true),
+                MarkdownListItem("•", "Child", indentLevel = 1, ordered = false),
+                MarkdownListItem("•", "Another child", indentLevel = 1, ordered = false),
+                MarkdownListItem("2.", "Parent", indentLevel = 0, ordered = true),
+            ),
+            list.items,
+        )
+    }
+
+    @Test
+    fun `four space nesting maps to a single semantic level`() {
+        val blocks = parseMarkdownBlocks(
+            """
+            - Parent
+                - Child
+                - Another child
+            - Sibling
+            """.trimIndent()
+        )
+
+        val list = blocks.single() as MarkdownBlock.ListBlock
+        assertEquals(
+            listOf(
+                MarkdownListItem("•", "Parent", indentLevel = 0),
+                MarkdownListItem("•", "Child", indentLevel = 1),
+                MarkdownListItem("•", "Another child", indentLevel = 1),
+                MarkdownListItem("•", "Sibling", indentLevel = 0),
+            ),
+            list.items,
+        )
+    }
+
+    @Test
+    fun `zero four eight indentation maps to depths zero one two`() {
+        val blocks = parseMarkdownBlocks(
+            """
+            - Level zero
+                - Level one
+                    - Level two
+            """.trimIndent()
+        )
+
+        val list = blocks.single() as MarkdownBlock.ListBlock
+        assertEquals(
+            listOf(
+                MarkdownListItem("•", "Level zero", indentLevel = 0),
+                MarkdownListItem("•", "Level one", indentLevel = 1),
+                MarkdownListItem("•", "Level two", indentLevel = 2),
+            ),
+            list.items,
+        )
+    }
+
+    @Test
+    fun `stream fragment beginning at indentation maps first item to zero`() {
+        val blocks = parseMarkdownBlocks(
+            "    - Fragment child\n    - Fragment sibling"
+        )
+
+        val list = blocks.single() as MarkdownBlock.ListBlock
+        assertEquals(
+            listOf(
+                MarkdownListItem("•", "Fragment child", indentLevel = 0),
+                MarkdownListItem("•", "Fragment sibling", indentLevel = 0),
+            ),
+            list.items,
+        )
+    }
+
+    @Test
+    fun `blank line splits two lists into separate blocks`() {
+        val blocks = parseMarkdownBlocks(
+            """
+            - first
+
+            - second
+            """.trimIndent()
+        )
+
+        assertEquals(2, blocks.size)
+        assertTrue(blocks[0] is MarkdownBlock.ListBlock)
+        assertTrue(blocks[1] is MarkdownBlock.ListBlock)
+    }
+
+    @Test
+    fun `tab indented child maps one semantic level below parent`() {
+        val blocks = parseMarkdownBlocks(
+            "- Parent\n\t- Tab child\n\t- Tab sibling\n- Second parent"
+        )
+
+        val list = blocks.single() as MarkdownBlock.ListBlock
+        assertEquals(
+            listOf(
+                MarkdownListItem("•", "Parent", indentLevel = 0),
+                MarkdownListItem("•", "Tab child", indentLevel = 1),
+                MarkdownListItem("•", "Tab sibling", indentLevel = 1),
+                MarkdownListItem("•", "Second parent", indentLevel = 0),
+            ),
+            list.items,
+        )
+    }
+
+    @Test
+    fun `tab indented fragment maps first item to zero`() {
+        val blocks = parseMarkdownBlocks("\t- Fragment child\n\t- Fragment sibling")
+
+        val list = blocks.single() as MarkdownBlock.ListBlock
+        assertEquals(
+            listOf(
+                MarkdownListItem("•", "Fragment child", indentLevel = 0),
+                MarkdownListItem("•", "Fragment sibling", indentLevel = 0),
+            ),
+            list.items,
+        )
+    }
 }

--- a/app/src/test/java/dev/blazelight/p4oc/ui/components/chat/StreamingMarkdownParserTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/ui/components/chat/StreamingMarkdownParserTest.kt
@@ -87,8 +87,33 @@ class StreamingMarkdownParserTest {
         val list = blocks.single() as MarkdownBlock.ListBlock
         assertEquals(
             listOf(
-                MarkdownListItem("4.", "first visible item"),
-                MarkdownListItem("7.", "skipped number from model"),
+                MarkdownListItem("4.", "first visible item", ordered = true),
+                MarkdownListItem("7.", "skipped number from model", ordered = true),
+            ),
+            list.items,
+        )
+    }
+
+    @Test
+    fun `preserves nested list indentation`() {
+        val blocks = parseMarkdownBlocks(
+            """
+            - **Home**
+              - project tree
+              - recent workspaces
+            - **Settings**
+              - grouped sections
+            """.trimIndent()
+        )
+
+        val list = blocks.single() as MarkdownBlock.ListBlock
+        assertEquals(
+            listOf(
+                MarkdownListItem("•", "**Home**", indentLevel = 0),
+                MarkdownListItem("•", "project tree", indentLevel = 1),
+                MarkdownListItem("•", "recent workspaces", indentLevel = 1),
+                MarkdownListItem("•", "**Settings**", indentLevel = 0),
+                MarkdownListItem("•", "grouped sections", indentLevel = 1),
             ),
             list.items,
         )

--- a/app/src/test/java/dev/blazelight/p4oc/ui/components/chat/StreamingMarkdownParserTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/ui/components/chat/StreamingMarkdownParserTest.kt
@@ -260,7 +260,7 @@ class StreamingMarkdownParserTest {
 
     @Test
     fun `display marker truncates long markers to six visible characters`() {
-        assertEquals("…23456", displayListMarker("1234567."))
-        assertEquals("…67890", displayListMarker("1234567890."))
+        assertEquals("…4567.", displayListMarker("1234567."))
+        assertEquals("…7890.", displayListMarker("1234567890."))
     }
 }

--- a/app/src/test/java/dev/blazelight/p4oc/ui/components/chat/StreamingMarkdownParserTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/ui/components/chat/StreamingMarkdownParserTest.kt
@@ -249,4 +249,18 @@ class StreamingMarkdownParserTest {
             list.items,
         )
     }
+
+    @Test
+    fun `display marker leaves normal markers unchanged`() {
+        assertEquals("•", displayListMarker("•"))
+        assertEquals("1.", displayListMarker("1."))
+        assertEquals("10.", displayListMarker("10."))
+        assertEquals("100.", displayListMarker("100."))
+    }
+
+    @Test
+    fun `display marker truncates long markers to six visible characters`() {
+        assertEquals("…23456", displayListMarker("1234567."))
+        assertEquals("…67890", displayListMarker("1234567890."))
+    }
 }

--- a/app/src/test/java/dev/blazelight/p4oc/ui/screens/chat/ChatPresentationBehaviorTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/ui/screens/chat/ChatPresentationBehaviorTest.kt
@@ -81,6 +81,69 @@ class ChatPresentationBehaviorTest {
         assertTrue(complete!!.showSeparator)
     }
 
+    @Test
+    fun chatLoading_loadingMessagesWithoutContent_isOpaque() {
+        assertEquals(
+            ChatLoadingOverlay.Opaque,
+            chatLoadingOverlay(isMessageLoading = true, hasActiveLoadSteps = false, hasContent = false),
+        )
+        assertEquals(
+            ChatLoadingOverlay.Opaque,
+            chatLoadingOverlay(isMessageLoading = true, hasActiveLoadSteps = true, hasContent = false),
+        )
+    }
+
+    @Test
+    fun chatLoading_loadingMessagesWithContent_isTransparent() {
+        assertEquals(
+            ChatLoadingOverlay.Transparent,
+            chatLoadingOverlay(isMessageLoading = true, hasActiveLoadSteps = false, hasContent = true),
+        )
+        assertEquals(
+            ChatLoadingOverlay.Transparent,
+            chatLoadingOverlay(isMessageLoading = true, hasActiveLoadSteps = true, hasContent = true),
+        )
+    }
+
+    @Test
+    fun chatLoading_emptyHistoryWithPendingQuestion_isTransparent() {
+        val hasContent = hasChatContent(
+            hasMessages = false,
+            isBusy = false,
+            hasPendingQuestion = true,
+            hasSessionPendingPermissions = false,
+        )
+
+        assertEquals(
+            ChatLoadingOverlay.Transparent,
+            chatLoadingOverlay(isMessageLoading = true, hasActiveLoadSteps = false, hasContent = hasContent),
+        )
+    }
+
+    @Test
+    fun chatLoading_incidentalStep_isTransparent() {
+        assertEquals(
+            ChatLoadingOverlay.Transparent,
+            chatLoadingOverlay(isMessageLoading = false, hasActiveLoadSteps = true, hasContent = false),
+        )
+        assertEquals(
+            ChatLoadingOverlay.Transparent,
+            chatLoadingOverlay(isMessageLoading = false, hasActiveLoadSteps = true, hasContent = true),
+        )
+    }
+
+    @Test
+    fun chatLoading_noActivity_isNone() {
+        assertEquals(
+            ChatLoadingOverlay.None,
+            chatLoadingOverlay(isMessageLoading = false, hasActiveLoadSteps = false, hasContent = false),
+        )
+        assertEquals(
+            ChatLoadingOverlay.None,
+            chatLoadingOverlay(isMessageLoading = false, hasActiveLoadSteps = false, hasContent = true),
+        )
+    }
+
     private fun assistantMessage(
         id: String,
         providerID: String,


### PR DESCRIPTION
## Proposed behavior

This PR improves mobile chat readability without replacing the app's deliberately lightweight, line-oriented streaming Markdown parser:

- only genuinely empty session-message loads show an opaque, full-bleed loading overlay, so existing/cached/pending content and incidental in-session steps stay visible;
- headings, strong text, and list markers use the existing OpenCode Markdown theme tokens;
- contiguous list-item runs preserve mixed ordered/unordered nesting, source numbering, and semantic indentation;
- list markers reserve one exact measured column at the active font scale; markers longer than six visible characters are bounded with an ellipsis while preserving their suffix;
- visual indentation is capped so deeply nested agent output stays readable on phones.

## Changes

- **Parser** (`StreamingMarkdown.kt`): a contiguous list run is one `ListBlock` even when markers switch between ordered and unordered; raw leading whitespace (spaces, and tabs counted as four spaces) is normalized through an indentation stack into per-item semantic `indentLevel`; ordered source numbers are preserved. Blank lines split list runs.
- **Renderer**: one text-measured marker column per run, `softWrap=false` with end alignment; measurement and rendering use the same bounded display marker; heading/strong/list colors come from theme tokens; nested indentation renders compact steps capped at four visual levels.
- **Loading overlay** (`ChatScreen.kt`): a pure presentation seam returns Opaque only while session messages load over no rendered content, Transparent for incidental steps or loads over populated/pending content, and None when idle. Both visible modes retain `chat_loading_overlay` and expose the localized `Loading` content description.
- Tests cover list indentation normalization (2-space, 4-space, 0/4/8, fragments, tabs), blank-line list separation, mixed ordered/unordered runs, bounded display markers, and the loading-overlay state machine.

## Verification

Validated on the final integrated tree with Temurin Java 17:

- `:app:compileDebugKotlin --rerun-tasks` — pass
- `:app:detekt --rerun-tasks` — pass
- focused Markdown/loading tests — pass
- `:app:testDebugUnitTest --rerun-tasks` — pass (840 tests, 0 failures, 1 ignored)
- `:app:assembleDebug --rerun-tasks --no-configuration-cache` — pass
- `:app:assembleGithubRelease --rerun-tasks --no-configuration-cache` — pass
- `git diff --check origin/main` — pass

## Known scope

This deliberately keeps the existing custom streaming parser; it does not migrate to a third-party Markdown renderer or rework table/fence layout. Renderer token wiring and measured geometry are covered by source/state tests and build gates, but not by a dedicated Compose screenshot test.