### PR TITLE
feat: jump to previous user message

### DIFF
--- a/app/src/androidTest/java/dev/blazelight/p4oc/ui/components/chat/ChatJumpNavigationButtonsTest.kt
+++ b/app/src/androidTest/java/dev/blazelight/p4oc/ui/components/chat/ChatJumpNavigationButtonsTest.kt
@@ -1,0 +1,107 @@
+package dev.blazelight.p4oc.ui.components.chat
+
+import androidx.compose.ui.test.assertContentDescriptionEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import dev.blazelight.p4oc.R
+import dev.blazelight.p4oc.ui.theme.PocketCodeTheme
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ChatJumpNavigationButtonsTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun bothButtonsShowDescriptionsInNavigationOrderAndHandleClicks() {
+        var previousClicks = 0
+        var bottomClicks = 0
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+
+        composeRule.setContent {
+            PocketCodeTheme {
+                ChatJumpNavigationButtons(
+                    showPrevious = true,
+                    showBottom = true,
+                    hasNewContent = true,
+                    onPrevious = { previousClicks++ },
+                    onBottom = { bottomClicks++ },
+                )
+            }
+        }
+
+        val previous = composeRule.onNodeWithTag("jump_to_previous_user_button")
+        val bottom = composeRule.onNodeWithTag("jump_to_bottom_button")
+        previous
+            .assertIsDisplayed()
+            .assertContentDescriptionEquals(context.getString(R.string.cd_jump_to_previous_user_message))
+        bottom
+            .assertIsDisplayed()
+            .assertContentDescriptionEquals(context.getString(R.string.cd_jump_to_bottom))
+
+        val previousBounds = previous.fetchSemanticsNode().boundsInRoot
+        val bottomBounds = bottom.fetchSemanticsNode().boundsInRoot
+        assertTrue("Previous action must be before the bottom action", previousBounds.left < bottomBounds.left)
+
+        previous.performClick()
+        bottom.performClick()
+        composeRule.runOnIdle {
+            assertEquals(1, previousClicks)
+            assertEquals(1, bottomClicks)
+        }
+    }
+
+    @Test
+    fun previousOnlyShowsAndHandlesPreviousAction() {
+        var previousClicks = 0
+
+        composeRule.setContent {
+            PocketCodeTheme {
+                ChatJumpNavigationButtons(
+                    showPrevious = true,
+                    showBottom = false,
+                    hasNewContent = false,
+                    onPrevious = { previousClicks++ },
+                    onBottom = {},
+                )
+            }
+        }
+
+        composeRule.onNodeWithTag("jump_to_previous_user_button")
+            .assertIsDisplayed()
+            .performClick()
+        composeRule.onNodeWithTag("jump_to_bottom_button").assertDoesNotExist()
+        composeRule.runOnIdle { assertEquals(1, previousClicks) }
+    }
+
+    @Test
+    fun bottomOnlyShowsAndHandlesBottomAction() {
+        var bottomClicks = 0
+
+        composeRule.setContent {
+            PocketCodeTheme {
+                ChatJumpNavigationButtons(
+                    showPrevious = false,
+                    showBottom = true,
+                    hasNewContent = false,
+                    onPrevious = {},
+                    onBottom = { bottomClicks++ },
+                )
+            }
+        }
+
+        composeRule.onNodeWithTag("jump_to_previous_user_button").assertDoesNotExist()
+        composeRule.onNodeWithTag("jump_to_bottom_button")
+            .assertIsDisplayed()
+            .performClick()
+        composeRule.runOnIdle { assertEquals(1, bottomClicks) }
+    }
+}

--- a/app/src/main/java/dev/blazelight/p4oc/ui/components/chat/ChatMessage.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/components/chat/ChatMessage.kt
@@ -38,6 +38,11 @@ import dev.blazelight.p4oc.ui.theme.Spacing
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.contentOrNull
 
