### PR TITLE
Wire dormant session features into the UI

### DIFF
--- a/app/src/androidTest/java/dev/blazelight/p4oc/ui/components/chat/ChatInputBarSubmissionTest.kt
+++ b/app/src/androidTest/java/dev/blazelight/p4oc/ui/components/chat/ChatInputBarSubmissionTest.kt
@@ -1,0 +1,150 @@
+package dev.blazelight.p4oc.ui.components.chat
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performImeAction
+import androidx.compose.ui.test.performTextInput
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import dev.blazelight.p4oc.ui.theme.PocketCodeTheme
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ChatInputBarSubmissionTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun sendButton_refusedSlashPreservesExactText_andAcceptedSlashClearsOnce() {
+        val exactSlash = "/custom exact  arguments "
+        var acceptsSubmission by mutableStateOf(false)
+        var sendCalls = 0
+        var clearedValues = 0
+
+        composeRule.setContent {
+            var value by remember { mutableStateOf("") }
+            PocketCodeTheme {
+                ChatInputBar(
+                    value = value,
+                    onValueChange = {
+                        if (value.isNotEmpty() && it.isEmpty()) clearedValues++
+                        value = it
+                    },
+                    onSend = {
+                        sendCalls++
+                        acceptsSubmission
+                    },
+                    isLoading = false,
+                    enabled = true,
+                )
+            }
+        }
+
+        val input = composeRule.onNodeWithTag("chat_input")
+        input.performTextInput(exactSlash)
+        composeRule.onNodeWithTag("send_button").performClick()
+
+        input.assertTextEquals(exactSlash)
+        composeRule.runOnIdle {
+            assertEquals(1, sendCalls)
+            assertEquals(0, clearedValues)
+            acceptsSubmission = true
+        }
+
+        composeRule.onNodeWithTag("send_button").performClick()
+
+        input.assertTextEquals("")
+        composeRule.runOnIdle {
+            assertEquals(2, sendCalls)
+            assertEquals(1, clearedValues)
+        }
+    }
+
+    @Test
+    fun imeAction_refusedSlashPreservesExactText_andAcceptedSlashClearsOnce() {
+        val exactSlash = "/custom keep  exact "
+        var acceptsSubmission by mutableStateOf(false)
+        var sendCalls = 0
+        var clearedValues = 0
+
+        composeRule.setContent {
+            var value by remember { mutableStateOf("") }
+            PocketCodeTheme {
+                ChatInputBar(
+                    value = value,
+                    onValueChange = {
+                        if (value.isNotEmpty() && it.isEmpty()) clearedValues++
+                        value = it
+                    },
+                    onSend = {
+                        sendCalls++
+                        acceptsSubmission
+                    },
+                    isLoading = false,
+                    enabled = true,
+                    enterToSend = true,
+                )
+            }
+        }
+
+        val input = composeRule.onNodeWithTag("chat_input")
+        input.performTextInput(exactSlash)
+        input.performImeAction()
+
+        input.assertTextEquals(exactSlash)
+        composeRule.runOnIdle {
+            assertEquals(1, sendCalls)
+            assertEquals(0, clearedValues)
+            acceptsSubmission = true
+        }
+
+        input.performImeAction()
+
+        input.assertTextEquals("")
+        composeRule.runOnIdle {
+            assertEquals(2, sendCalls)
+            assertEquals(1, clearedValues)
+        }
+    }
+
+    @Test
+    fun syncGenerationChange_restoresUnchangedParentSlashAfterAcceptedClear() {
+        val exactSlash = "/custom restore  exact "
+        var valueSyncGeneration by mutableStateOf(0L)
+        var clearedValues = 0
+
+        composeRule.setContent {
+            PocketCodeTheme {
+                ChatInputBar(
+                    value = exactSlash,
+                    onValueChange = { if (it.isEmpty()) clearedValues++ },
+                    onSend = { true },
+                    isLoading = false,
+                    enabled = true,
+                    valueSyncGeneration = valueSyncGeneration,
+                )
+            }
+        }
+
+        val input = composeRule.onNodeWithTag("chat_input")
+        input.assertTextEquals(exactSlash)
+        composeRule.onNodeWithTag("send_button").performClick()
+
+        input.assertTextEquals("")
+        composeRule.runOnIdle {
+            assertEquals(1, clearedValues)
+            valueSyncGeneration++
+        }
+
+        composeRule.waitForIdle()
+        input.assertTextEquals(exactSlash)
+    }
+}

