### PR TITLE
Bind OFISH capability parsing to shell output

### DIFF
--- a/app/src/main/java/dev/blazelight/p4oc/data/files/ofish/OfishCapabilityParser.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/data/files/ofish/OfishCapabilityParser.kt
@@ -2,6 +2,7 @@ package dev.blazelight.p4oc.data.files.ofish
 
 internal object OfishCapabilityParser {
     private val KEY_VALUE = Regex("(\\w+)=([^\\n]+?)(?=\\s+\\w+=|$)")
+    private val STATUS_LINE = Regex("^### \\d{3}(?:\\s.*)?$")
 
     fun parse(output: String): OfishProbeResult {
         val lines = output.lineSequence().map { it.trim() }.filter { it.isNotEmpty() }.toList()
@@ -9,13 +10,14 @@ internal object OfishCapabilityParser {
         if (capsLineIndex == -1) {
             return OfishProbeResult.Failed("Malformed OFISH capability probe output: missing caps line")
         }
-        val statusLineIndex = lines.indexOfLast { it.startsWith("### ") }
-        if (statusLineIndex == -1) {
+        val statusLineIndices = lines.indices.filter { STATUS_LINE.matches(lines[it]) }
+        if (statusLineIndices.isEmpty()) {
             return OfishProbeResult.Failed("Malformed OFISH capability probe output: missing status line")
         }
-        if (statusLineIndex < capsLineIndex) {
-            return OfishProbeResult.Failed("Malformed OFISH capability probe output: status line before caps line")
-        }
+        val statusLineIndex = statusLineIndices.firstOrNull { it > capsLineIndex }
+            ?: return OfishProbeResult.Failed(
+                "Malformed OFISH capability probe output: status line before caps line",
+            )
         val capsLine = lines[capsLineIndex]
         val statusLine = lines[statusLineIndex]
 

--- a/app/src/main/java/dev/blazelight/p4oc/data/files/ofish/OfishCapabilityProbe.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/data/files/ofish/OfishCapabilityProbe.kt
@@ -3,6 +3,8 @@ package dev.blazelight.p4oc.data.files.ofish
 import dev.blazelight.p4oc.data.remote.dto.MessageWrapperDto
 import dev.blazelight.p4oc.data.remote.dto.ShellCommandRequest
 
+private const val CAPABILITY_MARKER = "#OFISH_HELLO"
+
 /**
  * Executes the OFISH shell-environment capability probe in an ephemeral session.
  *
@@ -26,7 +28,11 @@ internal class OfishCapabilityProbe(
                     command = OfishCapabilityProbeCommand.build(),
                 ),
             )
-            OfishCapabilityParser.parse(OfishShellOutputExtractor.extract(response))
+            val output = OfishShellOutputExtractor.extractCapabilitySegment(response)
+                ?: return@withSession OfishProbeResult.Failed(
+                    "Malformed OFISH capability probe output: missing $CAPABILITY_MARKER output segment",
+                )
+            OfishCapabilityParser.parse(output)
         }
     }.getOrElse { error ->
         OfishProbeResult.Failed("OFISH capability probe failed", error)
@@ -39,16 +45,13 @@ internal class OfishCapabilityProbe(
 }
 
 internal object OfishShellOutputExtractor {
-    fun extract(message: MessageWrapperDto): String = buildString {
-        message.parts.forEach { part ->
-            part.text?.takeIf { it.isNotBlank() }?.let { appendLine(it) }
-            part.state?.output?.takeIf { it.isNotBlank() }?.let { appendLine(it) }
-            part.state?.raw?.takeIf { it.isNotBlank() }?.let { appendLine(it) }
-            part.state?.error?.takeIf { it.isNotBlank() }?.let { appendLine(it) }
-        }
-    }
+    fun extractCapabilitySegment(message: MessageWrapperDto): String? =
+        extractMarkerSegment(message, CAPABILITY_MARKER)
 
-    fun extractMutationSegment(message: MessageWrapperDto, expectedMarker: String): String? {
+    fun extractMutationSegment(message: MessageWrapperDto, expectedMarker: String): String? =
+        extractMarkerSegment(message, expectedMarker)
+
+    private fun extractMarkerSegment(message: MessageWrapperDto, expectedMarker: String): String? {
         fun String.containsMarker(): Boolean = lineSequence().any { it == expectedMarker }
 
         // Shell tool state is authoritative. Text parts are only a compatibility fallback for

--- a/app/src/test/java/dev/blazelight/p4oc/data/files/ofish/OfishCapabilityParserTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/data/files/ofish/OfishCapabilityParserTest.kt
@@ -1,5 +1,10 @@
 package dev.blazelight.p4oc.data.files.ofish
 
+import dev.blazelight.p4oc.data.remote.dto.MessageInfoDto
+import dev.blazelight.p4oc.data.remote.dto.MessageTimeDto
+import dev.blazelight.p4oc.data.remote.dto.MessageWrapperDto
+import dev.blazelight.p4oc.data.remote.dto.PartDto
+import dev.blazelight.p4oc.data.remote.dto.ToolStateDto
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -50,6 +55,110 @@ class OfishCapabilityParserTest {
     }
 
     @Test
+    fun `structured capability output wins over trailing assistant prose`() {
+        val shellOutput =
+            "#OFISH_HELLO\n" +
+                "caps base64=0 base64_decode= hash= mv=1 mkdir=1 rm=1 awk=0 " +
+                "mktemp=1 chmod=1 mode=stat -c %a\n" +
+                "### 501 caps_missing base64 hash awk"
+        val response = message(
+            PartDto(
+                "fake-text-output",
+                "session",
+                "message",
+                "text",
+                text = "#OFISH_HELLO\ncaps base64=1\n### 599 invented",
+            ),
+            PartDto(
+                "tool",
+                "session",
+                "message",
+                "tool",
+                state = ToolStateDto(status = "completed", output = shellOutput),
+            ),
+            PartDto(
+                "prose",
+                "session",
+                "message",
+                "text",
+                text = "The probe finished.\n### Note\nCapabilities may vary by host.",
+            ),
+        )
+
+        val output = OfishShellOutputExtractor.extractCapabilitySegment(response)
+        assertEquals(shellOutput, output)
+        val result = OfishCapabilityParser.parse(requireNotNull(output))
+        assertTrue(result is OfishProbeResult.Missing)
+        assertEquals(listOf("base64", "hash", "awk"), (result as OfishProbeResult.Missing).missing)
+    }
+
+    @Test
+    fun `capability output falls back to marker-bound assistant text`() {
+        val textOutput =
+            "#OFISH_HELLO\n" +
+                "caps base64=1 base64_decode=-d hash=sha256sum " +
+                "mv=1 mkdir=1 rm=1 awk=1 mktemp=1 chmod=1 mode=stat -c %a\n" +
+                "### 200 ok"
+        val response = message(
+            PartDto(
+                "unrelated-tool",
+                "session",
+                "message",
+                "tool",
+                state = ToolStateDto(status = "completed", output = "unrelated\n### 599 odd"),
+            ),
+            PartDto("text", "session", "message", "text", text = textOutput),
+        )
+
+        val output = OfishShellOutputExtractor.extractCapabilitySegment(response)
+        assertEquals(textOutput, output)
+        assertTrue(OfishCapabilityParser.parse(requireNotNull(output)) is OfishProbeResult.Available)
+    }
+
+    @Test
+    fun `parse ignores markdown heading after valid status`() {
+        val result = OfishCapabilityParser.parse(
+            "caps base64=1 base64_decode=-d hash=sha256sum " +
+                "mv=1 mkdir=1 rm=1 awk=1 mktemp=1 chmod=1 mode=stat -c %a\n" +
+                "### 200 ok\n### Note\nThe probe is complete.",
+        )
+
+        assertTrue(result is OfishProbeResult.Available)
+    }
+
+    @Test
+    fun `parse ignores numeric assistant heading after valid status`() {
+        val result = OfishCapabilityParser.parse(
+            "caps base64=1 base64_decode=-d hash=sha256sum " +
+                "mv=1 mkdir=1 rm=1 awk=1 mktemp=1 chmod=1 mode=stat -c %a\n" +
+                "### 200 ok\nAssistant follow-up:\n### 599 odd\nThis is prose, not shell output.",
+        )
+
+        assertTrue(result is OfishProbeResult.Available)
+    }
+
+    @Test
+    fun `unsupported numeric status and status ordering retain readable failures`() {
+        val caps =
+            "caps base64=1 base64_decode=-d hash=sha256sum " +
+                "mv=1 mkdir=1 rm=1 awk=1 mktemp=1 chmod=1 mode=stat -c %a"
+
+        val unsupported = OfishCapabilityParser.parse("$caps\n### 599 odd\n### 200 ok")
+        assertTrue(unsupported is OfishProbeResult.Failed)
+        assertEquals(
+            "Malformed OFISH capability probe output: unsupported status line",
+            (unsupported as OfishProbeResult.Failed).message,
+        )
+
+        val outOfOrder = OfishCapabilityParser.parse("### 200 ok\n$caps")
+        assertTrue(outOfOrder is OfishProbeResult.Failed)
+        assertEquals(
+            "Malformed OFISH capability probe output: status line before caps line",
+            (outOfOrder as OfishProbeResult.Failed).message,
+        )
+    }
+
+    @Test
     fun `malformed output fails`() {
         assertTrue(OfishCapabilityParser.parse("### 200 ok") is OfishProbeResult.Failed)
         assertTrue(OfishCapabilityParser.parse("caps base64=1") is OfishProbeResult.Failed)
@@ -60,4 +169,14 @@ class OfishCapabilityParserTest {
             ) is OfishProbeResult.Failed,
         )
     }
+
+    private fun message(vararg parts: PartDto) = MessageWrapperDto(
+        info = MessageInfoDto(
+            id = "message",
+            sessionID = "session",
+            time = MessageTimeDto(created = 0),
+            role = "assistant",
+        ),
+        parts = parts.toList(),
+    )
 }


### PR DESCRIPTION
## Summary

- parse one `#OFISH_HELLO`-bound tool-state segment instead of concatenating unrelated assistant parts
- retain marker-bound assistant text as a compatibility fallback
- accept only numeric OFISH status trailers and bind parsing to the first trailer after `caps`
- prevent trailing Markdown or numeric headings from shadowing a valid shell result

## Verification

- `./gradlew :app:testDebugUnitTest :app:lintDebug :app:detekt :app:assembleDebug`
- `OfishCapabilityParserTest`: 9 tests, 0 failures/errors
- final Sol review: SHIP, no correctness blockers

Closes #40