+internal fun MessageWithParts.hasVisibleUserText(): Boolean =
+    message is Message.User && parts.any { part ->
+        part is Part.Text && !part.synthetic && !part.ignored && part.text.isNotBlank()
+    }
+
 @Composable
 @Suppress("LongParameterList", "FunctionNaming")
 fun ChatMessage(
@@ -122,14 +127,13 @@ private fun UserMessage(
     val haptic = LocalHapticFeedback.current
     val density = LocalDensity.current
     var revertActionWidthPx by remember { mutableIntStateOf(0) }
+    if (!messageWithParts.hasVisibleUserText()) return
+
     // Filter out synthetic text parts (system prompts, AGENTS.md content, etc.)
     val textParts = messageWithParts.parts
         .filterIsInstance<Part.Text>()
         .filter { !it.synthetic && !it.ignored }
     val text = textParts.joinToString("\n") { it.text }
-
-    // Don't render anything if there's no visible text
-    if (text.isBlank()) return
 
     // TUI style: flat panel surface with a "you" label — matches the design's user block.
     Box(

--- a/app/src/main/java/dev/blazelight/p4oc/ui/components/chat/JumpToBottomButton.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/components/chat/JumpToBottomButton.kt
@@ -1,8 +1,22 @@
 package dev.blazelight.p4oc.ui.components.chat
 
-import androidx.compose.animation.*
-import androidx.compose.material3.*
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.PlainTooltip
+import androidx.compose.material3.SmallFloatingActionButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TooltipBox
+import androidx.compose.material3.TooltipDefaults
+import androidx.compose.material3.rememberTooltipState
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.platform.testTag
@@ -12,48 +26,93 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontFamily
 import dev.blazelight.p4oc.R
 import dev.blazelight.p4oc.ui.theme.LocalOpenCodeTheme
+import dev.blazelight.p4oc.ui.theme.Spacing
 
 /**
- * Floating action button that appears when the user has scrolled away from the bottom.
- * Tapping it scrolls back to the latest content.
+ * Contextual chat navigation actions, ordered from older content to newer content.
  */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun JumpToBottomButton(
-    visible: Boolean,
+@Suppress("LongParameterList", "FunctionNaming")
+fun ChatJumpNavigationButtons(
+    showPrevious: Boolean,
+    showBottom: Boolean,
     hasNewContent: Boolean,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier
+    onPrevious: () -> Unit,
+    onBottom: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     val theme = LocalOpenCodeTheme.current
-    val jumpDescription = stringResource(R.string.cd_jump_to_bottom)
+    val previousDescription = stringResource(R.string.cd_jump_to_previous_user_message)
+    val bottomDescription = stringResource(R.string.cd_jump_to_bottom)
 
     AnimatedVisibility(
-        visible = visible,
+        visible = showPrevious || showBottom,
         enter = fadeIn() + slideInVertically { it },
         exit = fadeOut() + slideOutVertically { it },
-        modifier = modifier
+        modifier = modifier,
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(Spacing.xs),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            if (showPrevious) {
+                ChatJumpNavigationButton(
+                    glyph = "↑",
+                    description = previousDescription,
+                    onClick = onPrevious,
+                    containerColor = theme.backgroundElement,
+                    contentColor = theme.textMuted,
+                    testTag = "jump_to_previous_user_button",
+                )
+            }
+            if (showBottom) {
+                ChatJumpNavigationButton(
+                    glyph = "↓",
+                    description = bottomDescription,
+                    onClick = onBottom,
+                    containerColor = if (hasNewContent) theme.accent else theme.backgroundElement,
+                    contentColor = if (hasNewContent) theme.background else theme.textMuted,
+                    testTag = "jump_to_bottom_button",
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+@Suppress("LongParameterList", "FunctionNaming")
+private fun ChatJumpNavigationButton(
+    glyph: String,
+    description: String,
+    onClick: () -> Unit,
+    containerColor: androidx.compose.ui.graphics.Color,
+    contentColor: androidx.compose.ui.graphics.Color,
+    testTag: String,
+) {
+    TooltipBox(
+        positionProvider = TooltipDefaults.rememberTooltipPositionProvider(),
+        tooltip = {
+            PlainTooltip {
+                Text(description)
+            }
+        },
+        state = rememberTooltipState(),
     ) {
         SmallFloatingActionButton(
             onClick = onClick,
-            containerColor = if (hasNewContent) {
-                theme.accent
-            } else {
-                theme.backgroundElement
-            },
-            contentColor = if (hasNewContent) {
-                theme.background
-            } else {
-                theme.textMuted
-            },
+            containerColor = containerColor,
+            contentColor = contentColor,
             shape = RectangleShape,
             modifier = Modifier
-                .semantics { contentDescription = jumpDescription }
-                .testTag("jump_to_bottom_button")
+                .semantics { contentDescription = description }
+                .testTag(testTag),
         ) {
             Text(
-                text = "↓",
+                text = glyph,
                 fontFamily = FontFamily.Monospace,
-                style = MaterialTheme.typography.titleMedium
+                style = MaterialTheme.typography.titleMedium,
             )
         }
     }

--- a/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ChatScreen.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ChatScreen.kt
@@ -45,8 +45,8 @@ import dev.blazelight.p4oc.ui.components.TuiLoadingScreen
 import dev.blazelight.p4oc.ui.components.TuiSnackbar
 import dev.blazelight.p4oc.ui.components.TuiTopBar
 import dev.blazelight.p4oc.ui.components.chat.ChatInputBar
+import dev.blazelight.p4oc.ui.components.chat.ChatJumpNavigationButtons
 import dev.blazelight.p4oc.ui.components.chat.FilePickerDialog
-import dev.blazelight.p4oc.ui.components.chat.JumpToBottomButton
 import dev.blazelight.p4oc.ui.components.chat.InlinePermissionPrompt
 import dev.blazelight.p4oc.ui.components.chat.ModelAgentSelectorBar
 import dev.blazelight.p4oc.ui.components.command.CommandPalette
@@ -227,6 +227,7 @@ fun ChatScreen(
         saver = ChatScrollRestorationState.Saver
     ) { ChatScrollRestorationState() }
     val messageBlocks = remember(messages, uiState.isBusy) { groupMessagesIntoBlocks(messages, uiState.isBusy) }
+    val olderMessagesItemOffset = if (uiState.hasOlderMessages) 1 else 0
     // A streaming assistant is initially reported with all-zero token totals.
     // Retain the newest meaningful usage until the live reply gains real usage.
     val contextUsage = remember(messages) { latestAssistantContextUsage(messages) }
@@ -242,6 +243,17 @@ fun ChatScreen(
     // discarded, zero-item instance.
     val isAtBottom by remember(listState) {
         derivedStateOf { !listState.canScrollForward }
+    }
+    val previousUserBlockIndex by remember(listState, messageBlocks, olderMessagesItemOffset) {
+        derivedStateOf {
+            val firstVisibleBlockIndex =
+                (listState.firstVisibleItemIndex - olderMessagesItemOffset).coerceAtMost(messageBlocks.size)
+            previousUserMessageBlockIndex(
+                blocks = messageBlocks,
+                firstVisibleBlockIndex = firstVisibleBlockIndex,
+                firstVisibleItemScrollOffset = listState.firstVisibleItemScrollOffset,
+            )
+        }
     }
 
     val focusManager = LocalFocusManager.current
@@ -340,7 +352,6 @@ fun ChatScreen(
             if (blockIndex != null) {
                 // Keep streaming tail updates from immediately pulling the viewport away again.
                 scrollRestorationState.shouldFollowTail = false
-                val olderMessagesItemOffset = if (uiState.hasOlderMessages) 1 else 0
                 listState.scrollToItem(blockIndex + olderMessagesItemOffset)
             } else {
                 scrollRestorationState.onJumpToBottom()
@@ -674,11 +685,19 @@ fun ChatScreen(
                     }
                 }
 
-                // Jump to bottom button - shows when scrolled away from the tail.
-                JumpToBottomButton(
-                    visible = !isAtBottom,
+                ChatJumpNavigationButtons(
+                    showPrevious = previousUserBlockIndex != null,
+                    showBottom = !isAtBottom,
                     hasNewContent = scrollRestorationState.hasNewContentWhileAway,
-                    onClick = {
+                    onPrevious = {
+                        previousUserBlockIndex?.let { blockIndex ->
+                            coroutineScope.launch {
+                                scrollRestorationState.onJumpToPreviousUser()
+                                listState.scrollToItem(blockIndex + olderMessagesItemOffset)
+                            }
+                        }
+                    },
+                    onBottom = {
                         coroutineScope.launch {
                             scrollRestorationState.onJumpToBottom()
                             listState.scrollChatToBottom()

--- a/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ChatScrollRestorationState.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ChatScrollRestorationState.kt
@@ -6,11 +6,41 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.setValue
+import dev.blazelight.p4oc.ui.components.chat.hasVisibleUserText
 
 internal enum class InitialTailDecision {
     ScrollToTail,
     KeepRestoredPosition,
     NoContent
+}
+
+internal fun previousUserMessageBlockIndex(
+    blocks: List<MessageBlock>,
+    firstVisibleBlockIndex: Int,
+    firstVisibleItemScrollOffset: Int,
+): Int? {
+    var targetIndex: Int? = null
+    if (firstVisibleBlockIndex in 0..blocks.size) {
+        val firstVisibleBlock = blocks.getOrNull(firstVisibleBlockIndex)
+        val partiallyVisibleUser =
+            firstVisibleItemScrollOffset > 0 &&
+                firstVisibleBlock is MessageBlock.UserBlock &&
+                firstVisibleBlock.message.hasVisibleUserText()
+        var index = when {
+            partiallyVisibleUser -> firstVisibleBlockIndex
+            firstVisibleBlockIndex == blocks.size -> blocks.lastIndex
+            else -> firstVisibleBlockIndex - 1
+        }
+
+        while (index >= 0 && targetIndex == null) {
+            val block = blocks[index]
+            if (block is MessageBlock.UserBlock && block.message.hasVisibleUserText()) {
+                targetIndex = index
+            }
+            index--
+        }
+    }
+    return targetIndex
 }
 
 internal class ChatScrollRestorationState(
@@ -51,6 +81,10 @@ internal class ChatScrollRestorationState(
     fun onJumpToBottom() {
         shouldFollowTail = true
         hasNewContentWhileAway = false
+    }
+
+    fun onJumpToPreviousUser() {
+        shouldFollowTail = false
     }
 
     fun shouldPinTailForIme(composerFocused: Boolean, hasRenderableTail: Boolean): Boolean =

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -684,6 +684,7 @@
     <string name="cd_show_branches">Show branches</string>
     <string name="cd_fork_conversation">Fork conversation from here</string>
     <string name="cd_delete_branch">Delete branch</string>
+    <string name="cd_jump_to_previous_user_message">Previous user message</string>
     <string name="cd_jump_to_bottom">Jump to bottom</string>
     <string name="cd_add_more_files">Add more files</string>
     <string name="cd_attach_files">Attach files</string>

--- a/app/src/test/java/dev/blazelight/p4oc/ui/screens/chat/ChatScrollRestorationTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/ui/screens/chat/ChatScrollRestorationTest.kt
@@ -1,7 +1,12 @@
 package dev.blazelight.p4oc.ui.screens.chat
 
+import dev.blazelight.p4oc.domain.model.Message
+import dev.blazelight.p4oc.domain.model.MessageWithParts
+import dev.blazelight.p4oc.domain.model.ModelRef
+import dev.blazelight.p4oc.domain.model.Part
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -75,6 +80,176 @@ class ChatScrollRestorationTest {
     }
 
     @Test
+    fun assistantAnchorFindsNearestPrecedingUserBlock() {
+        val blocks = listOf(
+            userBlock("user-1"),
+            assistantBlock(),
+            userBlock("user-2"),
+            assistantBlock(),
+        )
+
+        assertEquals(
+            2,
+            previousUserMessageBlockIndex(
+                blocks = blocks,
+                firstVisibleBlockIndex = 3,
+                firstVisibleItemScrollOffset = 400,
+            ),
+        )
+    }
+
+    @Test
+    fun partiallyScrolledUserSnapsToCurrentUserAndAlignedUserMovesEarlier() {
+        val blocks = listOf(
+            userBlock("user-1"),
+            assistantBlock(),
+            userBlock("user-2"),
+        )
+
+        assertEquals(
+            2,
+            previousUserMessageBlockIndex(
+                blocks = blocks,
+                firstVisibleBlockIndex = 2,
+                firstVisibleItemScrollOffset = 1,
+            ),
+        )
+        assertEquals(
+            0,
+            previousUserMessageBlockIndex(
+                blocks = blocks,
+                firstVisibleBlockIndex = 2,
+                firstVisibleItemScrollOffset = 0,
+            ),
+        )
+    }
+
+    @Test
+    fun repeatedNavigationWalksBackwardThroughUserBlocks() {
+        val blocks = listOf(
+            userBlock("user-1"),
+            assistantBlock(),
+            userBlock("user-2"),
+            assistantBlock(),
+            userBlock("user-3"),
+        )
+
+        val newest = checkNotNull(previousUserMessageBlockIndex(blocks, blocks.size, 0))
+        val middle = checkNotNull(previousUserMessageBlockIndex(blocks, newest, 0))
+        val oldest = checkNotNull(previousUserMessageBlockIndex(blocks, middle, 0))
+
+        assertEquals(4, newest)
+        assertEquals(2, middle)
+        assertEquals(0, oldest)
+        assertNull(previousUserMessageBlockIndex(blocks, oldest, 0))
+    }
+
+    @Test
+    fun virtualTrailingAnchorFindsLatestUserBeforePendingRows() {
+        val blocks = listOf(
+            userBlock("user-1"),
+            assistantBlock(),
+        )
+
+        assertEquals(
+            0,
+            previousUserMessageBlockIndex(
+                blocks = blocks,
+                firstVisibleBlockIndex = blocks.size,
+                firstVisibleItemScrollOffset = 37,
+            ),
+        )
+    }
+
+    @Test
+    fun partiallyScrolledInvisibleUserSkipsToPreviousVisibleUser() {
+        val blocks = listOf(
+            userBlock("user-1"),
+            userBlock("blank-user", text = " \n\t"),
+            userBlock("ignored-user", ignored = true),
+            userBlock("synthetic-user", synthetic = true),
+        )
+
+        assertEquals(
+            0,
+            previousUserMessageBlockIndex(
+                blocks = blocks,
+                firstVisibleBlockIndex = 3,
+                firstVisibleItemScrollOffset = 1,
+            ),
+        )
+    }
+
+    @Test
+    fun virtualTrailingAnchorSkipsEveryKindOfInvisibleUserRecord() {
+        val blocks = listOf(
+            userBlock("user-1"),
+            assistantBlock(),
+            userBlock("synthetic-user", synthetic = true),
+            userBlock("ignored-user", ignored = true),
+            userBlock("blank-user", text = "   "),
+        )
+
+        assertEquals(
+            0,
+            previousUserMessageBlockIndex(
+                blocks = blocks,
+                firstVisibleBlockIndex = blocks.size,
+                firstVisibleItemScrollOffset = 37,
+            ),
+        )
+        assertNull(
+            previousUserMessageBlockIndex(
+                blocks = blocks.drop(2),
+                firstVisibleBlockIndex = blocks.size - 2,
+                firstVisibleItemScrollOffset = 0,
+            ),
+        )
+    }
+
+    @Test
+    fun invalidHeaderAndNoUserAnchorsHaveNoTarget() {
+        val blocksWithUser = listOf(userBlock("user-1"), assistantBlock())
+        val assistantOnly = listOf(assistantBlock(), assistantBlock())
+
+        assertNull(
+            previousUserMessageBlockIndex(
+                blocksWithUser,
+                firstVisibleBlockIndex = -1,
+                firstVisibleItemScrollOffset = 0,
+            ),
+        )
+        assertNull(
+            previousUserMessageBlockIndex(
+                blocksWithUser,
+                firstVisibleBlockIndex = blocksWithUser.size + 1,
+                firstVisibleItemScrollOffset = 0,
+            ),
+        )
+        assertNull(previousUserMessageBlockIndex(assistantOnly, assistantOnly.size, 0))
+        assertNull(
+            previousUserMessageBlockIndex(
+                emptyList(),
+                firstVisibleBlockIndex = 0,
+                firstVisibleItemScrollOffset = 0,
+            ),
+        )
+    }
+
+    @Test
+    fun jumpToPreviousUserDisablesTailFollowingWithoutClearingNewContent() {
+        val state = ChatScrollRestorationState(
+            shouldFollowTail = true,
+            hasNewContentWhileAway = true,
+        )
+
+        state.onJumpToPreviousUser()
+
+        assertFalse(state.shouldFollowTail)
+        assertTrue(state.hasNewContentWhileAway)
+    }
+
+    @Test
     fun followingTailPinsWhenComposerFocusedAndContentPresent() {
         val state = ChatScrollRestorationState()
         state.onContentReady(hasRenderableTail = true)
@@ -141,4 +316,34 @@ class ChatScrollRestorationTest {
         assertEquals(InitialTailDecision.KeepRestoredPosition, state.onContentReady(hasRenderableTail = true))
         assertFalse(state.shouldFollowTail)
     }
+
+    private fun userBlock(
+        id: String,
+        text: String = id,
+        synthetic: Boolean = false,
+        ignored: Boolean = false,
+    ): MessageBlock.UserBlock = MessageBlock.UserBlock(
+        message = MessageWithParts(
+            message = Message.User(
+                id = id,
+                sessionID = "session-1",
+                createdAt = 1L,
+                agent = "general",
+                model = ModelRef(providerID = "provider-1", modelID = "model-1"),
+            ),
+            parts = listOf(
+                Part.Text(
+                    id = "part-$id",
+                    sessionID = "session-1",
+                    messageID = id,
+                    text = text,
+                    synthetic = synthetic,
+                    ignored = ignored,
+                ),
+            ),
+        ),
+    )
+
+    private fun assistantBlock(): MessageBlock.AssistantBlock =
+        MessageBlock.AssistantBlock(messages = emptyList())
 }


### PR DESCRIPTION
Closes #51.

## Problem

Long chats have a jump-to-bottom action but no compact way to move backward between user prompts.

## Changes

- Adds a contextual ↑ action beside the existing ↓ action.
- ↑ jumps to the nearest preceding rendered user message; repeated presses walk backward.
- A partially scrolled user message first snaps to its own top.
- ↓ retains its existing jump-to-tail and new-content accent behavior.
- Handles the optional load-older row and trailing permission/question rows without index drift.
- Previous-user navigation disables automatic tail following so streaming cannot immediately pull the viewport back.
- Synthetic, ignored, and blank-only user records are skipped because they do not render.
- Adds localized tooltips, content descriptions, and stable test tags.

## Verification

Java 17:

- `./gradlew :app:testDebugUnitTest --tests dev.blazelight.p4oc.ui.screens.chat.ChatScrollRestorationTest`
- `./gradlew :app:testDebugUnitTest :app:detekt :app:assembleDebug`
- `./gradlew :app:compileDebugAndroidTestKotlin --rerun-tasks`
- `ANDROID_SERIAL=R58X70XHB9P ./gradlew :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=dev.blazelight.p4oc.ui.components.chat.ChatJumpNavigationButtonsTest`
- `git diff --check origin/main`

The three control instrumentation tests passed on Samsung SM-A155F (`R58X70XHB9P`). The final APK was reinstalled and cold-launched afterward; the crash buffer remained empty.

Final independent Sol review: SHIP, no remaining production blockers.