--- a/app/src/androidTest/java/dev/blazelight/p4oc/ui/components/chat/ChatInputBarVolumeKeyTest.kt
+++ b/app/src/androidTest/java/dev/blazelight/p4oc/ui/components/chat/ChatInputBarVolumeKeyTest.kt
@@ -36,7 +36,7 @@ class ChatInputBarVolumeKeyTest {
                 ChatInputBar(
                     value = value,
                     onValueChange = { value = it },
-                    onSend = {},
+                    onSend = { true },
                     isLoading = false,
                     enabled = true,
                     requestFocus = true,

--- a/app/src/androidTest/java/dev/blazelight/p4oc/ui/components/chat/ChatMessageTokenUsageTest.kt
+++ b/app/src/androidTest/java/dev/blazelight/p4oc/ui/components/chat/ChatMessageTokenUsageTest.kt
@@ -1,0 +1,138 @@
+package dev.blazelight.p4oc.ui.components.chat
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import dev.blazelight.p4oc.domain.model.Message
+import dev.blazelight.p4oc.domain.model.MessageWithParts
+import dev.blazelight.p4oc.domain.model.TokenUsage
+import dev.blazelight.p4oc.ui.theme.PocketCodeTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ChatMessageTokenUsageTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun completedAssistantDisplaysTokenUsageAndCost() {
+        setAssistantUsage(
+            tokens = TokenUsage(
+                input = Int.MAX_VALUE,
+                output = 1,
+                reasoning = 2,
+                cacheRead = 3,
+                cacheWrite = 4,
+            ),
+            cost = 0.0123,
+        )
+
+        assertUsageRow("2147483657 total", "2147483647/1", "\$0.0123")
+    }
+
+    @Test
+    fun reasoningOnlyUsageDisplaysNonzeroTotalAndInputOutputDetail() {
+        setAssistantUsage(
+            tokens = TokenUsage(input = 0, output = 0, reasoning = 17),
+            cost = 0.0,
+        )
+
+        assertUsageRow("17 total", "0/0")
+    }
+
+    @Test
+    fun cacheOnlyUsageDisplaysCombinedNonzeroTotalAndInputOutputDetail() {
+        setAssistantUsage(
+            tokens = TokenUsage(input = 0, output = 0, cacheRead = 19, cacheWrite = 23),
+            cost = 0.0,
+        )
+
+        assertUsageRow("42 total", "0/0")
+    }
+
+    @Test
+    fun positiveCostOnlyDisplaysUsageRowAndLocaleStableCost() {
+        setAssistantUsage(
+            tokens = TokenUsage(input = 0, output = 0),
+            cost = 0.5,
+        )
+
+        assertUsageRow("0 total", "0/0", "\$0.5000")
+    }
+
+    @Test
+    fun tinyPositiveCostDisplaysMinimumCostIndicator() {
+        setAssistantUsage(
+            tokens = TokenUsage(input = 0, output = 0),
+            cost = 0.00001,
+        )
+
+        assertUsageRow("0 total", "0/0", "<\$0.0001")
+    }
+
+    @Test
+    fun assistantWithZeroUsageOmitsUsageRow() {
+        setAssistantUsage(
+            tokens = TokenUsage(
+                input = 0,
+                output = 0,
+                reasoning = 0,
+                cacheRead = 0,
+                cacheWrite = 0,
+            ),
+            cost = 0.0,
+        )
+
+        composeRule.onNodeWithTag("assistant_token_usage").assertDoesNotExist()
+    }
+
+    private fun setAssistantUsage(tokens: TokenUsage, cost: Double) {
+        composeRule.setContent {
+            PocketCodeTheme {
+                AssistantMessages(
+                    messagesWithParts = listOf(
+                        completedAssistantMessage(
+                            tokens = tokens,
+                            cost = cost,
+                        ),
+                    ),
+                    onToolApprove = {},
+                    onToolDeny = {},
+                    onToolAlways = {},
+                )
+            }
+        }
+    }
+
+    private fun assertUsageRow(total: String, inputOutput: String, cost: String? = null) {
+        composeRule.onNodeWithTag("assistant_token_usage").assertIsDisplayed()
+        composeRule.onNodeWithText(total, substring = false).assertIsDisplayed()
+        composeRule.onNodeWithText(inputOutput, substring = false).assertIsDisplayed()
+        cost?.let { composeRule.onNodeWithText(it, substring = false).assertIsDisplayed() }
+    }
+
+    private fun completedAssistantMessage(
+        tokens: TokenUsage,
+        cost: Double,
+    ) = MessageWithParts(
+        message = Message.Assistant(
+            id = "assistant-message",
+            sessionID = "session",
+            createdAt = 1L,
+            completedAt = 2L,
+            parentID = "user-message",
+            providerID = "provider",
+            modelID = "model",
+            mode = "build",
+            agent = "build",
+            cost = cost,
+            tokens = tokens,
+            finish = "stop",
+        ),
+        parts = emptyList(),
+    )
+}

--- a/app/src/main/java/dev/blazelight/p4oc/data/remote/dto/SessionDtos.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/data/remote/dto/SessionDtos.kt
@@ -117,12 +117,12 @@ data class RevertSessionRequest(
     @SerialName("partID") val partID: String? = null
 )
 
-// SummarizeSessionRequest removed — the /summarize endpoint body is optional
-// and the server uses its own default provider/model when omitted.
-
 @Serializable
 data class InitSessionRequest(
     @SerialName("messageID") val messageID: String,
     @SerialName("providerID") val providerID: String,
     @SerialName("modelID") val modelID: String
 )
+
+// SummarizeSessionRequest removed — the /summarize endpoint body is optional
+// and the server uses its own default provider/model when omitted.

--- a/app/src/main/java/dev/blazelight/p4oc/data/session/SessionRepositoryImpl.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/data/session/SessionRepositoryImpl.kt
@@ -3,6 +3,8 @@ package dev.blazelight.p4oc.data.session
 import dev.blazelight.p4oc.core.log.AppLog
 import dev.blazelight.p4oc.data.files.ofish.OfishSessionNames
 import dev.blazelight.p4oc.data.remote.dto.CreateSessionRequest
+import dev.blazelight.p4oc.data.remote.dto.ForkSessionRequest
+import dev.blazelight.p4oc.data.remote.dto.InitSessionRequest
 import dev.blazelight.p4oc.data.remote.dto.ProjectDto
 import dev.blazelight.p4oc.data.remote.dto.QuestionRequestDto
 import dev.blazelight.p4oc.data.remote.dto.SendMessageRequest
@@ -874,6 +876,16 @@ class SessionRepositoryImpl(
         upsert(workspaceSession)
         return workspaceSession
     }
+
+    suspend fun forkSession(id: SessionId): WorkspaceSession {
+        val dto = client.forkSession(id.value, ForkSessionRequest(messageID = null))
+        val session = workspaceSession(SessionMapper.mapToDomain(dto))
+        upsert(session)
+        return session
+    }
+
+    suspend fun initSession(id: SessionId, request: InitSessionRequest): Boolean =
+        client.initSession(id.value, request)
 
     suspend fun deleteSession(id: SessionId) {
         val before = state.value.snapshot

--- a/app/src/main/java/dev/blazelight/p4oc/data/workspace/SessionWorkspaceClient.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/data/workspace/SessionWorkspaceClient.kt
@@ -1,6 +1,8 @@
 package dev.blazelight.p4oc.data.workspace
 
 import dev.blazelight.p4oc.data.remote.dto.CreateSessionRequest
+import dev.blazelight.p4oc.data.remote.dto.ForkSessionRequest
+import dev.blazelight.p4oc.data.remote.dto.InitSessionRequest
 import dev.blazelight.p4oc.data.remote.dto.PermissionDto
 import dev.blazelight.p4oc.data.remote.dto.PermissionV2RequestDto
 import dev.blazelight.p4oc.data.remote.dto.ProjectDto
@@ -31,6 +33,8 @@ interface SessionWorkspaceClient {
 
     suspend fun createSession(request: CreateSessionRequest): SessionDto
 
+    suspend fun forkSession(id: String, request: ForkSessionRequest): SessionDto
+
     suspend fun deleteSession(id: String): Boolean
 
     suspend fun updateSession(id: String, request: UpdateSessionRequest): SessionDto
@@ -40,6 +44,8 @@ interface SessionWorkspaceClient {
     suspend fun unshareSession(id: String): SessionDto
 
     suspend fun summarizeSession(id: String): Boolean
+
+    suspend fun initSession(id: String, request: InitSessionRequest): Boolean
 
     suspend fun sendMessageAsync(sessionId: String, request: SendMessageRequest)
 

--- a/app/src/main/java/dev/blazelight/p4oc/data/workspace/WorkspaceClient.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/data/workspace/WorkspaceClient.kt
@@ -136,10 +136,10 @@ class WorkspaceClient(
 
     suspend fun getSessionTodos(id: String): List<TodoDto> = api.getSessionTodos(id, directory, workspace = null)
 
-    suspend fun forkSession(id: String, request: ForkSessionRequest): SessionDto =
+    override suspend fun forkSession(id: String, request: ForkSessionRequest): SessionDto =
         api.forkSession(id, request, directory, workspace = null)
 
-    suspend fun initSession(id: String, request: InitSessionRequest): Boolean =
+    override suspend fun initSession(id: String, request: InitSessionRequest): Boolean =
         api.initSession(id, request, directory, workspace = null)
 
     override suspend fun shareSession(id: String): SessionDto = api.shareSession(id, directory, workspace = null)

--- a/app/src/main/java/dev/blazelight/p4oc/ui/components/chat/ChatInputBar.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/components/chat/ChatInputBar.kt
@@ -125,7 +125,7 @@ private fun nextCommandIndex(
 fun ChatInputBar(
     value: String,
     onValueChange: (String) -> Unit,
-    onSend: () -> Unit,
+    onSend: () -> Boolean,
     isLoading: Boolean,
     enabled: Boolean,
     modifier: Modifier = Modifier,
@@ -145,6 +145,7 @@ fun ChatInputBar(
     promptHistory: List<String> = emptyList(),
     promptHistorySessionId: String? = null,
     enterToSend: Boolean = false,
+    valueSyncGeneration: Long = 0,
 ) {
     val theme = LocalOpenCodeTheme.current
     val focusRequester = remember { FocusRequester() }
@@ -158,8 +159,9 @@ fun ChatInputBar(
     val currentPromptHistory by rememberUpdatedState(promptHistory)
     val currentText = textState.text.toString()
 
-    // External value changes (e.g. a programmatic set from the parent) → field.
-    LaunchedEffect(value) {
+    // External value changes (e.g. a programmatic set from the parent) → field. The generation
+    // also allows the parent to re-apply an unchanged value after the local field was cleared.
+    LaunchedEffect(value, valueSyncGeneration) {
         if (value != textState.text.toString()) {
             historyNavigator.reset(value)
             textState.setTextAndPlaceCursorAtEnd(value)
@@ -251,8 +253,9 @@ fun ChatInputBar(
     fun submitFromEnter(): Boolean = when {
         showSlashCommands -> selectActiveCommand()
         canSubmit -> {
-            onSend()
-            clearInput()
+            if (onSend()) clearInput()
+            // A refused submission is still a handled Enter/IME action. Letting it propagate
+            // would insert a newline and mutate the exact draft the caller just refused.
             true
         }
         else -> false
@@ -493,8 +496,7 @@ fun ChatInputBar(
                         size = controlSize,
                         enabled = canSubmit,
                         onClick = {
-                            onSend()
-                            clearInput()
+                            if (onSend()) clearInput()
                             focusRequester.requestFocus()
                         },
                         contentDescription = sendContentDescription,

--- a/app/src/main/java/dev/blazelight/p4oc/ui/components/chat/ChatMessage.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/components/chat/ChatMessage.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.AnnotatedString
@@ -216,6 +217,7 @@ private fun AssistantMessageContent(
     defaultToolWidgetState: ToolWidgetState = ToolWidgetState.COMPACT,
     pendingPermissionsByCallId: Map<String, Permission> = emptyMap(),
 ) {
+    val assistant = messageWithParts.message as? Message.Assistant
     // Build ordered groups: consecutive tools get batched, non-tools rendered individually
     // Invisible parts (StepStart, StepFinish, Snapshot, etc.) don't break tool groups
     val partGroups = buildPartGroups(messageWithParts.parts)
@@ -225,8 +227,8 @@ private fun AssistantMessageContent(
         verticalArrangement = Arrangement.spacedBy(Spacing.hairline)
     ) {
         // Per-turn attribution header: `@build · claude-sonnet-4-5` (design 05).
-        (messageWithParts.message as? Message.Assistant)?.let { assistant ->
-            val attribution = assistantAttribution(assistant.agent, assistant.modelID)
+        assistant?.let { assistantMessage ->
+            val attribution = assistantAttribution(assistantMessage.agent, assistantMessage.modelID)
             if (partGroups.isNotEmpty() && attribution != null) {
                 AssistantAttributionHeader(attribution)
             }
@@ -251,8 +253,12 @@ private fun AssistantMessageContent(
             }
         }
 
-        (messageWithParts.message as? Message.Assistant)?.error?.let { error ->
+        assistant?.error?.let { error ->
             AssistantError(error, onProviderAuthRequired)
+        }
+
+        if (assistant != null && (assistant.tokens.hasUsage() || assistant.cost > 0.0)) {
+            TokenUsageInfo(tokens = assistant.tokens, cost = assistant.cost)
         }
     }
 }
@@ -684,12 +690,29 @@ private fun CompactPatchPart(part: Part.Patch) {
     }
 }
 
+private fun TokenUsage.hasUsage(): Boolean =
+    (input or output or reasoning or cacheRead or cacheWrite) != 0
+
+private const val MINIMUM_VISIBLE_COST = 0.0001
+
 @Composable
-private fun TokenUsageInfo(tokens: TokenUsage, cost: Double) {
+@Suppress("FunctionNaming")
+private fun TokenUsageInfo(tokens: TokenUsage, cost: Double, modifier: Modifier = Modifier) {
     val theme = LocalOpenCodeTheme.current
+    val total = tokens.input.toLong() +
+        tokens.output.toLong() +
+        tokens.reasoning.toLong() +
+        tokens.cacheRead.toLong() +
+        tokens.cacheWrite.toLong()
     Row(
+        modifier = modifier.testTag("assistant_token_usage"),
         horizontalArrangement = Arrangement.spacedBy(Spacing.sm)
     ) {
+        Text(
+            text = "$total total",
+            style = MaterialTheme.typography.labelSmall,
+            color = theme.textMuted
+        )
         Text(
             text = "${tokens.input}/${tokens.output}",
             style = MaterialTheme.typography.labelSmall,
@@ -697,7 +720,11 @@ private fun TokenUsageInfo(tokens: TokenUsage, cost: Double) {
         )
         if (cost > 0) {
             Text(
-                text = "$${String.format(java.util.Locale.US, "%.4f", cost)}",
+                text = if (cost < MINIMUM_VISIBLE_COST) {
+                    "<\$0.0001"
+                } else {
+                    "$${String.format(java.util.Locale.US, "%.4f", cost)}"
+                },
                 style = MaterialTheme.typography.labelSmall,
                 color = theme.textMuted
             )

--- a/app/src/main/java/dev/blazelight/p4oc/ui/components/command/CommandPalette.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/components/command/CommandPalette.kt
@@ -30,14 +30,16 @@ import dev.blazelight.p4oc.ui.theme.LocalOpenCodeTheme
 import dev.blazelight.p4oc.ui.theme.Sizing
 import dev.blazelight.p4oc.ui.theme.Spacing
 
+@Suppress("LongParameterList", "LongMethod", "FunctionNaming")
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CommandPalette(
     commands: List<Command>,
     isLoading: Boolean,
     error: String?,
+    executionError: String?,
     onRetry: () -> Unit,
-    onCommandSelected: (Command, String) -> Unit,
+    onCommandSelected: (Command, String) -> Boolean,
     onDismiss: () -> Unit
 ) {
     val theme = LocalOpenCodeTheme.current
@@ -122,20 +124,36 @@ fun CommandPalette(
                     CommandArgumentsView(
                         command = command,
                         arguments = commandArgs,
+                        error = executionError,
                         onArgumentsChange = { commandArgs = it },
                         onBack = {
                             selectedCommand = null
                             commandArgs = ""
                         },
                         onExecute = {
-                            onCommandSelected(command, commandArgs)
-                            onDismiss()
+                            executePaletteCommand(
+                                command = command,
+                                arguments = commandArgs,
+                                onCommandSelected = onCommandSelected,
+                                onDismiss = onDismiss,
+                            )
                         }
                     )
                 }
             }
         }
     }
+}
+
+internal fun executePaletteCommand(
+    command: Command,
+    arguments: String,
+    onCommandSelected: (Command, String) -> Boolean,
+    onDismiss: () -> Unit,
+): Boolean {
+    val accepted = onCommandSelected(command, arguments)
+    if (accepted) onDismiss()
+    return accepted
 }
 
 @Composable
@@ -418,10 +436,12 @@ private fun CommandSource.paletteLabel(): String = when (this) {
     CommandSource.Subtask -> "[subtask]"
 }
 
+@Suppress("LongParameterList", "FunctionNaming")
 @Composable
 private fun CommandArgumentsView(
     command: Command,
     arguments: String,
+    error: String?,
     onArgumentsChange: (String) -> Unit,
     onBack: () -> Unit,
     onExecute: () -> Unit
@@ -465,6 +485,15 @@ private fun CommandArgumentsView(
         )
 
         Spacer(modifier = Modifier.height(Spacing.md))
+
+        error?.let {
+            Text(
+                text = it,
+                style = MaterialTheme.typography.bodyMedium,
+                color = theme.warning,
+                modifier = Modifier.padding(bottom = Spacing.md)
+            )
+        }
 
         TuiButton(
             onClick = onExecute,

--- a/app/src/main/java/dev/blazelight/p4oc/ui/preview/ComponentPreviews.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/preview/ComponentPreviews.kt
@@ -253,7 +253,7 @@ private fun ChatInputBarPreview() {
             ChatInputBar(
                 value = "Review this diff and propose a fix",
                 onValueChange = {},
-                onSend = {},
+                onSend = { true },
                 isLoading = false,
                 enabled = true,
                 isBusy = true,

--- a/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ChatScreen.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ChatScreen.kt
@@ -447,13 +447,14 @@ fun ChatScreen(
                     )
                     ChatInputBar(
                         value = uiState.inputText,
+                        valueSyncGeneration = uiState.inputSyncGeneration,
                         onValueChange = { text ->
                             viewModel.updateInput(text)
                             if (text.startsWith("/") && !text.contains(" ")) {
                                 viewModel.refreshCommandsIfNeeded()
                             }
                         },
-                        onSend = viewModel::sendMessage,
+                        onSend = { viewModel.sendMessage() },
                         isLoading = uiState.isSending,
                         enabled = connectionState is ConnectionState.Connected,
                         isBusy = uiState.isBusy,
@@ -717,6 +718,7 @@ fun ChatScreen(
             commands = resolvedCommands,
             isLoading = uiState.isLoadingCommands,
             error = uiState.commandLoadError,
+            executionError = uiState.error,
             onRetry = { viewModel.refreshCommandsIfNeeded(force = true) },
             onCommandSelected = { command, args ->
                 viewModel.executeCommand(command.name, args)

--- a/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ChatViewModel.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ChatViewModel.kt
@@ -14,6 +14,7 @@ import dev.blazelight.p4oc.core.network.ConnectionState
 import dev.blazelight.p4oc.core.network.ServerConnectionRegistry
 import dev.blazelight.p4oc.core.network.safeApiCall
 import dev.blazelight.p4oc.data.remote.dto.ExecuteCommandRequest
+import dev.blazelight.p4oc.data.remote.dto.InitSessionRequest
 import dev.blazelight.p4oc.data.remote.dto.PartInputDto
 import dev.blazelight.p4oc.data.remote.dto.PermissionResponseRequest
 import dev.blazelight.p4oc.data.remote.dto.QuestionReplyRequest
@@ -32,6 +33,7 @@ import dev.blazelight.p4oc.ui.components.chat.SelectedFile
 import dev.blazelight.p4oc.ui.navigation.Screen
 import dev.blazelight.p4oc.ui.screens.files.upload.UploadCoordinator
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -41,6 +43,8 @@ import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import java.io.File
 import java.net.URI
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicLong
 
 /**
  * Slim coordinator — delegates to sub-managers for message state,
@@ -187,10 +191,14 @@ class ChatViewModel constructor(
         private const val MAX_PERSISTED_ATTACHMENTS_JSON_CHARS = 64 * 1024
         private const val UNAVAILABLE_ATTACHMENTS_ERROR =
             "Remove unavailable attachments before sending."
+        private const val COMMAND_REFUSED_WHILE_RUNNING_ERROR =
+            "Wait for the current run to finish or stop it first."
+        private const val NO_COMMAND_DISPATCH_OWNER = 0L
 
         /**
-         * Built-in OpenCode commands that aren't returned by the /command API endpoint.
-         * Localized descriptions are resolved at Compose display boundaries.
+         * Local command fallbacks used when the server catalog omits them or cannot be loaded.
+         * Server-provided metadata takes precedence by command name, while localized fallback
+         * descriptions are resolved at Compose display boundaries.
          */
         private val BUILTIN_COMMANDS = listOf(
             Command(name = "compact", source = CommandSource.BuiltIn),
@@ -281,8 +289,25 @@ class ChatViewModel constructor(
     }
 
     fun updateInput(text: String) {
-        persistInputText(text)
-        _uiState.update { it.copy(inputText = text) }
+        val pendingSubmission = pendingComposerSubmission
+        if (pendingSubmission?.failed == true && text.isEmpty()) {
+            pendingComposerSubmission = pendingSubmission.copy(clearAcknowledged = true)
+            failComposerSubmission(pendingSubmission.submission)
+            return
+        }
+        val effectiveText = when {
+            pendingSubmission == null -> text
+            text.isNotEmpty() -> {
+                pendingComposerSubmission = null
+                text
+            }
+            else -> {
+                pendingComposerSubmission = pendingSubmission.copy(clearAcknowledged = true)
+                text
+            }
+        }
+        persistInputText(effectiveText)
+        _uiState.update { it.copy(inputText = effectiveText) }
     }
 
     fun clearError() {
@@ -405,6 +430,26 @@ class ChatViewModel constructor(
     private var lastResponseCompletedToken = 0L
     private var hasResponseTokenBaseline = false
     private var responseReconciliationJob: Job? = null
+    private var initOperationGeneration = 0L
+    private var currentInitOperationGeneration: Long? = null
+    private var currentInitCommandDispatchOwner: Long? = null
+    private var initRequestJob: Job? = null
+    private var initTerminalTokenBaseline: Long? = null
+    private val commandDispatchGeneration = AtomicLong(NO_COMMAND_DISPATCH_OWNER)
+    private val commandDispatchOwner = AtomicLong(NO_COMMAND_DISPATCH_OWNER)
+    private var composerSubmissionGeneration = 0L
+    private var pendingComposerSubmission: PendingComposerSubmission? = null
+
+    private data class ComposerSubmission(
+        val generation: Long,
+        val draft: String,
+    )
+
+    private data class PendingComposerSubmission(
+        val submission: ComposerSubmission,
+        val clearAcknowledged: Boolean = false,
+        val failed: Boolean = false,
+    )
 
     // True from the moment a send clears the previous run's UI error until the run is confirmed
     // active (Busy/Retry) or reaches a genuine terminal boundary. While set, repository emissions
@@ -412,6 +457,7 @@ class ChatViewModel constructor(
     // before the synthetic Busy clears it) must not flicker that stale error back into the UI.
     private var suppressStaleRunErrors = false
 
+    @Suppress("CyclomaticComplexMethod")
     private fun applyRepositorySessionState(state: dev.blazelight.p4oc.data.session.SessionUiState) {
         dialogManager.setPermissionsByCallId(state.pendingPermissionsByCallId)
         dialogManager.setPendingQuestion(state.pendingQuestion)
@@ -419,6 +465,11 @@ class ChatViewModel constructor(
         val isBusy = state.status is SessionStatus.Busy || state.status is SessionStatus.Retry
         val isTerminalTransition = hasResponseTokenBaseline &&
             state.responseCompletedToken > lastResponseCompletedToken
+        val terminalBelongsToCurrentInit = isTerminalTransition &&
+            terminalBelongsToCurrentInit(state.responseCompletedToken)
+        val isUnrelatedTerminalDuringInit = isTerminalTransition &&
+            currentInitOperationGeneration != null &&
+            !terminalBelongsToCurrentInit
         if (!hasResponseTokenBaseline) {
             // The first collected repository state is the subscription snapshot, not a fresh
             // completion: adopt its token as the baseline so a token accumulated before this
@@ -428,7 +479,7 @@ class ChatViewModel constructor(
             hasResponseTokenBaseline = true
             lastResponseCompletedToken = state.responseCompletedToken
         }
-        if (isBusy || isTerminalTransition) {
+        if (isBusy || (isTerminalTransition && !isUnrelatedTerminalDuringInit)) {
             // The run is confirmed active (its Busy transition already cleared the previous run's
             // repository error) or has genuinely completed (a fresh terminal error is real, not
             // stale). Either way, stale-error suppression for the in-flight send ends now, before
@@ -438,25 +489,48 @@ class ChatViewModel constructor(
         val errorMessage = state.error?.takeUnless { it.isAborted() }?.toHumanMessage()
         val retryNotice = (state.status as? SessionStatus.Retry)?.toHumanMessage()
         _uiState.update {
+            val ownsCommandEndpoint = commandDispatchOwner.get() != NO_COMMAND_DISPATCH_OWNER
             it.copy(
                 session = state.session ?: it.session,
-                isBusy = isBusy,
-                isSending = if (state.status != null) false else it.isSending,
+                isBusy = if (isUnrelatedTerminalDuringInit) it.isBusy else isBusy,
+                isSending = when {
+                    ownsCommandEndpoint -> true
+                    state.status != null && !isUnrelatedTerminalDuringInit -> false
+                    else -> it.isSending
+                },
                 todos = state.todos,
-                error = if (suppressStaleRunErrors) it.error else errorMessage ?: it.error,
-                runNotice = resolveRunNotice(it.runNotice, retryNotice, isTerminalTransition, isBusy),
+                error = if (
+                    ownsCommandEndpoint || suppressStaleRunErrors || isUnrelatedTerminalDuringInit
+                ) {
+                    it.error
+                } else {
+                    errorMessage ?: it.error
+                },
+                runNotice = if (isUnrelatedTerminalDuringInit) {
+                    it.runNotice
+                } else {
+                    resolveRunNotice(it.runNotice, retryNotice, isTerminalTransition, isBusy)
+                },
             )
         }
 
         if (isTerminalTransition) {
-            responseReconciliationJob?.cancel()
-            responseReconciliationJob = null
+            if (!isUnrelatedTerminalDuringInit) {
+                responseReconciliationJob?.cancel()
+                responseReconciliationJob = null
+            }
+            if (terminalBelongsToCurrentInit) invalidateInitOperation()
             lastResponseCompletedToken = state.responseCompletedToken
-            if (state.error?.isAborted() != true) {
+            if (!isUnrelatedTerminalDuringInit && state.error?.isAborted() != true) {
                 _hasUnreadResponse.value = !_isActiveTab.value
                 handleResponseCompleted()
             }
         }
+    }
+
+    private fun terminalBelongsToCurrentInit(responseCompletedToken: Long): Boolean {
+        val baseline = initTerminalTokenBaseline ?: return false
+        return initRequestJob == null && responseCompletedToken > baseline
     }
 
     private fun handleResponseCompleted() {
@@ -483,19 +557,26 @@ class ChatViewModel constructor(
 
     // --- Message sending ---
 
-    fun sendMessage() {
-        val text = _uiState.value.inputText.trim()
+    @Suppress("ReturnCount")
+    fun sendMessage(): Boolean {
+        val input = _uiState.value.inputText
+        val text = input.trim()
         val attachedFiles = filePickerManager.attachedFiles.value
-        if (text.isEmpty() && attachedFiles.isEmpty()) return
+        if (text.isEmpty() && attachedFiles.isEmpty()) return false
         if (attachedFiles.isEmpty() && text.startsWith("/")) {
-            sendSlashCommand(text)
-            return
+            return sendSlashCommand(text, input)
+        }
+        if (attachedFiles.any { !it.available }) {
+            _uiState.update { it.copy(error = UNAVAILABLE_ATTACHMENTS_ERROR) }
+            return false
         }
 
         // A replacement send must supersede any in-flight reconciliation from a prior send so the
         // old poll can never reconcile the wrong assistant/status against the new run.
+        invalidateInitOperation()
         responseReconciliationJob?.cancel()
         responseReconciliationJob = null
+        val submission = beginComposerSubmission(input)
         suppressStaleRunErrors = true
         _uiState.update { it.copy(isSending = true, error = null, runNotice = null) }
         viewModelScope.launch {
@@ -503,19 +584,24 @@ class ChatViewModel constructor(
             if (validatedFiles.any { !it.available }) {
                 suppressStaleRunErrors = false
                 _uiState.update { it.copy(error = UNAVAILABLE_ATTACHMENTS_ERROR, isSending = false) }
+                failComposerSubmission(submission)
                 return@launch
             }
 
-            sendValidatedMessage(text, validatedFiles)
+            sendValidatedMessage(text, validatedFiles, submission)
         }
+        return true
     }
 
-    private suspend fun sendValidatedMessage(text: String, attachedFiles: List<SelectedFile>) {
+    private suspend fun sendValidatedMessage(
+        text: String,
+        attachedFiles: List<SelectedFile>,
+        submission: ComposerSubmission?,
+    ) {
         val knownMessageIds = messages.value.mapTo(mutableSetOf()) { it.message.id }
         val selectedAgent = modelAgentManager.selectedAgent.value
         val selectedModel = modelAgentManager.selectedModel.value
         val selectedVariant = modelAgentManager.currentReasoningEffort()
-        updateInput("")
         filePickerManager.clearAttachedFiles()
 
         val parts = buildPartInputs(text, attachedFiles)
@@ -529,6 +615,7 @@ class ChatViewModel constructor(
         val result = sessionRepository.sendMessageAsync(SessionId(sessionId), request).await().toApiResult()
         when (result) {
             is ApiResult.Success -> {
+                completeComposerSubmission(submission)
                 modelAgentManager.markComposerSelectionSent(selectedModel, selectedVariant)
                 sessionRepository.acceptEvent(
                     OpenCodeEvent.SessionStatusChanged(sessionId, SessionStatus.Busy)
@@ -545,20 +632,27 @@ class ChatViewModel constructor(
                         error = "Could not send the message. Check the connection and try again."
                     )
                 }
-                updateInput(text)
+                failComposerSubmission(submission)
                 filePickerManager.restoreAttachedFiles(attachedFiles)
             }
         }
     }
 
-    private fun startResponseReconciliation(knownMessageIds: Set<String>) {
+    @Suppress("CyclomaticComplexMethod")
+    private fun startResponseReconciliation(
+        knownMessageIds: Set<String>,
+        initOwnerGeneration: Long? = null,
+    ) {
+        if (!ownsResponseReconciliation(initOwnerGeneration)) return
         responseReconciliationJob?.cancel()
+        if (!ownsResponseReconciliation(initOwnerGeneration)) return
         responseReconciliationJob = viewModelScope.launch {
             var lastNewAssistant: MessageWithParts? = null
             var observedRetry = false
 
             RESPONSE_RECONCILIATION_DELAYS_MS.forEach { delayMs ->
                 delay(delayMs)
+                if (!ownsResponseReconciliation(initOwnerGeneration)) return@launch
                 if (!_uiState.value.isBusy) return@launch
 
                 val status = runCatching {
@@ -566,6 +660,7 @@ class ChatViewModel constructor(
                 }.onFailure { error ->
                     if (error is CancellationException) throw error
                 }.getOrNull()?.let(SessionMapper::mapStatusToDomain)
+                if (!ownsResponseReconciliation(initOwnerGeneration)) return@launch
                 observedRetry = observedRetry || status is SessionStatus.Retry
 
                 // Reconcile canonical messages BEFORE publishing any status. A terminal Idle
@@ -579,21 +674,28 @@ class ChatViewModel constructor(
                 }.onFailure { error ->
                     if (error is CancellationException) throw error
                 }
+                if (!ownsResponseReconciliation(initOwnerGeneration)) return@launch
                 lastNewAssistant = messages.value.asReversed().firstOrNull { messageWithParts ->
                     messageWithParts.message.id !in knownMessageIds &&
                         messageWithParts.message is Message.Assistant
                 } ?: lastNewAssistant
 
-                if (reconcileCompletedAssistant(lastNewAssistant, status)) return@launch
+                completedAssistantEvent(lastNewAssistant, status)?.let { event ->
+                    if (!ownsResponseReconciliation(initOwnerGeneration)) return@launch
+                    sessionRepository.acceptEvent(event)
+                    return@launch
+                }
 
                 // No assistant completed yet: only non-terminal statuses may be published. A REST
                 // Idle with no new assistant must not terminate the run (or cancel this poll);
                 // keep polling until an assistant appears or the bounded window is exhausted.
                 if (status is SessionStatus.Busy || status is SessionStatus.Retry) {
+                    if (!ownsResponseReconciliation(initOwnerGeneration)) return@launch
                     sessionRepository.acceptEvent(OpenCodeEvent.SessionStatusChanged(sessionId, status))
                 }
             }
 
+            if (!ownsResponseReconciliation(initOwnerGeneration)) return@launch
             if (!_uiState.value.isBusy) return@launch
             if (!observedRetry) {
                 _uiState.update { it.copy(runNotice = RUN_STALLED_NOTICE) }
@@ -601,52 +703,80 @@ class ChatViewModel constructor(
         }
     }
 
-    private fun reconcileCompletedAssistant(
+    private fun ownsResponseReconciliation(initOwnerGeneration: Long?): Boolean =
+        initOwnerGeneration == null || isCurrentInitOperation(initOwnerGeneration)
+
+    private fun completedAssistantEvent(
         messageWithParts: MessageWithParts?,
         status: SessionStatus?,
-    ): Boolean {
-        val assistant = messageWithParts?.message as? Message.Assistant
+    ): OpenCodeEvent? {
+        val assistant = messageWithParts?.message as? Message.Assistant ?: return null
         return when {
-            assistant == null -> false
             // An authoritative Busy/Retry just fetched from REST means nothing terminal was
             // missed: multi-step runs emit one assistant message per step, so a completed
             // intermediate assistant mid-run must never synthesize a terminal Idle/Error (false
             // completion haptic, unread badge, poll cancellation). The caller republishes the
             // non-terminal status and keeps polling.
-            status is SessionStatus.Busy || status is SessionStatus.Retry -> false
-            assistant.error != null -> {
-                sessionRepository.acceptEvent(OpenCodeEvent.SessionError(sessionId, assistant.error))
-                true
-            }
-            assistant.completedAt == null && status !is SessionStatus.Idle -> false
-            messageWithParts.parts.isEmpty() -> {
-                sessionRepository.acceptEvent(
-                    OpenCodeEvent.SessionError(
-                        sessionId,
-                        MessageError(
-                            name = "EmptyResponseError",
-                            message = "The model completed without returning content",
-                        ),
-                    )
-                )
-                true
-            }
-            else -> {
-                sessionRepository.acceptEvent(
-                    OpenCodeEvent.SessionStatusChanged(sessionId, SessionStatus.Idle)
-                )
-                true
-            }
+            status is SessionStatus.Busy || status is SessionStatus.Retry -> null
+            assistant.error != null -> OpenCodeEvent.SessionError(sessionId, assistant.error)
+            assistant.completedAt == null && status !is SessionStatus.Idle -> null
+            messageWithParts.parts.isEmpty() -> OpenCodeEvent.SessionError(
+                sessionId,
+                MessageError(
+                    name = "EmptyResponseError",
+                    message = "The model completed without returning content",
+                ),
+            )
+            else -> OpenCodeEvent.SessionStatusChanged(sessionId, SessionStatus.Idle)
         }
     }
 
-    private fun sendSlashCommand(text: String) {
+    private fun sendSlashCommand(text: String, submittedDraft: String): Boolean {
         val commandText = text.removePrefix("/")
         val commandName = commandText.substringBefore(" ").trim()
-        if (commandName.isEmpty()) return
+        if (commandName.isEmpty()) return false
         val arguments = commandText.substringAfter(" ", "").trim()
-        updateInput("")
-        executeCommand(commandName, arguments)
+        return executeCommand(commandName, arguments, submittedDraft)
+    }
+
+    private fun beginComposerSubmission(draft: String?): ComposerSubmission? {
+        pendingComposerSubmission = null
+        if (draft == null) return null
+        val submission = ComposerSubmission(
+            generation = ++composerSubmissionGeneration,
+            draft = draft,
+        )
+        pendingComposerSubmission = PendingComposerSubmission(submission)
+        return submission
+    }
+
+    private fun completeComposerSubmission(submission: ComposerSubmission?) {
+        if (pendingComposerSubmission?.submission?.generation == submission?.generation) {
+            pendingComposerSubmission = null
+        }
+    }
+
+    private fun failComposerSubmission(submission: ComposerSubmission?) {
+        val pendingSubmission = pendingComposerSubmission
+            ?.takeIf { it.submission.generation == submission?.generation }
+            ?: return
+        if (pendingSubmission.clearAcknowledged || _uiState.value.inputText.isEmpty()) {
+            pendingComposerSubmission = null
+            val draft = pendingSubmission.submission.draft
+            persistInputText(draft)
+            _uiState.update {
+                it.copy(
+                    inputText = draft,
+                    inputSyncGeneration = it.inputSyncGeneration + 1,
+                )
+            }
+        } else {
+            pendingComposerSubmission = pendingSubmission.copy(failed = true)
+        }
+    }
+
+    private fun discardPendingComposerSubmission() {
+        pendingComposerSubmission = null
     }
 
     private fun buildPartInputs(text: String, files: List<SelectedFile>): List<PartInputDto> {
@@ -748,7 +878,7 @@ class ChatViewModel constructor(
                 is ApiResult.Success -> {
                     AppLog.d(TAG, "loadCommands: Got ${result.data.size} commands from API")
                     val apiCommands = result.data.map { CommandMapper.mapToDomain(it) }
-                    val allCommands = (BUILTIN_COMMANDS + apiCommands).distinctBy { it.name }
+                    val allCommands = mergeCommands(apiCommands, BUILTIN_COMMANDS)
                     _uiState.update {
                         it.copy(
                             commands = allCommands,
@@ -780,7 +910,7 @@ class ChatViewModel constructor(
                     val apiCommands = result.data.map(CommandMapper::mapToDomain)
                     _uiState.update {
                         it.copy(
-                            commands = (BUILTIN_COMMANDS + apiCommands).distinctBy(Command::name),
+                            commands = mergeCommands(apiCommands, BUILTIN_COMMANDS),
                             hasLoadedWorkspaceCommands = true,
                         )
                     }
@@ -798,31 +928,290 @@ class ChatViewModel constructor(
         }
     }
 
-    fun executeCommand(commandName: String, arguments: String) {
-        when (commandName.trim().lowercase()) {
-            "undo" -> undoSessionCommand()
-            "redo" -> redoSessionCommand()
-            else -> executeServerCommand(commandName, arguments)
+    fun executeCommand(
+        commandName: String,
+        arguments: String,
+        submittedDraft: String? = null,
+    ): Boolean {
+        val dispatchOwner = tryClaimCommandDispatch() ?: return false
+
+        return when (commandName.trim().lowercase()) {
+            "undo" -> undoSessionCommand(dispatchOwner, submittedDraft)
+            "redo" -> redoSessionCommand(dispatchOwner, submittedDraft)
+            "init" -> initializeSession(dispatchOwner, submittedDraft)
+            else -> {
+                val submission = beginComposerSubmission(submittedDraft)
+                executeServerCommand(commandName, arguments, dispatchOwner, submission)
+                true
+            }
         }
     }
 
-    private fun executeServerCommand(commandName: String, arguments: String) {
-        viewModelScope.launch {
-            _uiState.update { it.copy(isSending = true) }
-            val request = ExecuteCommandRequest(
-                command = commandName,
-                arguments = arguments
-            )
-            val result = safeApiCall { workspaceClient.executeCommand(sessionId, request) }
-            when (result) {
-                is ApiResult.Success -> {
-                    _uiState.update { it.copy(isSending = false, isBusy = true) }
-                }
-                is ApiResult.Error -> {
+    @Suppress("ComplexCondition", "ReturnCount")
+    private fun tryClaimCommandDispatch(): Long? {
+        val dispatchOwner = commandDispatchGeneration.incrementAndGet()
+        while (true) {
+            val state = _uiState.value
+            if (
+                commandDispatchOwner.get() != NO_COMMAND_DISPATCH_OWNER ||
+                state.isSending ||
+                state.isBusy ||
+                currentInitOperationGeneration != null
+            ) {
+                _uiState.update { it.copy(error = COMMAND_REFUSED_WHILE_RUNNING_ERROR) }
+                return null
+            }
+            if (_uiState.compareAndSet(state, state.copy(isSending = true, error = null))) {
+                if (commandDispatchOwner.compareAndSet(NO_COMMAND_DISPATCH_OWNER, dispatchOwner)) {
+                    // A repository emission can race the UI CAS above. Once the durable owner is
+                    // installed, project its sending state again so the endpoint is never in
+                    // flight while the UI appears dispatchable. Preserve a refusal another caller
+                    // may already have published during that race.
                     _uiState.update {
-                        it.copy(isSending = false, error = "Could not execute the command. Try again.")
+                        it.copy(
+                            isSending = true,
+                            error = it.error?.takeIf { error ->
+                                error == COMMAND_REFUSED_WHILE_RUNNING_ERROR
+                            },
+                        )
+                    }
+                    return dispatchOwner
+                }
+
+                // Another caller won ownership after an unrelated repository emission reopened
+                // the UI-state CAS window. Its owner keeps isSending asserted; this caller only
+                // contributes the visible refusal.
+                _uiState.update { it.copy(error = COMMAND_REFUSED_WHILE_RUNNING_ERROR) }
+                return null
+            }
+        }
+    }
+
+    private inline fun finishCommandDispatch(
+        dispatchOwner: Long,
+        updateUi: (ChatUiState) -> ChatUiState,
+    ): Boolean {
+        if (!commandDispatchOwner.compareAndSet(dispatchOwner, NO_COMMAND_DISPATCH_OWNER)) {
+            return false
+        }
+        _uiState.update(updateUi)
+        return true
+    }
+
+    private fun releaseCommandDispatch(dispatchOwner: Long) {
+        finishCommandDispatch(dispatchOwner) { it.copy(isSending = false) }
+    }
+
+    private fun releaseActiveCommandDispatch(clearSending: Boolean) {
+        while (true) {
+            val dispatchOwner = commandDispatchOwner.get()
+            if (dispatchOwner == NO_COMMAND_DISPATCH_OWNER) return
+            if (commandDispatchOwner.compareAndSet(dispatchOwner, NO_COMMAND_DISPATCH_OWNER)) {
+                if (currentInitCommandDispatchOwner == dispatchOwner) {
+                    currentInitCommandDispatchOwner = null
+                }
+                if (clearSending) {
+                    _uiState.update { it.copy(isSending = false) }
+                }
+                return
+            }
+        }
+    }
+
+    private fun initializeSession(dispatchOwner: Long, submittedDraft: String?): Boolean {
+        val selectedModel = modelAgentManager.selectedModel.value
+        if (selectedModel == null) {
+            suppressStaleRunErrors = false
+            finishCommandDispatch(dispatchOwner) {
+                it.copy(
+                    isSending = false,
+                    error = "Select a model before initializing the session.",
+                )
+            }
+            return false
+        }
+
+        val submission = beginComposerSubmission(submittedDraft)
+        val operationGeneration = ++initOperationGeneration
+        currentInitOperationGeneration = operationGeneration
+        currentInitCommandDispatchOwner = dispatchOwner
+        initTerminalTokenBaseline = null
+        responseReconciliationJob?.cancel()
+        responseReconciliationJob = null
+        suppressStaleRunErrors = true
+        val knownMessageIds = messages.value.mapTo(mutableSetOf()) { it.message.id }
+        val request = InitSessionRequest(
+            messageID = "msg_${UUID.randomUUID()}",
+            providerID = selectedModel.providerID,
+            modelID = selectedModel.modelID,
+        )
+
+        _uiState.update { it.copy(isSending = true, error = null, runNotice = null) }
+        val requestJob = viewModelScope.launch(start = CoroutineStart.LAZY) {
+            var endpointCompleted = false
+            try {
+                val result = safeApiCall {
+                    sessionRepository.initSession(SessionId(sessionId), request)
+                }
+                when (result) {
+                    is ApiResult.Success -> handleInitCompletion(
+                        operationGeneration,
+                        dispatchOwner,
+                        result.data,
+                        knownMessageIds,
+                        submission,
+                    )
+                    is ApiResult.Error -> publishInitFailure(operationGeneration, dispatchOwner, submission)
+                }
+                endpointCompleted = true
+            } finally {
+                if (!endpointCompleted) {
+                    cancelInitCommandDispatch(operationGeneration, dispatchOwner, submission)
+                }
+            }
+        }
+        initRequestJob = requestJob
+        requestJob.invokeOnCompletion { cause ->
+            if (cause != null) cancelInitCommandDispatch(operationGeneration, dispatchOwner, submission)
+        }
+        requestJob.start()
+        return true
+    }
+
+    @Suppress("ReturnCount")
+    private fun handleInitCompletion(
+        operationGeneration: Long,
+        dispatchOwner: Long,
+        succeeded: Boolean,
+        knownMessageIds: Set<String>,
+        submission: ComposerSubmission?,
+    ) {
+        if (!isCurrentInitOperation(operationGeneration)) return
+        if (!succeeded) {
+            publishInitFailure(operationGeneration, dispatchOwner, submission)
+            return
+        }
+
+        if (!isCurrentInitOperation(operationGeneration)) return
+        sessionRepository.acceptEvent(
+            OpenCodeEvent.SessionStatusChanged(sessionId, SessionStatus.Busy)
+        )
+        if (!isCurrentInitOperation(operationGeneration)) return
+        initTerminalTokenBaseline = repositorySessionState.value.responseCompletedToken
+        if (!isCurrentInitOperation(operationGeneration)) return
+        if (
+            !finishCommandDispatch(dispatchOwner) {
+                it.copy(isSending = false, isBusy = true, runNotice = null)
+            }
+        ) {
+            return
+        }
+        completeComposerSubmission(submission)
+        currentInitCommandDispatchOwner = null
+        if (!isCurrentInitOperation(operationGeneration)) return
+        startResponseReconciliation(knownMessageIds, operationGeneration)
+        if (isCurrentInitOperation(operationGeneration)) {
+            initRequestJob = null
+        }
+    }
+
+    @Suppress("ReturnCount")
+    private fun publishInitFailure(
+        operationGeneration: Long,
+        dispatchOwner: Long,
+        submission: ComposerSubmission?,
+    ) {
+        if (!isCurrentInitOperation(operationGeneration)) return
+        suppressStaleRunErrors = false
+        if (!isCurrentInitOperation(operationGeneration)) return
+        if (
+            !finishCommandDispatch(dispatchOwner) {
+                it.copy(
+                    isSending = false,
+                    error = "Could not initialize the session. Try again.",
+                )
+            }
+        ) {
+            return
+        }
+        failComposerSubmission(submission)
+        currentInitCommandDispatchOwner = null
+        completeInitOperation(operationGeneration)
+    }
+
+    private fun cancelInitCommandDispatch(
+        operationGeneration: Long,
+        dispatchOwner: Long,
+        submission: ComposerSubmission?,
+    ) {
+        // Invalidation owns release for a superseded generation, including whether an abort keeps
+        // the sending presentation asserted while its own endpoint is pending.
+        if (!isCurrentInitOperation(operationGeneration)) return
+        suppressStaleRunErrors = false
+        releaseCommandDispatch(dispatchOwner)
+        completeComposerSubmission(submission)
+        currentInitCommandDispatchOwner = null
+        completeInitOperation(operationGeneration)
+    }
+
+    private fun isCurrentInitOperation(generation: Long): Boolean =
+        currentInitOperationGeneration == generation
+
+    private fun completeInitOperation(generation: Long) {
+        if (!isCurrentInitOperation(generation)) return
+        currentInitOperationGeneration = null
+        currentInitCommandDispatchOwner = null
+        initRequestJob = null
+        initTerminalTokenBaseline = null
+    }
+
+    private fun invalidateInitOperation(clearSending: Boolean = true) {
+        val dispatchOwner = currentInitCommandDispatchOwner
+        discardPendingComposerSubmission()
+        initOperationGeneration += 1
+        currentInitOperationGeneration = null
+        currentInitCommandDispatchOwner = null
+        initRequestJob?.cancel()
+        initRequestJob = null
+        initTerminalTokenBaseline = null
+        if (dispatchOwner != null) {
+            if (clearSending) {
+                releaseCommandDispatch(dispatchOwner)
+            } else {
+                releaseActiveCommandDispatch(clearSending = false)
+            }
+        }
+    }
+
+    private fun executeServerCommand(
+        commandName: String,
+        arguments: String,
+        dispatchOwner: Long,
+        submission: ComposerSubmission?,
+    ) {
+        viewModelScope.launch {
+            try {
+                val request = ExecuteCommandRequest(
+                    command = commandName,
+                    arguments = arguments
+                )
+                val result = safeApiCall { workspaceClient.executeCommand(sessionId, request) }
+                when (result) {
+                    is ApiResult.Success -> {
+                        val finished = finishCommandDispatch(dispatchOwner) {
+                            it.copy(isSending = false, isBusy = true)
+                        }
+                        if (finished) completeComposerSubmission(submission)
+                    }
+                    is ApiResult.Error -> {
+                        val finished = finishCommandDispatch(dispatchOwner) {
+                            it.copy(isSending = false, error = "Could not execute the command. Try again.")
+                        }
+                        if (finished) failComposerSubmission(submission)
                     }
                 }
+            } finally {
+                releaseCommandDispatch(dispatchOwner)
             }
         }
     }
@@ -847,22 +1236,30 @@ class ChatViewModel constructor(
 
     // --- Revert / Unrevert ---
 
-    private fun undoSessionCommand() {
+    private fun undoSessionCommand(dispatchOwner: Long, submittedDraft: String?): Boolean {
         val targetMessageId = previousUserMessageBoundary()
         if (targetMessageId == null) {
-            _uiState.update { it.copy(error = "Nothing to undo") }
-            return
+            finishCommandDispatch(dispatchOwner) {
+                it.copy(isSending = false, error = "Nothing to undo")
+            }
+            return false
         }
-        revertSessionTo(targetMessageId, "undo")
+        val submission = beginComposerSubmission(submittedDraft)
+        revertSessionTo(targetMessageId, "undo", dispatchOwner, submission)
+        return true
     }
 
-    private fun redoSessionCommand() {
+    private fun redoSessionCommand(dispatchOwner: Long, submittedDraft: String?): Boolean {
         val targetMessageId = nextUserMessageBoundary()
         if (targetMessageId == null) {
-            _uiState.update { it.copy(error = "Nothing to redo") }
-            return
+            finishCommandDispatch(dispatchOwner) {
+                it.copy(isSending = false, error = "Nothing to redo")
+            }
+            return false
         }
-        revertSessionTo(targetMessageId, "redo")
+        val submission = beginComposerSubmission(submittedDraft)
+        revertSessionTo(targetMessageId, "redo", dispatchOwner, submission)
+        return true
     }
 
     private fun previousUserMessageBoundary(): String? {
@@ -886,19 +1283,32 @@ class ChatViewModel constructor(
         return userMessages.indexOfFirst { it.id == activeRevertMessageId }.takeIf { it >= 0 }
     }
 
-    private fun revertSessionTo(messageId: String, action: String) {
+    private fun revertSessionTo(
+        messageId: String,
+        action: String,
+        dispatchOwner: Long,
+        submission: ComposerSubmission?,
+    ) {
         viewModelScope.launch {
-            _uiState.update { it.copy(isSending = true) }
-            val request = RevertSessionRequest(messageID = messageId)
-            val result = safeApiCall { workspaceClient.revertSession(sessionId, request) }
-            when (result) {
-                is ApiResult.Success -> {
-                    _uiState.update { it.copy(isSending = false) }
-                    loadSession()
+            try {
+                val request = RevertSessionRequest(messageID = messageId)
+                val result = safeApiCall { workspaceClient.revertSession(sessionId, request) }
+                when (result) {
+                    is ApiResult.Success -> {
+                        if (finishCommandDispatch(dispatchOwner) { it.copy(isSending = false) }) {
+                            completeComposerSubmission(submission)
+                            loadSession()
+                        }
+                    }
+                    is ApiResult.Error -> {
+                        val finished = finishCommandDispatch(dispatchOwner) {
+                            it.copy(isSending = false, error = "Could not $action. Try again.")
+                        }
+                        if (finished) failComposerSubmission(submission)
+                    }
                 }
-                is ApiResult.Error -> {
-                    _uiState.update { it.copy(isSending = false, error = "Could not $action. Try again.") }
-                }
+            } finally {
+                releaseCommandDispatch(dispatchOwner)
             }
         }
     }
@@ -935,23 +1345,35 @@ class ChatViewModel constructor(
     // --- Abort ---
 
     fun abortSession() {
+        // Abort supersedes any command endpoint. Retire its dispatch owner immediately so a
+        // non-cooperative response cannot publish stale success/error state, but leave the
+        // sending presentation asserted until the abort endpoint itself resolves.
+        invalidateInitOperation(clearSending = false)
+        releaseActiveCommandDispatch(clearSending = false)
+        responseReconciliationJob?.cancel()
+        responseReconciliationJob = null
         viewModelScope.launch {
             when (val result = sessionRepository.abortSession(SessionId(sessionId)).await().toApiResult()) {
                 is ApiResult.Success -> {
-                    responseReconciliationJob?.cancel()
-                    responseReconciliationJob = null
+                    suppressStaleRunErrors = false
                     sessionRepository.clearStreamingFlags(SessionId(sessionId))
                     _uiState.update { it.copy(isBusy = false, isSending = false, runNotice = null) }
                 }
-                is ApiResult.Error -> _uiState.update {
-                    it.copy(error = "Could not stop the run. Try again.")
+                is ApiResult.Error -> {
+                    suppressStaleRunErrors = false
+                    _uiState.update {
+                        it.copy(isSending = false, error = "Could not stop the run. Try again.")
+                    }
                 }
             }
         }
     }
 
     override fun onCleared() {
+        invalidateInitOperation()
+        releaseActiveCommandDispatch(clearSending = true)
         responseReconciliationJob?.cancel()
+        responseReconciliationJob = null
         sessionLease.close()
         super.onCleared()
     }
@@ -993,6 +1415,17 @@ class ChatViewModel constructor(
     )
 }
 
+private fun mergeCommands(
+    serverCommands: List<Command>,
+    localFallbacks: List<Command>,
+): List<Command> {
+    val serverCommandNames = serverCommands.mapTo(HashSet(serverCommands.size), Command::name)
+    return buildList(serverCommands.size + localFallbacks.size) {
+        addAll(serverCommands)
+        localFallbacks.filterTo(this) { it.name !in serverCommandNames }
+    }
+}
+
 /**
  * Core UI state — only session lifecycle, sending state, commands, and todos.
  * Model/agent, file picker, and dialog state are exposed via sub-manager StateFlows.
@@ -1000,6 +1433,7 @@ class ChatViewModel constructor(
 data class ChatUiState(
     val session: Session? = null,
     val inputText: String = "",
+    val inputSyncGeneration: Long = 0,
     val isLoading: Boolean = false,
     val isLoadingOlderMessages: Boolean = false,
     val hasOlderMessages: Boolean = false,

--- a/app/src/main/java/dev/blazelight/p4oc/ui/screens/sessions/SessionListScreen.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/screens/sessions/SessionListScreen.kt
@@ -59,15 +59,20 @@ private data class SessionNode(
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
+@Suppress("LongParameterList", "LongMethod", "CyclomaticComplexMethod", "FunctionNaming")
 fun SessionListScreen(
     viewModel: SessionListViewModel = koinViewModel(),
     filterProjectId: String? = null,
+    isSessionForkPending: Boolean = false,
     onSessionClick: (sessionId: String, directory: String?) -> Unit,
     onNewSession: (sessionId: String, directory: String?) -> Unit,
     onSettings: () -> Unit,
     onProjects: () -> Unit = {},
     onProjectClick: (directory: String) -> Unit = {},
     onViewChanges: (sessionId: String) -> Unit = {},
+    onForkSessionInWorkspace: (sessionId: String, directory: String?) -> Unit = { sessionId, _ ->
+        viewModel.forkSession(sessionId)
+    },
     onCreateSessionInWorkspace: (title: String?, directory: String?) -> Unit = { title, directory ->
         viewModel.createSession(title, directory)
     },
@@ -311,10 +316,16 @@ fun SessionListScreen(
                                 expandedSessionIds = uiState.expandedSessionIds,
                                 sessionStatuses = uiState.sessionStatuses,
                                 sessionPresences = uiState.sessionPresences,
+                                forkingSessionIds = uiState.forkingSessionIds,
+                                isSessionForkPending = isSessionForkPending ||
+                                    uiState.forkingSessionIds.isNotEmpty(),
                                 showProjectChip = filterProjectId == null,
                                 onSessionClick = { session -> onSessionClick(session.id, session.directory) },
                                 onDeleteSession = { showDeleteDialog = it },
                                 onRenameSession = { showRenameDialog = it },
+                                onForkSession = { session ->
+                                    onForkSessionInWorkspace(session.id, session.directory)
+                                },
                                 onShareSession = { session ->
                                     if (session.shareUrl != null) {
                                         viewModel.unshareSession(session.id)
@@ -508,16 +519,20 @@ private fun buildSessionTree(sessions: List<SessionWithProject>): List<SessionNo
 }
 
 @Composable
+@Suppress("FunctionNaming", "LongParameterList", "LongMethod")
 private fun SessionTreeNode(
     node: SessionNode,
     depth: Int,
     expandedSessionIds: Set<String>,
     sessionStatuses: Map<String, SessionStatus>,
     sessionPresences: Map<String, SessionPresence>,
+    forkingSessionIds: Set<String>,
+    isSessionForkPending: Boolean,
     showProjectChip: Boolean,
     onSessionClick: (Session) -> Unit,
     onDeleteSession: (Session) -> Unit,
     onRenameSession: (Session) -> Unit,
+    onForkSession: (Session) -> Unit,
     onShareSession: (Session) -> Unit,
     onViewChanges: (Session) -> Unit,
     onSummarizeSession: (Session) -> Unit,
@@ -538,10 +553,13 @@ private fun SessionTreeNode(
             showProjectChip = showProjectChip,
             status = sessionStatuses[session.id],
             presence = sessionPresences[session.id] ?: SessionPresence.IDLE,
+            isForking = session.id in forkingSessionIds,
+            isSessionForkPending = isSessionForkPending,
             isShared = session.shareUrl != null,
             onClick = { onSessionClick(session) },
             onDelete = { onDeleteSession(session) },
             onRename = { onRenameSession(session) },
+            onFork = { onForkSession(session) },
             onShare = { onShareSession(session) },
             onViewChanges = { onViewChanges(session) },
             onSummarize = { onSummarizeSession(session) },
@@ -568,10 +586,13 @@ private fun SessionTreeNode(
                         expandedSessionIds = expandedSessionIds,
                         sessionStatuses = sessionStatuses,
                         sessionPresences = sessionPresences,
+                        forkingSessionIds = forkingSessionIds,
+                        isSessionForkPending = isSessionForkPending,
                         showProjectChip = showProjectChip,
                         onSessionClick = onSessionClick,
                         onDeleteSession = onDeleteSession,
                         onRenameSession = onRenameSession,
+                        onForkSession = onForkSession,
                         onShareSession = onShareSession,
                         onViewChanges = onViewChanges,
                         onSummarizeSession = onSummarizeSession,
@@ -586,6 +607,7 @@ private fun SessionTreeNode(
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
+@Suppress("FunctionNaming", "LongParameterList", "LongMethod", "CyclomaticComplexMethod")
 private fun SessionCard(
     session: Session,
     projectId: String?,
@@ -593,10 +615,13 @@ private fun SessionCard(
     showProjectChip: Boolean,
     status: SessionStatus?,
     presence: SessionPresence,
+    isForking: Boolean,
+    isSessionForkPending: Boolean,
     isShared: Boolean,
     onClick: () -> Unit,
     onDelete: () -> Unit,
     onRename: () -> Unit,
+    onFork: () -> Unit,
     onShare: () -> Unit,
     onViewChanges: () -> Unit,
     onSummarize: () -> Unit,
@@ -617,6 +642,7 @@ private fun SessionCard(
         workspaceIdentity,
         formatDateTime(session.updatedAt),
     )
+    val forkingDescription = stringResource(R.string.sessions_forking)
 
     Surface(
         modifier = Modifier
@@ -626,6 +652,7 @@ private fun SessionCard(
             .combinedClickable(
                 onClick = onClick,
                 onLongClick = { showContextMenu = true },
+                onLongClickLabel = stringResource(R.string.sessions_open_actions),
                 role = Role.Button,
             ),
         color = when {
@@ -731,6 +758,18 @@ private fun SessionCard(
                 }
             }
 
+            if (isForking) {
+                CircularProgressIndicator(
+                    modifier = Modifier
+                        .size(Sizing.iconSm)
+                        .semantics {
+                            contentDescription = forkingDescription
+                        },
+                    color = theme.accent,
+                    strokeWidth = Sizing.strokeThin,
+                )
+            }
+
             // Directory chip on far right. Real projects and pseudo-project
             // directories use the same navigation model: filter by directory.
             if (showProjectChip && !projectName.isNullOrEmpty()) {
@@ -755,6 +794,15 @@ private fun SessionCard(
                 onRename()
             },
             leadingIcon = Icons.Default.Edit
+        )
+        TuiDropdownMenuItem(
+            text = stringResource(R.string.sessions_fork),
+            onClick = {
+                showContextMenu = false
+                onFork()
+            },
+            leadingIcon = Icons.Default.ContentCopy,
+            enabled = !isSessionForkPending && !isForking,
         )
         TuiDropdownMenuItem(
             text = stringResource(R.string.sessions_view_changes),

--- a/app/src/main/java/dev/blazelight/p4oc/ui/screens/sessions/SessionListViewModel.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/screens/sessions/SessionListViewModel.kt
@@ -397,6 +397,37 @@ class SessionListViewModel constructor(
         }
     }
 
+    fun forkSession(sessionId: String) {
+        viewModelScope.launch {
+            _uiState.update {
+                it.copy(
+                    forkingSessionIds = it.forkingSessionIds + sessionId,
+                    error = null,
+                )
+            }
+            try {
+                val forked = sessionRepository.forkSession(SessionId(sessionId))
+                _uiState.update {
+                    it.copy(
+                        newSessionId = forked.id.value,
+                        newSessionDirectory = forked.session.directory,
+                        forkingSessionIds = it.forkingSessionIds - sessionId,
+                        error = null,
+                    )
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                AppLog.e(TAG, "Failed to fork session")
+                _uiState.update { it.copy(error = "Could not fork the session. Try again.") }
+            } finally {
+                _uiState.update {
+                    it.copy(forkingSessionIds = it.forkingSessionIds - sessionId)
+                }
+            }
+        }
+    }
+
     fun deleteSession(sessionId: String) {
         viewModelScope.launch {
             try {
@@ -510,6 +541,7 @@ data class SessionListUiState(
     val newSessionDirectory: String? = null,
     val shareUrl: String? = null,
     val expandedSessionIds: Set<String> = emptySet(),
+    val forkingSessionIds: Set<String> = emptySet(),
     val error: String? = null
 ) {
     val isSearchActive: Boolean

--- a/app/src/main/java/dev/blazelight/p4oc/ui/tabs/TabNavHost.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/tabs/TabNavHost.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavHostController
@@ -161,6 +162,7 @@ fun TabNavHost(
     // Sessions tab: exits the app.
     var backPressedAt by remember { mutableLongStateOf(0L) }
     val context = LocalContext.current
+    val forkAlreadyPendingMessage = stringResource(R.string.sessions_fork_already_pending)
     val isDedicatedTab = startRoute != Screen.Sessions.route
 
     BackHandler(enabled = navController.previousBackStackEntry == null) {
@@ -314,7 +316,7 @@ fun TabNavHost(
                         if (!decision.accepted) {
                             Toast.makeText(
                                 context,
-                                context.getString(R.string.sessions_fork_already_pending),
+                                forkAlreadyPendingMessage,
                                 Toast.LENGTH_SHORT,
                             ).show()
                             return@SessionListScreen
@@ -424,7 +426,7 @@ fun TabNavHost(
                         if (!decision.accepted) {
                             Toast.makeText(
                                 context,
-                                context.getString(R.string.sessions_fork_already_pending),
+                                forkAlreadyPendingMessage,
                                 Toast.LENGTH_SHORT,
                             ).show()
                             return@SessionListScreen

--- a/app/src/main/java/dev/blazelight/p4oc/ui/tabs/TabNavHost.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/tabs/TabNavHost.kt
@@ -22,6 +22,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.navigation
 import androidx.navigation.navArgument
+import dev.blazelight.p4oc.R
 import dev.blazelight.p4oc.core.datastore.SettingsDataStore
 import dev.blazelight.p4oc.core.datastore.VisualSettings
 import dev.blazelight.p4oc.core.network.ServerConnectionRegistry
@@ -60,6 +61,45 @@ private data class PendingSessionCreate(
     val title: String?,
     val directory: String?,
 )
+
+internal data class PendingSessionFork(
+    val sourceSessionId: String,
+    val directory: String?,
+)
+
+internal data class PendingSessionForkEnqueueDecision(
+    val pending: PendingSessionFork,
+    val accepted: Boolean,
+)
+
+internal fun decidePendingSessionForkEnqueue(
+    current: PendingSessionFork?,
+    requested: PendingSessionFork,
+): PendingSessionForkEnqueueDecision = if (current == null) {
+    PendingSessionForkEnqueueDecision(pending = requested, accepted = true)
+} else {
+    PendingSessionForkEnqueueDecision(pending = current, accepted = false)
+}
+
+internal data class PendingSessionForkStep(
+    val remaining: PendingSessionFork?,
+    val sourceSessionIdToFork: String?,
+)
+
+internal fun pendingSessionForkStep(
+    pending: PendingSessionFork?,
+    currentDirectory: String?,
+): PendingSessionForkStep = when {
+    pending == null -> PendingSessionForkStep(remaining = null, sourceSessionIdToFork = null)
+    pending.directory != currentDirectory -> PendingSessionForkStep(
+        remaining = pending,
+        sourceSessionIdToFork = null,
+    )
+    else -> PendingSessionForkStep(
+        remaining = null,
+        sourceSessionIdToFork = pending.sourceSessionId,
+    )
+}
 
 private fun workspaceGraphRoute(tabId: String, revision: Int): String = "workspace/$tabId/$revision"
 
@@ -107,6 +147,7 @@ fun TabNavHost(
     val workspaceRoute = remember(tabId, workspaceRevision) { workspaceGraphRoute(tabId, workspaceRevision) }
     var pendingRoute by remember(tabId) { mutableStateOf<String?>(null) }
     var pendingSessionCreate by remember(tabId) { mutableStateOf<PendingSessionCreate?>(null) }
+    var pendingSessionFork by remember(tabId) { mutableStateOf<PendingSessionFork?>(null) }
 
     LaunchedEffect(workspaceRevision, pendingRoute, pendingSessionCreate) {
         pendingRoute?.let { route ->
@@ -206,12 +247,23 @@ fun TabNavHost(
                     workspaceOwner,
                     backStackEntry.destination.route
                 )
+                val sessionListViewModel = sessionListViewModelForRoute(
+                    owner = backStackEntry,
+                    workspaceViewModel = workspaceViewModel,
+                    keySuffix = "sessions",
+                )
+                LaunchedEffect(workspaceViewModel, sessionListViewModel, pendingSessionFork) {
+                    val step = pendingSessionForkStep(
+                        pending = pendingSessionFork,
+                        currentDirectory = workspaceViewModel.workspace.directory,
+                    )
+                    val sourceSessionId = step.sourceSessionIdToFork ?: return@LaunchedEffect
+                    pendingSessionFork = step.remaining
+                    sessionListViewModel.forkSession(sourceSessionId)
+                }
                 SessionListScreen(
-                    viewModel = sessionListViewModelForRoute(
-                        owner = backStackEntry,
-                        workspaceViewModel = workspaceViewModel,
-                        keySuffix = "sessions",
-                    ),
+                    viewModel = sessionListViewModel,
+                    isSessionForkPending = pendingSessionFork != null,
                     onSessionClick = { sessionId, directory ->
                         val selection = directory.toNavigationWorkspaceSelection()
                             ?: return@SessionListScreen
@@ -251,6 +303,26 @@ fun TabNavHost(
                     onViewChanges = { sessionId ->
                         navController.navigate(Screen.SessionDiff.createRoute(sessionId))
                     },
+                    onForkSessionInWorkspace = { sourceSessionId, directory ->
+                        val selection = directory.toNavigationWorkspaceSelection()
+                            ?: return@SessionListScreen
+                        val decision = decidePendingSessionForkEnqueue(
+                            current = pendingSessionFork,
+                            requested = PendingSessionFork(sourceSessionId, selection.directory),
+                        )
+                        pendingSessionFork = decision.pending
+                        if (!decision.accepted) {
+                            Toast.makeText(
+                                context,
+                                context.getString(R.string.sessions_fork_already_pending),
+                                Toast.LENGTH_SHORT,
+                            ).show()
+                            return@SessionListScreen
+                        }
+                        if (selection.directory != workspaceOwner.workspace.directory) {
+                            tabManager.updateTabWorkspace(tabId, selection.workspaceKey)
+                        }
+                    },
                     onCreateSessionInWorkspace = { title, directory ->
                         val selection = directory.toNavigationWorkspaceSelection()
                             ?: return@SessionListScreen
@@ -284,13 +356,24 @@ fun TabNavHost(
                     backStackEntry.destination.route
                 )
                 val projectId = backStackEntry.arguments?.getString(Screen.SessionsFiltered.ARG_PROJECT_ID) ?: ""
+                val sessionListViewModel = sessionListViewModelForRoute(
+                    owner = backStackEntry,
+                    workspaceViewModel = workspaceViewModel,
+                    keySuffix = "sessions-filtered-$projectId",
+                )
+                LaunchedEffect(workspaceViewModel, sessionListViewModel, pendingSessionFork) {
+                    val step = pendingSessionForkStep(
+                        pending = pendingSessionFork,
+                        currentDirectory = workspaceViewModel.workspace.directory,
+                    )
+                    val sourceSessionId = step.sourceSessionIdToFork ?: return@LaunchedEffect
+                    pendingSessionFork = step.remaining
+                    sessionListViewModel.forkSession(sourceSessionId)
+                }
                 SessionListScreen(
-                    viewModel = sessionListViewModelForRoute(
-                        owner = backStackEntry,
-                        workspaceViewModel = workspaceViewModel,
-                        keySuffix = "sessions-filtered-$projectId",
-                    ),
+                    viewModel = sessionListViewModel,
                     filterProjectId = projectId,
+                    isSessionForkPending = pendingSessionFork != null,
                     onSessionClick = { sessionId, directory ->
                         val selection = directory.toNavigationWorkspaceSelection()
                             ?: return@SessionListScreen
@@ -329,6 +412,27 @@ fun TabNavHost(
                     },
                     onViewChanges = { sessionId ->
                         navController.navigate(Screen.SessionDiff.createRoute(sessionId))
+                    },
+                    onForkSessionInWorkspace = { sourceSessionId, directory ->
+                        val selection = directory.toNavigationWorkspaceSelection()
+                            ?: return@SessionListScreen
+                        val decision = decidePendingSessionForkEnqueue(
+                            current = pendingSessionFork,
+                            requested = PendingSessionFork(sourceSessionId, selection.directory),
+                        )
+                        pendingSessionFork = decision.pending
+                        if (!decision.accepted) {
+                            Toast.makeText(
+                                context,
+                                context.getString(R.string.sessions_fork_already_pending),
+                                Toast.LENGTH_SHORT,
+                            ).show()
+                            return@SessionListScreen
+                        }
+                        if (selection.directory != workspaceOwner.workspace.directory) {
+                            pendingRoute = Screen.SessionsFiltered.createRoute(projectId)
+                            tabManager.updateTabWorkspace(tabId, selection.workspaceKey)
+                        }
                     },
                     onCreateSessionInWorkspace = { title, directory ->
                         val selection = directory.toNavigationWorkspaceSelection()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -241,6 +241,10 @@
     <string name="sessions_new">New Session</string>
     <string name="sessions_delete">Delete</string>
     <string name="sessions_rename">Rename</string>
+    <string name="sessions_open_actions">Open session actions</string>
+    <string name="sessions_fork">Fork session</string>
+    <string name="sessions_forking">Forking session</string>
+    <string name="sessions_fork_already_pending">Another session fork is already starting</string>
     <string name="sessions_rename_title">Rename Session</string>
     <string name="sessions_rename_failed">Failed to rename session</string>
     <string name="sessions_share">Share</string>

--- a/app/src/test/java/dev/blazelight/p4oc/data/workspace/WorkspaceClientTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/data/workspace/WorkspaceClientTest.kt
@@ -3,6 +3,7 @@ package dev.blazelight.p4oc.data.workspace
 import dev.blazelight.p4oc.core.network.ConnectionState
 import dev.blazelight.p4oc.core.network.OpenCodeApi
 import dev.blazelight.p4oc.data.remote.dto.ConfigDto
+import dev.blazelight.p4oc.data.remote.dto.ForkSessionRequest
 import dev.blazelight.p4oc.data.remote.dto.ProvidersResponseDto
 import dev.blazelight.p4oc.data.remote.dto.QuestionDto
 import dev.blazelight.p4oc.data.remote.dto.QuestionOptionDto
@@ -11,6 +12,7 @@ import dev.blazelight.p4oc.data.remote.dto.QuestionRequestDto
 import dev.blazelight.p4oc.data.remote.dto.QuestionV2RequestListResponseDto
 import dev.blazelight.p4oc.data.server.ActiveServerApiProvider
 import dev.blazelight.p4oc.data.server.StaleWorkspaceClientException
+import dev.blazelight.p4oc.di.appModule
 import dev.blazelight.p4oc.domain.server.ServerGeneration
 import dev.blazelight.p4oc.domain.server.ServerRef
 import dev.blazelight.p4oc.domain.workspace.Workspace
@@ -19,16 +21,32 @@ import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.Assert.assertEquals
 import org.junit.Assert.fail
 import org.junit.Test
+import org.koin.dsl.koinApplication
 import retrofit2.HttpException
 import retrofit2.Response
 import java.net.SocketTimeoutException
 
 class WorkspaceClientTest {
+    @Test
+    fun `fork request omits null message id with production json`() {
+        val application = koinApplication { modules(appModule) }
+
+        try {
+            val json = application.koin.get<Json>()
+
+            assertEquals("{}", json.encodeToString(ForkSessionRequest(messageID = null)))
+        } finally {
+            application.close()
+        }
+    }
+
     @Test
     fun `question operations use legacy endpoints without v2 requests`() = runTest {
         val api = mockk<OpenCodeApi>()

--- a/app/src/test/java/dev/blazelight/p4oc/fakes/FakeWorkspaceClient.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/fakes/FakeWorkspaceClient.kt
@@ -1,6 +1,8 @@
 package dev.blazelight.p4oc.fakes
 
 import dev.blazelight.p4oc.data.remote.dto.CreateSessionRequest
+import dev.blazelight.p4oc.data.remote.dto.ForkSessionRequest
+import dev.blazelight.p4oc.data.remote.dto.InitSessionRequest
 import dev.blazelight.p4oc.data.remote.dto.PermissionDto
 import dev.blazelight.p4oc.data.remote.dto.PermissionToolDto
 import dev.blazelight.p4oc.data.remote.dto.PermissionV2RequestDto
@@ -53,10 +55,22 @@ class FakeWorkspaceClient(
         val limit: Int?,
     )
 
+    data class ForkSessionCall(
+        val sourceSessionId: String,
+        val request: ForkSessionRequest,
+    )
+
+    data class InitSessionCall(
+        val sessionId: String,
+        val request: InitSessionRequest,
+    )
+
     val listSessionsDirectories = mutableListOf<String?>()
     val listSessionsScopes = mutableListOf<String?>()
     val listSessionsCallsLog = mutableListOf<ListSessionsCall>()
     val getSessionStatusesDirectories = mutableListOf<String?>()
+    val forkSessionCallsLog = mutableListOf<ForkSessionCall>()
+    val initSessionCallsLog = mutableListOf<InitSessionCall>()
 
     var projects: List<ProjectDto> = emptyList()
     var listSessionsResult: List<SessionDto> = emptyList()
@@ -70,6 +84,10 @@ class FakeWorkspaceClient(
     var getSessionResults: MutableMap<String, SessionDto> = mutableMapOf()
     var getSessionFailure: Throwable? = null
     var createSessionFailure: Throwable? = null
+    var forkSessionResult: SessionDto? = null
+    var forkSessionFailure: Throwable? = null
+    var initSessionResult: Boolean = true
+    var initSessionFailure: Throwable? = null
     var deleteSessionFailure: Throwable? = null
     var sendMessageBlocker: CompletableDeferred<Unit>? = null
     var abortSessionBlocker: CompletableDeferred<Unit>? = null
@@ -130,6 +148,18 @@ class FakeWorkspaceClient(
             sessionDto(id = "created", title = request.title ?: "created", directory = workspace.directory.orEmpty())
         setSessions(session, *listSessionsResult.toTypedArray())
         return session
+    }
+
+    override suspend fun forkSession(id: String, request: ForkSessionRequest): SessionDto {
+        forkSessionCallsLog += ForkSessionCall(sourceSessionId = id, request = request)
+        forkSessionFailure?.let { throw it }
+        return forkSessionResult ?: error("No fake fork session result configured")
+    }
+
+    override suspend fun initSession(id: String, request: InitSessionRequest): Boolean {
+        initSessionCallsLog += InitSessionCall(sessionId = id, request = request)
+        initSessionFailure?.let { throw it }
+        return initSessionResult
     }
 
     override suspend fun deleteSession(id: String): Boolean {

--- a/app/src/test/java/dev/blazelight/p4oc/ui/components/command/CommandPaletteTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/ui/components/command/CommandPaletteTest.kt
@@ -1,0 +1,45 @@
+package dev.blazelight.p4oc.ui.components.command
+
+import dev.blazelight.p4oc.domain.model.Command
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CommandPaletteTest {
+    private val command = Command(name = "custom")
+
+    @Test
+    fun `refused command keeps palette open`() {
+        var dismissCount = 0
+
+        val accepted = executePaletteCommand(
+            command = command,
+            arguments = "arguments",
+            onCommandSelected = { selectedCommand, arguments ->
+                assertEquals(command, selectedCommand)
+                assertEquals("arguments", arguments)
+                false
+            },
+            onDismiss = { dismissCount += 1 },
+        )
+
+        assertFalse(accepted)
+        assertEquals(0, dismissCount)
+    }
+
+    @Test
+    fun `accepted command dismisses palette once`() {
+        var dismissCount = 0
+
+        val accepted = executePaletteCommand(
+            command = command,
+            arguments = "arguments",
+            onCommandSelected = { _, _ -> true },
+            onDismiss = { dismissCount += 1 },
+        )
+
+        assertTrue(accepted)
+        assertEquals(1, dismissCount)
+    }
+}

--- a/app/src/test/java/dev/blazelight/p4oc/ui/screens/chat/ChatViewModelDraftPersistenceTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/ui/screens/chat/ChatViewModelDraftPersistenceTest.kt
@@ -258,12 +258,13 @@ class ChatViewModelDraftPersistenceTest {
         assertFalse(restored.available)
 
         vm.updateInput("please read this")
-        vm.sendMessage()
+        assertFalse(vm.sendMessage())
         advanceUntilIdle()
 
         coVerify(exactly = 0) { api.sendMessageAsync(any(), any(), any(), null) }
         assertEquals("please read this", vm.uiState.value.inputText)
         assertEquals(listOf("src/Missing.kt"), vm.filePickerManager.attachedFiles.value.map { it.path })
+        assertEquals("Remove unavailable attachments before sending.", vm.uiState.value.error)
     }
 
     @Test
@@ -310,7 +311,7 @@ class ChatViewModelDraftPersistenceTest {
     }
 
     @Test
-    fun sendMessage_successClearsPersistedDraftAndAttachments() = runTest {
+    fun acceptedSend_composerClearClearsPersistedDraftAndAttachments() = runTest {
         val savedStateHandle = SavedStateHandle(mapOf(Screen.Chat.ARG_SESSION_ID to "session-1"))
         val vm = createViewModel(savedStateHandle)
         coEvery { api.sendMessageAsync(any(), any(), any(), null) } returns Unit
@@ -330,7 +331,9 @@ class ChatViewModelDraftPersistenceTest {
         assertEquals("hello", savedStateHandle.get<String>("chat_draft_text"))
         assertTrue(savedStateHandle.get<String>("chat_attached_files")?.contains("src/Main.kt") == true)
 
-        vm.sendMessage()
+        assertTrue(vm.sendMessage())
+        assertEquals("hello", savedStateHandle.get<String>("chat_draft_text"))
+        vm.updateInput("")
         advanceUntilIdle()
 
         assertNull(savedStateHandle.get<String>("chat_draft_text"))

--- a/app/src/test/java/dev/blazelight/p4oc/ui/screens/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/ui/screens/chat/ChatViewModelTest.kt
@@ -13,12 +13,15 @@ import dev.blazelight.p4oc.core.network.OpenCodeApi
 import dev.blazelight.p4oc.data.files.FileRepository
 import dev.blazelight.p4oc.data.files.FileRepositoryFactory
 import dev.blazelight.p4oc.data.remote.dto.CommandDto
+import dev.blazelight.p4oc.data.remote.dto.ExecuteCommandRequest
 import dev.blazelight.p4oc.data.remote.dto.FileNodeDto
+import dev.blazelight.p4oc.data.remote.dto.InitSessionRequest
 import dev.blazelight.p4oc.data.remote.dto.MessageInfoDto
 import dev.blazelight.p4oc.data.remote.dto.MessageTimeDto
 import dev.blazelight.p4oc.data.remote.dto.MessageWrapperDto
 import dev.blazelight.p4oc.data.remote.dto.ModelRefDto
 import dev.blazelight.p4oc.data.remote.dto.PartDto
+import dev.blazelight.p4oc.data.remote.dto.ProvidersResponseDto
 import dev.blazelight.p4oc.data.remote.dto.RevertSessionRequest
 import dev.blazelight.p4oc.data.remote.dto.SendMessageRequest
 import dev.blazelight.p4oc.data.remote.dto.SessionDto
@@ -30,6 +33,7 @@ import dev.blazelight.p4oc.data.remote.mapper.MessageMapper
 import dev.blazelight.p4oc.data.server.ActiveServerApiProvider
 import dev.blazelight.p4oc.data.session.SessionRepositoryImpl
 import dev.blazelight.p4oc.data.workspace.WorkspaceClient
+import dev.blazelight.p4oc.domain.model.CommandSource
 import dev.blazelight.p4oc.domain.model.Message
 import dev.blazelight.p4oc.domain.model.MessageError
 import dev.blazelight.p4oc.domain.model.MessageWithParts
@@ -64,6 +68,8 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
@@ -76,7 +82,9 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.After
@@ -91,6 +99,7 @@ import org.junit.rules.TestWatcher
 import org.junit.runner.Description
 import retrofit2.HttpException
 import retrofit2.Response
+import java.io.IOException
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @Suppress("LargeClass")
@@ -401,6 +410,25 @@ class ChatViewModelTest {
     }
 
     @Test
+    fun sendMessage_blankAndEmptySlashReturnFalsePreserveInputAndCallNoSubmissionEndpoints() = runTest {
+        val vm = createViewModel()
+        val refusedInputs = listOf("  \n  ", "/")
+
+        refusedInputs.forEach { input ->
+            vm.updateInput(input)
+
+            assertFalse(vm.sendMessage())
+            assertEquals(input, vm.uiState.value.inputText)
+        }
+
+        coVerify(exactly = 0) { api.sendMessageAsync(any(), any(), any(), null) }
+        coVerify(exactly = 0) { api.executeCommand(any(), any(), any(), null) }
+        coVerify(exactly = 0) { api.revertSession(any(), any(), any(), null) }
+        coVerify(exactly = 0) { api.unrevertSession(any(), any(), null) }
+        coVerify(exactly = 0) { api.initSession(any(), any(), any(), null) }
+    }
+
+    @Test
     fun sendMessage_undoSlashCommand_revertsToPreviousUserMessageBoundaryWithoutExecutingCommand() =
         runTest {
             coEvery { api.getSession("session-1", any(), null) } returns sessionDto(revertMessageId = "user-2")
@@ -418,9 +446,10 @@ class ChatViewModelTest {
             val vm = createViewModel()
 
             vm.updateInput("/undo")
-            vm.sendMessage()
+            assertTrue(vm.sendMessage())
             advanceUntilIdle()
 
+            assertEquals("/undo", vm.uiState.value.inputText)
             coVerify(exactly = 0) { api.executeCommand(any(), any(), any(), null) }
             coVerify(exactly = 1) {
                 api.revertSession("session-1", RevertSessionRequest(messageID = "user-1"), "/test", null)
@@ -446,9 +475,10 @@ class ChatViewModelTest {
             val vm = createViewModel()
 
             vm.updateInput("/redo")
-            vm.sendMessage()
+            assertTrue(vm.sendMessage())
             advanceUntilIdle()
 
+            assertEquals("/redo", vm.uiState.value.inputText)
             coVerify(exactly = 0) { api.executeCommand(any(), any(), any(), null) }
             coVerify(exactly = 1) {
                 api.revertSession("session-1", RevertSessionRequest(messageID = "user-2"), "/test", null)
@@ -457,16 +487,148 @@ class ChatViewModelTest {
         }
 
     @Test
-    fun sendMessage_clearsInput_andMarksBusyUntilSseStatus() = runTest {
+    fun sendMessage_busySlashCommandsPreserveExactInputShowErrorAndCallNoCommandEndpoints() = runTest {
+        val vm = createViewModel()
+        emitEvent(OpenCodeEvent.SessionStatusChanged("session-1", SessionStatus.Busy))
+        flushMessages()
+
+        val refusedInputs = listOf(
+            "/undo",
+            "/redo   keep  these arguments ",
+            "/init   keep init arguments ",
+            "/custom keep  custom arguments ",
+        )
+        refusedInputs.forEach { input ->
+            vm.updateInput(input)
+
+            assertFalse(vm.sendMessage())
+
+            assertEquals(input, vm.uiState.value.inputText)
+            assertEquals(
+                "Wait for the current run to finish or stop it first.",
+                vm.uiState.value.error,
+            )
+        }
+
+        coVerify(exactly = 0) { api.sendMessageAsync(any(), any(), any(), null) }
+        coVerify(exactly = 0) { api.executeCommand(any(), any(), any(), null) }
+        coVerify(exactly = 0) { api.revertSession(any(), any(), any(), null) }
+        coVerify(exactly = 0) { api.unrevertSession(any(), any(), null) }
+        coVerify(exactly = 0) { api.initSession(any(), any(), any(), null) }
+    }
+
+    @Test
+    fun sendMessage_idleCustomSlashCommandReturnsAcceptedAndDispatchesParsedArguments() = runTest {
+        val request = slot<ExecuteCommandRequest>()
+        coEvery {
+            api.executeCommand("session-1", capture(request), "/test", null)
+        } returns assistantMessageDto("command-response", createdAt = 5)
+        val vm = createViewModel()
+        vm.updateInput("/custom exact  arguments")
+
+        assertTrue(vm.sendMessage())
+        runCurrent()
+
+        assertEquals("/custom exact  arguments", vm.uiState.value.inputText)
+        assertEquals("custom", request.captured.command)
+        assertEquals("exact  arguments", request.captured.arguments)
+        coVerify(exactly = 1) { api.executeCommand("session-1", any(), "/test", null) }
+    }
+
+    @Test
+    fun sendMessage_gatedGenericSlashFailureRestoresExactRawDraftAndSendsTrimmedPayload() = runTest {
+        val failureGate = CompletableDeferred<Unit>()
+        val request = slot<ExecuteCommandRequest>()
+        coEvery { api.executeCommand("session-1", capture(request), "/test", null) } coAnswers {
+            failureGate.await()
+            throw IOException("boom")
+        }
+        val vm = createViewModel()
+        val submittedDraft = " \t/custom exact  arguments  \n"
+
+        vm.updateInput(submittedDraft)
+        assertTrue(vm.sendMessage())
+        runCurrent()
+        vm.updateInput("")
+
+        failureGate.complete(Unit)
+        advanceUntilIdle()
+
+        assertEquals(submittedDraft, vm.uiState.value.inputText)
+        assertEquals("custom", request.captured.command)
+        assertEquals("exact  arguments", request.captured.arguments)
+        assertEquals("Could not execute the command. Try again.", vm.uiState.value.error)
+    }
+
+    @Test
+    fun sendMessage_missingInitModelReturnsFalseWithoutClearingDraftAndReleasesCommandOwner() = runTest {
+        coEvery { api.getSession("session-1", any(), null) } returns sessionDto()
+        coEvery { api.getProviders(any(), null) } returns ProvidersResponseDto(
+            all = emptyList(),
+            default = emptyMap(),
+            connected = emptyList(),
+        )
+        coEvery { api.executeCommand("session-1", any(), "/test", null) } returns assistantMessageDto(
+            "command-response",
+            createdAt = 5,
+        )
+        val vm = createViewModel()
+        val refusedDraft = "  /init keep exact spacing  \n"
+
+        vm.updateInput(refusedDraft)
+        assertFalse(vm.sendMessage())
+
+        assertEquals(refusedDraft, vm.uiState.value.inputText)
+        assertFalse(vm.uiState.value.isSending)
+        assertEquals("Select a model before initializing the session.", vm.uiState.value.error)
+        coVerify(exactly = 0) { api.initSession(any(), any(), any(), null) }
+
+        assertTrue(vm.executeCommand("custom", "after refusal"))
+        runCurrent()
+        coVerify(exactly = 1) { api.executeCommand("session-1", any(), "/test", null) }
+    }
+
+    @Test
+    fun sendMessage_noUndoOrRedoBoundaryReturnsFalseWithoutClearingExactDraft() = runTest {
+        coEvery { api.getMessages("session-1", any(), null, any(), null) } returns emptyList()
+        coEvery { api.executeCommand("session-1", any(), "/test", null) } returns assistantMessageDto(
+            "command-response",
+            createdAt = 5,
+        )
+        val vm = createViewModel()
+        val refusedDrafts = listOf(
+            " \t/undo  \n" to "Nothing to undo",
+            "  /redo keep ignored args  " to "Nothing to redo",
+        )
+
+        refusedDrafts.forEach { (draft, expectedError) ->
+            vm.updateInput(draft)
+
+            assertFalse(vm.sendMessage())
+
+            assertEquals(draft, vm.uiState.value.inputText)
+            assertFalse(vm.uiState.value.isSending)
+            assertEquals(expectedError, vm.uiState.value.error)
+        }
+        coVerify(exactly = 0) { api.revertSession(any(), any(), any(), null) }
+        coVerify(exactly = 0) { api.unrevertSession(any(), any(), null) }
+
+        assertTrue(vm.executeCommand("custom", "after redo refusal"))
+        runCurrent()
+        coVerify(exactly = 1) { api.executeCommand("session-1", any(), "/test", null) }
+    }
+
+    @Test
+    fun sendMessage_acceptsInput_andMarksBusyUntilSseStatus() = runTest {
         val vm = createViewModel()
         coEvery { api.sendMessageAsync(any(), any(), any(), null) } returns Unit
         vm.updateInput("hello")
 
-        vm.sendMessage()
+        assertTrue(vm.sendMessage())
         assertTrue(vm.uiState.value.isSending)
 
         advanceUntilIdle()
-        assertEquals("", vm.uiState.value.inputText)
+        assertEquals("hello", vm.uiState.value.inputText)
         assertFalse(vm.uiState.value.isSending)
         assertTrue(vm.uiState.value.isBusy)
     }
@@ -822,21 +984,128 @@ class ChatViewModelTest {
     }
 
     @Test
-    fun sendMessage_restoresInput_onApiError() = runTest {
+    fun sendMessage_immediateApiErrorRestoresExactDraftAfterAcceptedComposerClear() = runTest {
+        val request = slot<SendMessageRequest>()
+        coEvery { api.sendMessageAsync(any(), capture(request), any(), null) } throws RuntimeException("boom")
         val vm = createViewModel()
+        val submittedDraft = "  hello from composer  \n"
 
-        coEvery { api.sendMessageAsync(any(), any(), any(), null) } throws RuntimeException("boom")
+        vm.updateInput(submittedDraft)
+        val syncGenerationBeforeSend = vm.uiState.value.inputSyncGeneration
+        assertTrue(vm.sendMessage())
+        runCurrent()
 
-        vm.updateInput("hello")
-        vm.sendMessage()
-        advanceUntilIdle()
+        // The endpoint can fail before ChatInputBar's accepted clear is hoisted to the ViewModel.
+        // That later clear atomically acknowledges the submission and forces the exact failed
+        // draft back into the owned field, without relying on a transient empty state or a frame.
+        assertEquals(syncGenerationBeforeSend, vm.uiState.value.inputSyncGeneration)
+        vm.updateInput("")
 
-        assertEquals("hello", vm.uiState.value.inputText)
+        assertEquals(submittedDraft, vm.uiState.value.inputText)
+        assertTrue(vm.uiState.value.inputSyncGeneration > syncGenerationBeforeSend)
+        assertEquals("hello from composer", request.captured.parts.single().text)
         assertFalse(vm.uiState.value.isSending)
         assertEquals(
             "Could not send the message. Check the connection and try again.",
             vm.uiState.value.error,
         )
+    }
+
+    @Test
+    fun sendMessage_gatedApiErrorRestoresExactDraftClearedWhileRequestIsPending() = runTest {
+        val failureGate = CompletableDeferred<Unit>()
+        val request = slot<SendMessageRequest>()
+        coEvery { api.sendMessageAsync(any(), capture(request), any(), null) } coAnswers {
+            failureGate.await()
+            throw IOException("boom")
+        }
+        val vm = createViewModel()
+        val submittedDraft = "\t message with exact whitespace \n"
+
+        vm.updateInput(submittedDraft)
+        val syncGenerationBeforeSend = vm.uiState.value.inputSyncGeneration
+        assertTrue(vm.sendMessage())
+        runCurrent()
+        vm.updateInput("")
+        assertEquals("", vm.uiState.value.inputText)
+        assertEquals(syncGenerationBeforeSend, vm.uiState.value.inputSyncGeneration)
+
+        failureGate.complete(Unit)
+        advanceUntilIdle()
+
+        assertEquals(submittedDraft, vm.uiState.value.inputText)
+        assertTrue(vm.uiState.value.inputSyncGeneration > syncGenerationBeforeSend)
+        assertEquals("message with exact whitespace", request.captured.parts.single().text)
+    }
+
+    @Test
+    fun sendMessage_gatedApiErrorDoesNotOverwriteNewerNonblankDraft() = runTest {
+        val failureGate = CompletableDeferred<Unit>()
+        coEvery { api.sendMessageAsync(any(), any(), any(), null) } coAnswers {
+            failureGate.await()
+            throw IOException("boom")
+        }
+        val vm = createViewModel()
+
+        vm.updateInput("  original draft  ")
+        val syncGenerationBeforeSend = vm.uiState.value.inputSyncGeneration
+        assertTrue(vm.sendMessage())
+        runCurrent()
+        vm.updateInput("")
+        vm.updateInput("newer typed draft")
+
+        failureGate.complete(Unit)
+        advanceUntilIdle()
+
+        assertEquals("newer typed draft", vm.uiState.value.inputText)
+        assertEquals(syncGenerationBeforeSend, vm.uiState.value.inputSyncGeneration)
+        assertEquals(
+            "Could not send the message. Check the connection and try again.",
+            vm.uiState.value.error,
+        )
+    }
+
+    @Test
+    fun sendMessage_gatedApiErrorDoesNotOverwriteWhitespaceDraftTypedAfterClear() = runTest {
+        val failureGate = CompletableDeferred<Unit>()
+        coEvery { api.sendMessageAsync(any(), any(), any(), null) } coAnswers {
+            failureGate.await()
+            throw IOException("boom")
+        }
+        val vm = createViewModel()
+        val newerWhitespaceDraft = " \t\n"
+
+        vm.updateInput("original draft")
+        val syncGenerationBeforeSend = vm.uiState.value.inputSyncGeneration
+        assertTrue(vm.sendMessage())
+        runCurrent()
+        vm.updateInput("")
+        vm.updateInput(newerWhitespaceDraft)
+
+        failureGate.complete(Unit)
+        advanceUntilIdle()
+
+        assertEquals(newerWhitespaceDraft, vm.uiState.value.inputText)
+        assertEquals(syncGenerationBeforeSend, vm.uiState.value.inputSyncGeneration)
+    }
+
+    @Test
+    fun sendMessage_immediateApiErrorDoesNotOverwriteNewerWhitespaceDraft() = runTest {
+        coEvery { api.sendMessageAsync(any(), any(), any(), null) } throws RuntimeException("boom")
+        val vm = createViewModel()
+        val newerWhitespaceDraft = "\t \n"
+
+        vm.updateInput("original draft")
+        val syncGenerationBeforeSend = vm.uiState.value.inputSyncGeneration
+        assertTrue(vm.sendMessage())
+        runCurrent()
+
+        // Failure has already completed, but a nonempty whitespace edit is user input rather
+        // than the composer's accepted empty-string clear acknowledgment.
+        vm.updateInput(newerWhitespaceDraft)
+
+        assertEquals(newerWhitespaceDraft, vm.uiState.value.inputText)
+        assertEquals(syncGenerationBeforeSend, vm.uiState.value.inputSyncGeneration)
     }
 
     @Test
@@ -1031,6 +1300,554 @@ class ChatViewModelTest {
         assertTrue(vm.uiState.value.commands.any { it.name == "workspace" })
         assertTrue(vm.uiState.value.hasLoadedWorkspaceCommands)
         assertNull(vm.uiState.value.commandLoadError)
+    }
+
+    @Test
+    fun loadCommands_serverInitOverridesBuiltinMetadata_withoutRemovingOtherBuiltIns() = runTest {
+        coEvery { api.listCommands("/test", null) } returns listOf(
+            CommandDto(
+                name = "init",
+                description = "Initialize from the live server",
+                agent = "server-agent",
+                model = "server-model",
+                template = JsonPrimitive("server-template"),
+                source = "command",
+            ),
+        )
+        val vm = createViewModel()
+
+        vm.loadCommands()
+        advanceUntilIdle()
+
+        val commands = vm.uiState.value.commands
+        val initCommands = commands.filter { it.name == "init" }
+        assertEquals(1, initCommands.size)
+        with(initCommands.single()) {
+            assertEquals("Initialize from the live server", description)
+            assertEquals("server-agent", agent)
+            assertEquals("server-model", model)
+            assertEquals("server-template", template)
+            assertEquals(CommandSource.Skill, source)
+        }
+        assertTrue(commands.any { it.name == "help" && it.source == CommandSource.BuiltIn })
+    }
+
+    @Test
+    fun executeCommand_initWithSelectedModel_usesDedicatedInitEndpointWithGeneratedMessageId() = runTest {
+        val selectedModel = dev.blazelight.p4oc.data.remote.dto.ModelInput("openai", "gpt-5")
+        val request = slot<InitSessionRequest>()
+        coEvery { api.initSession("session-1", capture(request), "/test", null) } returns true
+        val vm = createViewModel()
+        vm.modelAgentManager.selectModel(selectedModel)
+        runCurrent()
+
+        vm.executeCommand("init", "ignored arguments")
+        runCurrent()
+
+        coVerify(exactly = 1) { api.initSession("session-1", any(), "/test", null) }
+        assertTrue(request.captured.messageID.startsWith("msg_"))
+        assertTrue(request.captured.messageID.removePrefix("msg_").isNotBlank())
+        assertEquals(selectedModel.providerID, request.captured.providerID)
+        assertEquals(selectedModel.modelID, request.captured.modelID)
+        assertTrue(vm.uiState.value.isBusy)
+
+        emitEvent(OpenCodeEvent.SessionStatusChanged("session-1", SessionStatus.Idle))
+        runCurrent()
+
+        coVerify(exactly = 0) { api.executeCommand(any(), any(), any(), null) }
+    }
+
+    @Test
+    fun sendMessage_gatedInitFailureRestoresExactRawSlashDraft() = runTest {
+        val initResponse = CompletableDeferred<Boolean>()
+        coEvery { api.initSession("session-1", any(), "/test", null) } coAnswers {
+            initResponse.await()
+        }
+        val vm = createViewModel()
+        vm.modelAgentManager.selectModel(
+            dev.blazelight.p4oc.data.remote.dto.ModelInput("openai", "gpt-5")
+        )
+        runCurrent()
+        val submittedDraft = " \t/init ignored  arguments \n"
+
+        vm.updateInput(submittedDraft)
+        assertTrue(vm.sendMessage())
+        runCurrent()
+        vm.updateInput("")
+
+        initResponse.complete(false)
+        advanceUntilIdle()
+
+        assertEquals(submittedDraft, vm.uiState.value.inputText)
+        assertFalse(vm.uiState.value.isSending)
+        assertEquals("Could not initialize the session. Try again.", vm.uiState.value.error)
+        coVerify(exactly = 1) { api.initSession("session-1", any(), "/test", null) }
+    }
+
+    @Test
+    fun sendMessage_gatedUndoFailureRestoresExactRawSlashDraft() = runTest {
+        val revertGate = CompletableDeferred<Unit>()
+        coEvery { api.getSession("session-1", any(), null) } returns sessionDto(revertMessageId = "user-2")
+        coEvery { api.getMessages("session-1", any(), null, any(), null) } returns listOf(
+            userMessageDto("user-1", createdAt = 1),
+            assistantMessageDto("assistant-1", createdAt = 2),
+            userMessageDto("user-2", createdAt = 3),
+        )
+        coEvery { api.revertSession(any(), any(), any(), null) } coAnswers {
+            revertGate.await()
+            throw IOException("boom")
+        }
+        val vm = createViewModel()
+        val submittedDraft = "  /undo keep exact whitespace \n"
+
+        vm.updateInput(submittedDraft)
+        assertTrue(vm.sendMessage())
+        runCurrent()
+        vm.updateInput("")
+
+        revertGate.complete(Unit)
+        advanceUntilIdle()
+
+        assertEquals(submittedDraft, vm.uiState.value.inputText)
+        assertFalse(vm.uiState.value.isSending)
+        assertEquals("Could not undo. Try again.", vm.uiState.value.error)
+        coVerify(exactly = 1) {
+            api.revertSession("session-1", RevertSessionRequest(messageID = "user-1"), "/test", null)
+        }
+    }
+
+    @Test
+    fun sendMessage_gatedRedoFailureRestoresExactRawSlashDraft() = runTest {
+        val revertGate = CompletableDeferred<Unit>()
+        coEvery { api.getSession("session-1", any(), null) } returns sessionDto(revertMessageId = "user-1")
+        coEvery { api.getMessages("session-1", any(), null, any(), null) } returns listOf(
+            userMessageDto("user-1", createdAt = 1),
+            assistantMessageDto("assistant-1", createdAt = 2),
+            userMessageDto("user-2", createdAt = 3),
+        )
+        coEvery { api.revertSession(any(), any(), any(), null) } coAnswers {
+            revertGate.await()
+            throw IOException("boom")
+        }
+        val vm = createViewModel()
+        val submittedDraft = "\t/redo keep exact whitespace  \n"
+
+        vm.updateInput(submittedDraft)
+        assertTrue(vm.sendMessage())
+        runCurrent()
+        vm.updateInput("")
+
+        revertGate.complete(Unit)
+        advanceUntilIdle()
+
+        assertEquals(submittedDraft, vm.uiState.value.inputText)
+        assertFalse(vm.uiState.value.isSending)
+        assertEquals("Could not redo. Try again.", vm.uiState.value.error)
+        coVerify(exactly = 1) {
+            api.revertSession("session-1", RevertSessionRequest(messageID = "user-2"), "/test", null)
+        }
+    }
+
+    @Test
+    fun executeCommand_genericCommandDispatchesOnlyWhileIdle() = runTest {
+        val commandResponse = CompletableDeferred<MessageWrapperDto>()
+        coEvery { api.executeCommand("session-1", any(), "/test", null) } coAnswers {
+            commandResponse.await()
+        }
+        val vm = createViewModel()
+
+        assertTrue(vm.executeCommand("custom", "first"))
+        assertFalse(vm.executeCommand("custom", "while sending"))
+        assertEquals(
+            "Wait for the current run to finish or stop it first.",
+            vm.uiState.value.error,
+        )
+        runCurrent()
+        assertTrue(vm.uiState.value.isSending)
+        coVerify(exactly = 1) { api.executeCommand("session-1", any(), "/test", null) }
+
+        commandResponse.complete(assistantMessageDto("command-response", createdAt = 10))
+        runCurrent()
+        assertTrue(vm.uiState.value.isBusy)
+
+        assertFalse(vm.executeCommand("custom", "while busy"))
+        runCurrent()
+        coVerify(exactly = 1) { api.executeCommand("session-1", any(), "/test", null) }
+
+        emitEvent(OpenCodeEvent.SessionStatusChanged("session-1", SessionStatus.Idle))
+        advanceUntilIdle()
+    }
+
+    @Test
+    fun executeCommand_paletteFailureLeavesExistingComposerDraftUnchanged() = runTest {
+        coEvery { api.executeCommand("session-1", any(), "/test", null) } throws RuntimeException("boom")
+        val vm = createViewModel()
+        val existingDraft = "keep palette composer draft"
+        vm.updateInput(existingDraft)
+
+        assertTrue(vm.executeCommand("custom", "palette arguments"))
+        advanceUntilIdle()
+
+        assertEquals(existingDraft, vm.uiState.value.inputText)
+        assertFalse(vm.uiState.value.isSending)
+        assertEquals("Could not execute the command. Try again.", vm.uiState.value.error)
+    }
+
+    @Test
+    fun executeCommand_inFlightGenericRetainsOwnerAcrossUnrelatedIdleTodo_andReleasesAfterCompletion() =
+        runTest {
+            val commandResponse = CompletableDeferred<MessageWrapperDto>()
+            coEvery { api.executeCommand("session-1", any(), "/test", null) } coAnswers {
+                commandResponse.await()
+            }
+            val vm = createViewModel()
+            emitEvent(OpenCodeEvent.SessionStatusChanged("session-1", SessionStatus.Idle))
+            runCurrent()
+
+            assertTrue(vm.executeCommand("custom", "first"))
+            runCurrent()
+            assertTrue(vm.uiState.value.isSending)
+
+            emitEvent(
+                OpenCodeEvent.TodoUpdated(
+                    "session-1",
+                    listOf(Todo(id = "t1", content = "step", status = "pending", priority = "medium")),
+                )
+            )
+            runCurrent()
+
+            val refusedInput = "/custom keep this input"
+            vm.updateInput(refusedInput)
+            assertFalse(vm.executeCommand("custom", "second"))
+            assertEquals(refusedInput, vm.uiState.value.inputText)
+            assertTrue(vm.uiState.value.isSending)
+            assertEquals(
+                "Wait for the current run to finish or stop it first.",
+                vm.uiState.value.error,
+            )
+            coVerify(exactly = 1) { api.executeCommand("session-1", any(), "/test", null) }
+
+            commandResponse.complete(assistantMessageDto("command-response", createdAt = 10))
+            runCurrent()
+            assertFalse(vm.uiState.value.isSending)
+            assertTrue(vm.uiState.value.isBusy)
+
+            emitEvent(OpenCodeEvent.SessionStatusChanged("session-1", SessionStatus.Idle))
+            runCurrent()
+            assertFalse(vm.uiState.value.isBusy)
+            assertTrue(vm.executeCommand("custom", "after completion"))
+            runCurrent()
+            coVerify(exactly = 2) { api.executeCommand("session-1", any(), "/test", null) }
+        }
+
+    @Test
+    fun executeCommand_inFlightUndoRetainsOwnerAcrossPriorErrorTodo_andReleasesAfterCompletion() =
+        runTest {
+            val revertResponse = CompletableDeferred<SessionDto>()
+            coEvery { api.getSession("session-1", any(), null) } returns sessionDto(
+                revertMessageId = "user-2",
+            )
+            coEvery { api.getMessages("session-1", any(), null, any(), null) } returns listOf(
+                userMessageDto("user-1", createdAt = 1),
+                assistantMessageDto("assistant-1", createdAt = 2),
+                userMessageDto("user-2", createdAt = 3),
+            )
+            coEvery { api.revertSession(any(), any(), any(), null) } coAnswers {
+                revertResponse.await()
+            }
+            val vm = createViewModel()
+            emitEvent(
+                OpenCodeEvent.SessionError(
+                    "session-1",
+                    MessageError(name = "APIError", message = "prior failure"),
+                )
+            )
+            runCurrent()
+            assertEquals("The run failed. Try again.", vm.uiState.value.error)
+
+            assertTrue(vm.executeCommand("undo", ""))
+            runCurrent()
+            assertTrue(vm.uiState.value.isSending)
+
+            emitEvent(
+                OpenCodeEvent.TodoUpdated(
+                    "session-1",
+                    listOf(Todo(id = "t1", content = "step", status = "pending", priority = "medium")),
+                )
+            )
+            runCurrent()
+
+            val refusedInput = "/redo keep this input"
+            vm.updateInput(refusedInput)
+            assertFalse(vm.executeCommand("redo", ""))
+            assertEquals(refusedInput, vm.uiState.value.inputText)
+            assertTrue(vm.uiState.value.isSending)
+            assertEquals(
+                "Wait for the current run to finish or stop it first.",
+                vm.uiState.value.error,
+            )
+            coVerify(exactly = 1) {
+                api.revertSession("session-1", RevertSessionRequest(messageID = "user-1"), "/test", null)
+            }
+            coVerify(exactly = 0) { api.executeCommand(any(), any(), any(), null) }
+
+            revertResponse.complete(sessionDto(revertMessageId = "user-1"))
+            runCurrent()
+            assertFalse(vm.uiState.value.isSending)
+        }
+
+    @Test
+    fun executeCommand_undoWithoutBoundaryReleasesOwnerForNextIdleCommand() = runTest {
+        coEvery { api.getMessages("session-1", any(), null, any(), null) } returns emptyList()
+        coEvery { api.executeCommand("session-1", any(), "/test", null) } returns assistantMessageDto(
+            "command-response",
+            createdAt = 10,
+        )
+        val vm = createViewModel()
+
+        assertFalse(vm.executeCommand("undo", ""))
+        assertFalse(vm.uiState.value.isSending)
+        assertEquals("Nothing to undo", vm.uiState.value.error)
+        coVerify(exactly = 0) { api.revertSession(any(), any(), any(), null) }
+
+        assertTrue(vm.executeCommand("custom", "after no boundary"))
+        runCurrent()
+        coVerify(exactly = 1) { api.executeCommand("session-1", any(), "/test", null) }
+    }
+
+    @Test
+    fun executeCommand_concurrentCallersAcceptAndDispatchExactlyOneCommand() = runTest {
+        val commandResponse = CompletableDeferred<MessageWrapperDto>()
+        coEvery { api.executeCommand("session-1", any(), "/test", null) } coAnswers {
+            commandResponse.await()
+        }
+        val vm = createViewModel()
+        val start = CompletableDeferred<Unit>()
+        val callers = List(32) { attempt ->
+            async(Dispatchers.Default) {
+                start.await()
+                vm.executeCommand("custom", "attempt-$attempt")
+            }
+        }
+
+        start.complete(Unit)
+        val results = callers.map { it.await() }
+        runCurrent()
+
+        assertEquals(1, results.count { it })
+        assertEquals(31, results.count { !it })
+        assertEquals(
+            "Wait for the current run to finish or stop it first.",
+            vm.uiState.value.error,
+        )
+        coVerify(exactly = 1) { api.executeCommand("session-1", any(), "/test", null) }
+
+        commandResponse.complete(assistantMessageDto("command-response", createdAt = 10))
+        runCurrent()
+    }
+
+    @Test
+    fun executeCommand_duplicateInitWhileSendingOrBusy_launchesOnlyOnce() = runTest {
+        val initResponse = CompletableDeferred<Boolean>()
+        coEvery { api.initSession("session-1", any(), "/test", null) } coAnswers {
+            initResponse.await()
+        }
+        val vm = createViewModel()
+        vm.modelAgentManager.selectModel(
+            dev.blazelight.p4oc.data.remote.dto.ModelInput("openai", "gpt-5")
+        )
+        runCurrent()
+
+        vm.executeCommand("init", "")
+        vm.executeCommand("init", "")
+        runCurrent()
+
+        coVerify(exactly = 1) { api.initSession("session-1", any(), "/test", null) }
+        assertTrue(vm.uiState.value.isSending)
+
+        initResponse.complete(true)
+        runCurrent()
+        assertTrue(vm.uiState.value.isBusy)
+
+        vm.executeCommand("init", "")
+        runCurrent()
+        coVerify(exactly = 1) { api.initSession("session-1", any(), "/test", null) }
+
+        emitEvent(OpenCodeEvent.SessionStatusChanged("session-1", SessionStatus.Idle))
+        advanceUntilIdle()
+    }
+
+    @Test
+    fun executeCommand_pendingInitIgnoresUnrelatedTerminalToken() = runTest {
+        val initResponse = CompletableDeferred<Boolean>()
+        coEvery { api.initSession("session-1", any(), "/test", null) } coAnswers {
+            initResponse.await()
+        }
+        val vm = createViewModel()
+        vm.modelAgentManager.selectModel(
+            dev.blazelight.p4oc.data.remote.dto.ModelInput("openai", "gpt-5")
+        )
+        runCurrent()
+
+        vm.executeCommand("init", "")
+        runCurrent()
+
+        emitEvent(OpenCodeEvent.SessionStatusChanged("session-1", SessionStatus.Idle))
+        runCurrent()
+        initResponse.complete(true)
+        runCurrent()
+
+        assertTrue(vm.uiState.value.isBusy)
+        assertNull(vm.uiState.value.error)
+
+        emitEvent(OpenCodeEvent.SessionStatusChanged("session-1", SessionStatus.Idle))
+        advanceUntilIdle()
+        assertFalse(vm.uiState.value.isBusy)
+    }
+
+    @Test
+    fun abortSession_invalidatesPendingSuccessfulInit_beforeBusyOrReconciliation() = runTest {
+        val initResponse = CompletableDeferred<Boolean>()
+        val abortResponse = CompletableDeferred<Response<Unit>>()
+        coEvery { api.initSession("session-1", any(), "/test", null) } coAnswers {
+            withContext(NonCancellable) { initResponse.await() }
+        }
+        coEvery { api.abortSession("session-1", "/test", null) } coAnswers {
+            abortResponse.await()
+        }
+        val vm = createViewModel()
+        vm.modelAgentManager.selectModel(
+            dev.blazelight.p4oc.data.remote.dto.ModelInput("openai", "gpt-5")
+        )
+        runCurrent()
+
+        vm.executeCommand("init", "")
+        runCurrent()
+        assertTrue(vm.uiState.value.isSending)
+
+        vm.abortSession()
+        runCurrent()
+
+        initResponse.complete(true)
+        runCurrent()
+
+        assertFalse(vm.uiState.value.isBusy)
+        assertNull(vm.uiState.value.error)
+        advanceTimeBy(2_000)
+        runCurrent()
+        coVerify(exactly = 0) { api.getSessionStatuses("/test", null) }
+
+        abortResponse.complete(Response.success(Unit))
+        advanceUntilIdle()
+        assertFalse(vm.uiState.value.isSending)
+    }
+
+    @Test
+    fun abortSession_invalidatesPendingFailedInit_beforeError() = runTest {
+        val initResponse = CompletableDeferred<Boolean>()
+        val abortResponse = CompletableDeferred<Response<Unit>>()
+        coEvery { api.initSession("session-1", any(), "/test", null) } coAnswers {
+            withContext(NonCancellable) { initResponse.await() }
+        }
+        coEvery { api.abortSession("session-1", "/test", null) } coAnswers {
+            abortResponse.await()
+        }
+        val vm = createViewModel()
+        vm.modelAgentManager.selectModel(
+            dev.blazelight.p4oc.data.remote.dto.ModelInput("openai", "gpt-5")
+        )
+        runCurrent()
+
+        vm.executeCommand("init", "")
+        runCurrent()
+        vm.abortSession()
+        runCurrent()
+
+        initResponse.complete(false)
+        runCurrent()
+
+        assertFalse(vm.uiState.value.isBusy)
+        assertNull(vm.uiState.value.error)
+        coVerify(exactly = 0) { api.getSessionStatuses("/test", null) }
+
+        abortResponse.complete(Response.success(Unit))
+        advanceUntilIdle()
+        assertFalse(vm.uiState.value.isSending)
+    }
+
+    @Test
+    fun sendMessage_replacementInvalidatesPendingInitCompletion() = runTest {
+        val initResponse = CompletableDeferred<Boolean>()
+        coEvery { api.initSession("session-1", any(), "/test", null) } coAnswers {
+            withContext(NonCancellable) { initResponse.await() }
+        }
+        coEvery { api.sendMessageAsync(any(), any(), any(), null) } returns Unit
+        val vm = createViewModel()
+        vm.modelAgentManager.selectModel(
+            dev.blazelight.p4oc.data.remote.dto.ModelInput("openai", "gpt-5")
+        )
+        runCurrent()
+
+        vm.executeCommand("init", "")
+        runCurrent()
+        vm.updateInput("replacement")
+        vm.sendMessage()
+        runCurrent()
+        assertTrue(vm.uiState.value.isBusy)
+
+        initResponse.complete(false)
+        runCurrent()
+
+        assertTrue(vm.uiState.value.isBusy)
+        assertNull(vm.uiState.value.error)
+
+        emitEvent(OpenCodeEvent.SessionStatusChanged("session-1", SessionStatus.Idle))
+        advanceUntilIdle()
+    }
+
+    @Test
+    fun executeCommand_initReconcilesAssistant_whenTerminalSseIsMissing() = runTest {
+        val existingUser = userMessageDto("user-existing", createdAt = 10)
+        val initAssistant = assistantMessageDto(
+            id = "assistant-init",
+            createdAt = 11,
+            completedAt = 12,
+            parts = listOf(
+                PartDto(
+                    id = "part-init",
+                    sessionID = "session-1",
+                    messageID = "assistant-init",
+                    type = "text",
+                    text = "Initialized",
+                )
+            ),
+        )
+        coEvery { api.getMessages("session-1", 100, null, "/test", null) } returnsMany listOf(
+            listOf(existingUser),
+            listOf(existingUser, initAssistant),
+        )
+        coEvery { api.getSessionStatuses("/test", null) } returns mapOf(
+            "session-1" to SessionStatusDto(type = "idle")
+        )
+        coEvery { api.initSession("session-1", any(), "/test", null) } returns true
+        val vm = createViewModel()
+        vm.modelAgentManager.selectModel(
+            dev.blazelight.p4oc.data.remote.dto.ModelInput("openai", "gpt-5")
+        )
+        runCurrent()
+
+        vm.executeCommand("init", "")
+        advanceUntilIdle()
+
+        assertFalse(vm.uiState.value.isBusy)
+        assertNull(vm.uiState.value.error)
+        assertEquals(
+            listOf("user-existing", "assistant-init"),
+            vm.currentMessages().map { it.message.id },
+        )
+        assertEquals("Initialized", (vm.currentMessages().last().parts.single() as Part.Text).text)
+        coVerify(exactly = 1) { api.getSessionStatuses("/test", null) }
+        coVerify(exactly = 2) { api.getMessages("session-1", 100, null, "/test", null) }
     }
 
     @Test

--- a/app/src/test/java/dev/blazelight/p4oc/ui/screens/sessions/SessionListViewModelTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/ui/screens/sessions/SessionListViewModelTest.kt
@@ -1,6 +1,7 @@
 package dev.blazelight.p4oc.ui.screens.sessions
 
 import androidx.lifecycle.SavedStateHandle
+import dev.blazelight.p4oc.data.remote.dto.ForkSessionRequest
 import dev.blazelight.p4oc.data.remote.mapper.MessageMapper
 import dev.blazelight.p4oc.data.session.SessionRepositoryImpl
 import dev.blazelight.p4oc.fakes.FakeWorkspaceClient
@@ -48,6 +49,58 @@ class SessionListViewModelTest {
         advanceUntilIdle()
 
         assertNull(viewModel.uiState.value.error)
+        repository.close()
+    }
+
+    @Test
+    fun forkSession_usesUnboundedRequestAndNavigatesToReturnedSession() = runTest(dispatcher) {
+        val returned = FakeWorkspaceClient.sessionDto(
+            id = "forked-session",
+            directory = "/returned/worktree",
+            parentID = "source-session",
+        )
+        val client = FakeWorkspaceClient().apply {
+            setSessions(FakeWorkspaceClient.sessionDto("source-session", directory = "/source/worktree"))
+            forkSessionResult = returned
+        }
+        val repository = repository(client)
+        val viewModel = SessionListViewModel(repository)
+        advanceUntilIdle()
+
+        viewModel.forkSession("source-session")
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf(
+                FakeWorkspaceClient.ForkSessionCall(
+                    sourceSessionId = "source-session",
+                    request = ForkSessionRequest(messageID = null),
+                ),
+            ),
+            client.forkSessionCallsLog,
+        )
+        assertTrue(viewModel.uiState.value.sessions.any { it.session.id == "forked-session" })
+        assertEquals("forked-session", viewModel.uiState.value.newSessionId)
+        assertEquals("/returned/worktree", viewModel.uiState.value.newSessionDirectory)
+        assertFalse("source-session" in viewModel.uiState.value.forkingSessionIds)
+        repository.close()
+    }
+
+    @Test
+    fun forkSession_failureShowsReadableErrorAndClearsRowBusyState() = runTest(dispatcher) {
+        val client = FakeWorkspaceClient().apply {
+            setSessions(FakeWorkspaceClient.sessionDto("source-session"))
+            forkSessionFailure = IllegalStateException("raw server failure")
+        }
+        val repository = repository(client)
+        val viewModel = SessionListViewModel(repository)
+        advanceUntilIdle()
+
+        viewModel.forkSession("source-session")
+        advanceUntilIdle()
+
+        assertEquals("Could not fork the session. Try again.", viewModel.uiState.value.error)
+        assertFalse("source-session" in viewModel.uiState.value.forkingSessionIds)
         repository.close()
     }
 

--- a/app/src/test/java/dev/blazelight/p4oc/ui/tabs/PendingSessionForkStepTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/ui/tabs/PendingSessionForkStepTest.kt
@@ -1,0 +1,122 @@
+package dev.blazelight.p4oc.ui.tabs
+
+import dev.blazelight.p4oc.core.network.ConnectionState
+import dev.blazelight.p4oc.core.network.OpenCodeApi
+import dev.blazelight.p4oc.data.remote.dto.ForkSessionRequest
+import dev.blazelight.p4oc.data.server.ActiveServerApiProvider
+import dev.blazelight.p4oc.data.workspace.WorkspaceClient
+import dev.blazelight.p4oc.domain.server.ServerGeneration
+import dev.blazelight.p4oc.domain.server.ServerRef
+import dev.blazelight.p4oc.domain.workspace.Workspace
+import dev.blazelight.p4oc.fakes.FakeWorkspaceClient
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PendingSessionForkStepTest {
+    @Test
+    fun `enqueue accepts first request and rejects distinct second without overwriting`() {
+        val first = PendingSessionFork(
+            sourceSessionId = "first-session",
+            directory = "/project",
+        )
+        val second = PendingSessionFork(
+            sourceSessionId = "second-session",
+            directory = "/other-project",
+        )
+
+        val accepted = decidePendingSessionForkEnqueue(current = null, requested = first)
+        val rejected = decidePendingSessionForkEnqueue(current = accepted.pending, requested = second)
+
+        assertTrue(accepted.accepted)
+        assertSame(first, accepted.pending)
+        assertFalse(rejected.accepted)
+        assertSame(first, rejected.pending)
+    }
+
+    @Test
+    fun `same-directory fork executes and is consumed exactly once`() {
+        val pending = PendingSessionFork(
+            sourceSessionId = "source-session",
+            directory = "/project",
+        )
+
+        val ready = pendingSessionForkStep(pending, currentDirectory = "/project")
+        val consumed = pendingSessionForkStep(ready.remaining, currentDirectory = "/project")
+
+        assertEquals("source-session", ready.sourceSessionIdToFork)
+        assertNull(ready.remaining)
+        assertNull(consumed.sourceSessionIdToFork)
+        assertNull(consumed.remaining)
+    }
+
+    @Test
+    fun `rejected second fork cannot execute before first cutover and first executes scoped once`() = runTest {
+        val first = PendingSessionFork(
+            sourceSessionId = "first-session",
+            directory = "/project",
+        )
+        val second = PendingSessionFork(
+            sourceSessionId = "second-session",
+            directory = "/other-project",
+        )
+        val accepted = decidePendingSessionForkEnqueue(current = null, requested = first)
+        val rejected = decidePendingSessionForkEnqueue(current = accepted.pending, requested = second)
+        val request = ForkSessionRequest(messageID = null)
+        val api = mockk<OpenCodeApi>()
+        coEvery {
+            api.forkSession("first-session", request, "/project", null)
+        } returns FakeWorkspaceClient.sessionDto(
+            id = "forked-session",
+            directory = "/project",
+            parentID = "first-session",
+        )
+
+        val beforeCutover = pendingSessionForkStep(
+            pending = rejected.pending,
+            currentDirectory = "/other-project",
+        )
+        assertFalse(rejected.accepted)
+        assertNull(beforeCutover.sourceSessionIdToFork)
+        assertSame(first, beforeCutover.remaining)
+        coVerify(exactly = 0) { api.forkSession(any(), any(), any(), any()) }
+
+        val server = ServerRef.fromEndpointKey("http://test.local")
+        val projectClient = WorkspaceClient(
+            workspace = Workspace(server, directory = "/project"),
+            generation = ServerGeneration(1L),
+            apiProvider = ActiveServerApiProvider { _, _ -> api },
+            connectionState = MutableStateFlow(ConnectionState.Connected),
+        )
+        val afterCutover = pendingSessionForkStep(beforeCutover.remaining, currentDirectory = "/project")
+        afterCutover.sourceSessionIdToFork?.let { sourceSessionId ->
+            projectClient.forkSession(sourceSessionId, request)
+        }
+        val consumed = pendingSessionForkStep(afterCutover.remaining, currentDirectory = "/project")
+        consumed.sourceSessionIdToFork?.let { sourceSessionId ->
+            projectClient.forkSession(sourceSessionId, request)
+        }
+
+        assertEquals("first-session", afterCutover.sourceSessionIdToFork)
+        assertNull(afterCutover.remaining)
+        assertNull(consumed.sourceSessionIdToFork)
+        assertNull(consumed.remaining)
+        coVerify(exactly = 1) {
+            api.forkSession("first-session", request, "/project", null)
+        }
+        coVerify(exactly = 0) {
+            api.forkSession("first-session", request, null, null)
+        }
+        coVerify(exactly = 0) {
+            api.forkSession("second-session", any(), any(), any())
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- render complete assistant token usage and cost, including reasoning/cache-only usage and tiny positive costs
- route `/init` through the dedicated session initialization endpoint with lifecycle ownership and reconciliation
- add session fork actions with workspace-scoped handoff into the returned chat
- prioritize live server command metadata while retaining local-only fallbacks
- preserve composer drafts and refuse duplicate commands without clearing user input

## Verification

- `./gradlew :app:testDebugUnitTest :app:detekt :app:compileDebugAndroidTestKotlin :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=dev.blazelight.p4oc.ui.components.chat.ChatInputBarSubmissionTest`
- physical Samsung SM-A155F (`R58X70XHB9P`): 3/3 composer submission/restoration tests passed
- focused token rendering suite previously passed 6/6 on the same device
- final Sol review: SHIP, no correctness blockers

Closes #49
Closes #48