### PR TITLE
Honor auto-reconnect when choosing servers

### DIFF
--- a/app/src/main/java/dev/blazelight/p4oc/ui/screens/server/ServerViewModel.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/screens/server/ServerViewModel.kt
@@ -22,6 +22,7 @@ import dev.blazelight.p4oc.domain.server.ServerIdentity
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import java.security.cert.CertPathValidatorException
@@ -95,7 +96,13 @@ class ServerViewModel constructor(
         loadRecentServers()
         loadSavedServers()
         collectDiscoveryFlows()
-        if (autoReconnect) tryAutoReconnect()
+        if (autoReconnect) {
+            viewModelScope.launch {
+                if (settingsDataStore.connectionSettings.first().autoReconnect) {
+                    tryAutoReconnect()
+                }
+            }
+        }
     }
 
     private fun loadRecentServers() {
@@ -114,58 +121,56 @@ class ServerViewModel constructor(
         }
     }
 
-    private fun tryAutoReconnect() {
-        viewModelScope.launch {
-            val (lastConfig, password) = settingsDataStore.getLastConnection() ?: return@launch
+    private suspend fun tryAutoReconnect() {
+        val (lastConfig, password) = settingsDataStore.getLastConnection() ?: return
 
-            AppLog.d(TAG, "Found last connection")
-            val endpointKey = ServerUrl.endpointKey(lastConfig.url)
-            _uiState.update {
-                it.copy(
-                    isConnecting = true,
-                    connectingEndpointKey = endpointKey,
-                    remoteUrl = lastConfig.url,
-                    username = lastConfig.username ?: ServerUrl.DEFAULT_USERNAME,
-                    password = password ?: "",
-                    allowInsecure = lastConfig.allowInsecure
-                )
-            }
-
-            val server = SavedServerRegistry.fromConnection(
-                url = lastConfig.url,
-                name = lastConfig.name,
-                username = lastConfig.username,
-                allowInsecure = lastConfig.allowInsecure,
-            )
-            val result = serverConnectionRegistry.connectAndAwait(server, password)
-
-            result.fold(
-                onSuccess = { projects ->
-                    AppLog.d(TAG, "Auto-reconnect successful")
-                    initializeProjectContext()
-                    _uiState.update {
-                        it.copy(
-                            isConnecting = false,
-                            isConnected = true,
-                            connectingEndpointKey = null,
-                            connectedEndpointKey = endpointKey,
-                            failedEndpointKey = null,
-                        )
-                    }
-                },
-                onFailure = { error ->
-                    AppLog.w(TAG, "Auto-reconnect failed")
-                    _uiState.update {
-                        it.copy(
-                            isConnecting = false,
-                            connectingEndpointKey = null,
-                            failedEndpointKey = endpointKey,
-                            error = "Could not reconnect to the server. Check the address and connection."
-                        )
-                    }
-                }
+        AppLog.d(TAG, "Found last connection")
+        val endpointKey = ServerUrl.endpointKey(lastConfig.url)
+        _uiState.update {
+            it.copy(
+                isConnecting = true,
+                connectingEndpointKey = endpointKey,
+                remoteUrl = lastConfig.url,
+                username = lastConfig.username ?: ServerUrl.DEFAULT_USERNAME,
+                password = password ?: "",
+                allowInsecure = lastConfig.allowInsecure
             )
         }
+
+        val server = SavedServerRegistry.fromConnection(
+            url = lastConfig.url,
+            name = lastConfig.name,
+            username = lastConfig.username,
+            allowInsecure = lastConfig.allowInsecure,
+        )
+        val result = serverConnectionRegistry.connectAndAwait(server, password)
+
+        result.fold(
+            onSuccess = { projects ->
+                AppLog.d(TAG, "Auto-reconnect successful")
+                initializeProjectContext()
+                _uiState.update {
+                    it.copy(
+                        isConnecting = false,
+                        isConnected = true,
+                        connectingEndpointKey = null,
+                        connectedEndpointKey = endpointKey,
+                        failedEndpointKey = null,
+                    )
+                }
+            },
+            onFailure = { error ->
+                AppLog.w(TAG, "Auto-reconnect failed")
+                _uiState.update {
+                    it.copy(
+                        isConnecting = false,
+                        connectingEndpointKey = null,
+                        failedEndpointKey = endpointKey,
+                        error = "Could not reconnect to the server. Check the address and connection."
+                    )
+                }
+            }
+        )
     }
 
     fun setRemoteUrl(url: String) {

--- a/app/src/test/java/dev/blazelight/p4oc/ui/screens/server/ServerViewModelIssue37Test.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/ui/screens/server/ServerViewModelIssue37Test.kt
@@ -1,0 +1,170 @@
+@file:Suppress("ImportOrdering")
+
+package dev.blazelight.p4oc.ui.screens.server
+
+import dev.blazelight.p4oc.core.datastore.ConnectionSettings
+import dev.blazelight.p4oc.core.datastore.RecentServer
+import dev.blazelight.p4oc.core.datastore.SavedServer
+import dev.blazelight.p4oc.core.datastore.SettingsDataStore
+import dev.blazelight.p4oc.core.network.DiscoveryState
+import dev.blazelight.p4oc.core.network.MdnsDiscoveryManager
+import dev.blazelight.p4oc.core.network.ServerConfig
+import dev.blazelight.p4oc.core.network.ServerConnectionRegistry
+import dev.blazelight.p4oc.core.security.CredentialStore
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.match
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ServerViewModelIssue37Test {
+    private val dispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `allowed reconnect respects stored false and still loads server inventory`() = runTest(dispatcher) {
+        val recentServers = listOf(
+            RecentServer(
+                url = "http://recent.local:4096",
+                name = "Recent server",
+            )
+        )
+        val savedServers = listOf(savedServer())
+        val settingsDataStore = mockk<SettingsDataStore>()
+        val connectionRegistry = mockk<ServerConnectionRegistry>()
+        val discoveryManager = discoveryManager()
+        every { settingsDataStore.recentServers } returns flowOf(recentServers)
+        every { settingsDataStore.savedServers } returns flowOf(savedServers)
+        every { settingsDataStore.connectionSettings } returns flowOf(
+            ConnectionSettings(autoReconnect = false)
+        )
+        val viewModel = viewModel(settingsDataStore, connectionRegistry, discoveryManager)
+
+        viewModel.start(autoReconnect = true)
+        advanceUntilIdle()
+
+        assertEquals(recentServers, viewModel.uiState.value.recentServers)
+        assertEquals(savedServers, viewModel.uiState.value.savedServers)
+        assertFalse(viewModel.uiState.value.isConnecting)
+        assertFalse(viewModel.uiState.value.isConnected)
+        assertNull(viewModel.uiState.value.connectingEndpointKey)
+        verify(exactly = 1) { settingsDataStore.connectionSettings }
+        coVerify(exactly = 0) { settingsDataStore.getLastConnection() }
+        coVerify(exactly = 0) { connectionRegistry.connectAndAwait(any(), any()) }
+    }
+
+    @Test
+    fun `hard-disabled reconnect wins over stored true and start stays one-shot`() = runTest(dispatcher) {
+        val settingsDataStore = mockk<SettingsDataStore>()
+        val connectionRegistry = mockk<ServerConnectionRegistry>()
+        val discoveryManager = discoveryManager()
+        every { settingsDataStore.recentServers } returns flowOf(emptyList())
+        every { settingsDataStore.savedServers } returns flowOf(listOf(savedServer()))
+        every { settingsDataStore.connectionSettings } returns flowOf(
+            ConnectionSettings(autoReconnect = true)
+        )
+        val viewModel = viewModel(settingsDataStore, connectionRegistry, discoveryManager)
+
+        viewModel.start(autoReconnect = false)
+        viewModel.start(autoReconnect = true)
+        advanceUntilIdle()
+
+        assertEquals(listOf(savedServer()), viewModel.uiState.value.savedServers)
+        assertFalse(viewModel.uiState.value.isConnecting)
+        assertFalse(viewModel.uiState.value.isConnected)
+        verify(exactly = 0) { settingsDataStore.connectionSettings }
+        coVerify(exactly = 0) { settingsDataStore.getLastConnection() }
+        coVerify(exactly = 0) { connectionRegistry.connectAndAwait(any(), any()) }
+    }
+
+    @Test
+    fun `allowed reconnect with stored true reconnects the last server`() = runTest(dispatcher) {
+        val settingsDataStore = mockk<SettingsDataStore>()
+        val connectionRegistry = mockk<ServerConnectionRegistry>()
+        val discoveryManager = discoveryManager()
+        val config = ServerConfig(
+            url = "http://saved.local:4096",
+            name = "Saved server",
+            username = "opencode",
+        )
+        every { settingsDataStore.recentServers } returns flowOf(emptyList())
+        every { settingsDataStore.savedServers } returns flowOf(listOf(savedServer()))
+        every { settingsDataStore.connectionSettings } returns flowOf(
+            ConnectionSettings(autoReconnect = true)
+        )
+        coEvery { settingsDataStore.getLastConnection() } returns (config to "secret")
+        coEvery { connectionRegistry.connectAndAwait(any(), any()) } returns Result.success(emptyList())
+        val viewModel = viewModel(settingsDataStore, connectionRegistry, discoveryManager)
+
+        viewModel.start(autoReconnect = true)
+        advanceUntilIdle()
+
+        verify(exactly = 1) { settingsDataStore.connectionSettings }
+        coVerify(exactly = 1) { settingsDataStore.getLastConnection() }
+        coVerify(exactly = 1) {
+            connectionRegistry.connectAndAwait(
+                match {
+                    it.endpoint == config.url &&
+                        it.displayName == config.name &&
+                        it.username == config.username
+                },
+                "secret",
+            )
+        }
+        assertFalse(viewModel.uiState.value.isConnecting)
+        assertTrue(viewModel.uiState.value.isConnected)
+        assertEquals("http://saved.local:4096", viewModel.uiState.value.connectedEndpointKey)
+        assertEquals(NavigationDestination.Sessions, viewModel.uiState.value.navigationDestination)
+    }
+
+    private fun viewModel(
+        settingsDataStore: SettingsDataStore,
+        connectionRegistry: ServerConnectionRegistry,
+        discoveryManager: MdnsDiscoveryManager,
+    ) = ServerViewModel(
+        settingsDataStore = settingsDataStore,
+        serverConnectionRegistry = connectionRegistry,
+        credentialStore = mockk<CredentialStore>(),
+        mdnsDiscoveryManager = discoveryManager,
+    )
+
+    private fun discoveryManager() = mockk<MdnsDiscoveryManager> {
+        every { discoveredServers } returns MutableStateFlow(emptyList())
+        every { discoveryState } returns MutableStateFlow(DiscoveryState.IDLE)
+    }
+
+    private fun savedServer() = SavedServer(
+        id = "http://saved.local:4096",
+        endpoint = "http://saved.local:4096",
+        endpointKey = "http://saved.local:4096",
+        displayName = "Saved server",
+        username = "opencode",
+    )
+}

--- a/app/src/test/java/dev/blazelight/p4oc/ui/screens/server/ServerViewModelIssue37Test.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/ui/screens/server/ServerViewModelIssue37Test.kt
@@ -14,8 +14,8 @@ import dev.blazelight.p4oc.core.security.CredentialStore
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
-import io.mockk.match
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -109,6 +109,7 @@ class ServerViewModelIssue37Test {
         val settingsDataStore = mockk<SettingsDataStore>()
         val connectionRegistry = mockk<ServerConnectionRegistry>()
         val discoveryManager = discoveryManager()
+        val connectedServer = slot<SavedServer>()
         val config = ServerConfig(
             url = "http://saved.local:4096",
             name = "Saved server",
@@ -129,15 +130,11 @@ class ServerViewModelIssue37Test {
         verify(exactly = 1) { settingsDataStore.connectionSettings }
         coVerify(exactly = 1) { settingsDataStore.getLastConnection() }
         coVerify(exactly = 1) {
-            connectionRegistry.connectAndAwait(
-                match {
-                    it.endpoint == config.url &&
-                        it.displayName == config.name &&
-                        it.username == config.username
-                },
-                "secret",
-            )
+            connectionRegistry.connectAndAwait(capture(connectedServer), "secret")
         }
+        assertEquals(config.url, connectedServer.captured.endpoint)
+        assertEquals(config.name, connectedServer.captured.displayName)
+        assertEquals(config.username, connectedServer.captured.username)
         assertFalse(viewModel.uiState.value.isConnecting)
         assertTrue(viewModel.uiState.value.isConnected)
         assertEquals("http://saved.local:4096", viewModel.uiState.value.connectedEndpointKey)

--- a/app/src/test/java/dev/blazelight/p4oc/ui/screens/server/ServerViewModelIssue37Test.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/ui/screens/server/ServerViewModelIssue37Test.kt
@@ -19,6 +19,7 @@ import io.mockk.slot
 import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -60,19 +61,25 @@ class ServerViewModelIssue37Test {
         val settingsDataStore = mockk<SettingsDataStore>()
         val connectionRegistry = mockk<ServerConnectionRegistry>()
         val discoveryManager = discoveryManager()
+        val connectionSettings = MutableSharedFlow<ConnectionSettings>()
         every { settingsDataStore.recentServers } returns flowOf(recentServers)
         every { settingsDataStore.savedServers } returns flowOf(savedServers)
-        every { settingsDataStore.connectionSettings } returns flowOf(
-            ConnectionSettings(autoReconnect = false)
-        )
+        every { settingsDataStore.connectionSettings } returns connectionSettings
         val viewModel = viewModel(settingsDataStore, connectionRegistry, discoveryManager)
 
         viewModel.start(autoReconnect = true)
         advanceUntilIdle()
 
+        // Inventory collectors are independent from the still-suspended reconnect setting read.
         assertEquals(recentServers, viewModel.uiState.value.recentServers)
         assertEquals(savedServers, viewModel.uiState.value.savedServers)
         assertFalse(viewModel.uiState.value.isConnecting)
+        coVerify(exactly = 0) { settingsDataStore.getLastConnection() }
+        coVerify(exactly = 0) { connectionRegistry.connectAndAwait(any(), any()) }
+
+        connectionSettings.emit(ConnectionSettings(autoReconnect = false))
+        advanceUntilIdle()
+
         assertFalse(viewModel.uiState.value.isConnected)
         assertNull(viewModel.uiState.value.connectingEndpointKey)
         verify(exactly = 1) { settingsDataStore.connectionSettings }


### PR DESCRIPTION
## Summary

- gate launch-time reconnect on the persisted Auto-reconnect setting
- preserve the Server Management screen's hard disable
- continue loading selectable saved/recent server inventory while reconnect is disabled
- retain existing enabled reconnect and one-shot startup behavior

## Verification

- `./gradlew :app:testDebugUnitTest :app:lintDebug :app:detekt :app:assembleDebug`
- `ServerViewModelIssue37Test`: 3 tests, 0 failures/errors
- final Sol review: SHIP, no correctness blockers

Closes #37