### PR TITLE
fix: discard unbounded message summaries

### DIFF
--- a/app/src/main/java/dev/blazelight/p4oc/data/remote/dto/MessageDtos.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/data/remote/dto/MessageDtos.kt
@@ -2,7 +2,6 @@ package dev.blazelight.p4oc.data.remote.dto
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 
 // ============================================================================
@@ -30,7 +29,6 @@ data class MessageInfoDto(
     val tokens: TokenUsageDto? = null,
     val error: MessageErrorDto? = null,
     val path: MessagePathDto? = null,
-    val summary: JsonElement? = null,
     val finish: String? = null,
     val mode: String? = null,
     val system: String? = null,
@@ -92,11 +90,4 @@ data class ApiErrorDataDto(
     val isRetryable: Boolean = false,
     val responseHeaders: Map<String, String>? = null,
     val responseBody: String? = null
-)
-
-@Serializable
-data class MessageSummaryDto(
-    val title: String? = null,
-    val body: String? = null,
-    val diffs: List<FileDiffDto> = emptyList()
 )

--- a/app/src/main/java/dev/blazelight/p4oc/data/remote/mapper/Mappers.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/data/remote/mapper/Mappers.kt
@@ -5,7 +5,6 @@ import dev.blazelight.p4oc.data.remote.dto.*
 import dev.blazelight.p4oc.domain.model.*
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
@@ -100,9 +99,7 @@ private fun JsonObject.intValue(key: String): Int? = (this[key] as? JsonPrimitiv
 private fun JsonObject.booleanValue(key: String): Boolean =
     (this[key] as? JsonPrimitive)?.contentOrNull?.toBooleanStrictOrNull() ?: false
 
-class MessageMapper constructor(
-    private val json: Json
-) {
+class MessageMapper {
     fun mapToDomain(dto: MessageInfoDto): Message = when (dto.role) {
         "user" -> Message.User(
             id = dto.id,
@@ -111,7 +108,7 @@ class MessageMapper constructor(
             agent = dto.agent ?: "",
             model = dto.model?.let { ModelRef(it.providerID, it.modelID) }
                 ?: ModelRef("", ""),
-            summary = mapMessageSummaryToDomain(dto.summary),
+            summary = null,
             system = dto.system,
             tools = dto.tools?.let { jsonObj ->
                 jsonObj.mapValues { (_, v) -> v.toString().toBooleanStrictOrNull() ?: false }
@@ -132,7 +129,7 @@ class MessageMapper constructor(
             path = dto.path?.let { MessagePath(it.cwd ?: "", it.root ?: "") },
             error = dto.error?.let { mapMessageErrorToDomain(it) },
             finish = dto.finish,
-            summary = dto.summary?.toString()?.toBooleanStrictOrNull()
+            summary = null
         )
     }
 
@@ -172,29 +169,6 @@ class MessageMapper constructor(
             isRetryable = data.booleanValue("isRetryable"),
             responseBody = data.stringValue("responseBody")
         )
-    }
-
-    private fun mapMessageSummaryToDomain(summary: JsonElement?): MessageSummary? {
-        if (summary == null) return null
-        return try {
-            val obj = summary as? JsonObject ?: return null
-            val summaryDto = json.decodeFromJsonElement<MessageSummaryDto>(obj)
-            MessageSummary(
-                title = summaryDto.title,
-                body = summaryDto.body,
-                diffs = summaryDto.diffs.map { dto ->
-                    FileDiff(
-                        file = dto.file,
-                        before = dto.before,
-                        after = dto.after,
-                        additions = dto.additions,
-                        deletions = dto.deletions
-                    )
-                }
-            )
-        } catch (e: Exception) {
-            null
-        }
     }
 }
 

--- a/app/src/main/java/dev/blazelight/p4oc/di/KoinModules.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/di/KoinModules.kt
@@ -71,8 +71,8 @@ val appModule = module {
 }
 
 val networkModule = module {
-    // Mappers (stateless mappers are objects — only DI-dependent ones registered here)
-    single { MessageMapper(get()) }
+    // Mappers
+    single { MessageMapper() }
     single { EventMapper(get(), get()) }
 
     // Network

--- a/app/src/test/java/dev/blazelight/p4oc/core/network/ConnectionManagerFallbackTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/core/network/ConnectionManagerFallbackTest.kt
@@ -29,7 +29,7 @@ class ConnectionManagerFallbackTest {
         Dispatchers.setMain(dispatcher)
         manager = ConnectionManager(
             json = json,
-            eventMapper = EventMapper(json, MessageMapper(json)),
+            eventMapper = EventMapper(json, MessageMapper()),
             settingsDataStore = mockk<SettingsDataStore>(),
         )
     }

--- a/app/src/test/java/dev/blazelight/p4oc/core/network/ConnectionManagerLoggingTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/core/network/ConnectionManagerLoggingTest.kt
@@ -60,7 +60,7 @@ class ConnectionManagerLoggingTest {
         Dispatchers.setMain(dispatcher)
         manager = ConnectionManager(
             json = json,
-            eventMapper = EventMapper(json, MessageMapper(json)),
+            eventMapper = EventMapper(json, MessageMapper()),
             settingsDataStore = mockk<SettingsDataStore>(),
         )
     }

--- a/app/src/test/java/dev/blazelight/p4oc/core/network/OpenCodeEventSourceTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/core/network/OpenCodeEventSourceTest.kt
@@ -55,7 +55,7 @@ class OpenCodeEventSourceTest {
             okHttpClient = OkHttpClient(),
             json = json,
             baseUrl = "http://127.0.0.1:1",
-            eventMapper = EventMapper(json, MessageMapper(json)),
+            eventMapper = EventMapper(json, MessageMapper()),
         )
         val collected = mutableListOf<String>()
         var collector: Job? = null
@@ -171,7 +171,7 @@ class OpenCodeEventSourceTest {
         okHttpClient = OkHttpClient(),
         json = json,
         baseUrl = "http://127.0.0.1:1",
-        eventMapper = EventMapper(json, MessageMapper(json)),
+        eventMapper = EventMapper(json, MessageMapper()),
     )
 
     @Suppress("UNCHECKED_CAST")

--- a/app/src/test/java/dev/blazelight/p4oc/data/remote/dto/UpstreamContractDtoTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/data/remote/dto/UpstreamContractDtoTest.kt
@@ -1,12 +1,79 @@
 package dev.blazelight.p4oc.data.remote.dto
 
+import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class UpstreamContractDtoTest {
     private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun `message decoding discards multi-megabyte object summary`() {
+        val patchMarker = "summary-patch-must-not-be-retained"
+        val patch = patchMarker + "x".repeat(3 * 1024 * 1024)
+        val payload =
+            """
+            {
+              "info": {
+                "id": "msg-user",
+                "sessionID": "ses-1",
+                "time": { "created": 1 },
+                "role": "user",
+                "summary": {
+                  "title": "large diff",
+                  "diffs": [
+                    {
+                      "file": "src/Main.kt",
+                      "patch": "$patch",
+                      "additions": 1,
+                      "deletions": 0
+                    }
+                  ]
+                }
+              },
+              "parts": []
+            }
+            """.trimIndent()
+
+        val message = json.decodeFromString<MessageWrapperDto>(payload)
+        val encoded = json.encodeToString(message)
+
+        assertEquals("user", message.info.role)
+        assertFalse(encoded.contains(patchMarker))
+        assertFalse(encoded.contains("\"summary\""))
+        assertTrue(encoded.length < payload.length / 100)
+    }
+
+    @Test
+    fun `assistant message decoding ignores boolean summary`() {
+        val payload =
+            """
+            {
+              "info": {
+                "id": "msg-assistant",
+                "sessionID": "ses-1",
+                "time": { "created": 2, "completed": 3 },
+                "role": "assistant",
+                "parentID": "msg-user",
+                "modelID": "model-1",
+                "providerID": "provider-1",
+                "agent": "build",
+                "summary": true
+              },
+              "parts": []
+            }
+            """.trimIndent()
+
+        val message = json.decodeFromString<MessageWrapperDto>(payload)
+        val encoded = json.encodeToString(message)
+
+        assertEquals("assistant", message.info.role)
+        assertFalse(encoded.contains("\"summary\""))
+    }
 
     @Test
     fun `mcp add response decodes status map`() {

--- a/app/src/test/java/dev/blazelight/p4oc/data/remote/mapper/EventMapperTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/data/remote/mapper/EventMapperTest.kt
@@ -27,7 +27,7 @@ import org.junit.Test
 class EventMapperTest {
 
     private val json = Json { ignoreUnknownKeys = true }
-    private val messageMapper = MessageMapper(json)
+    private val messageMapper = MessageMapper()
     private val eventMapper = EventMapper(json, messageMapper)
 
     @Before

--- a/app/src/test/java/dev/blazelight/p4oc/data/remote/mapper/MapperTests.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/data/remote/mapper/MapperTests.kt
@@ -2,7 +2,6 @@ package dev.blazelight.p4oc.data.remote.mapper
 
 import dev.blazelight.p4oc.data.remote.dto.*
 import dev.blazelight.p4oc.domain.model.*
-import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import org.junit.Assert.*
@@ -305,8 +304,7 @@ class PartMapperTest {
 
 class MessageMapperTest {
 
-    private val json = Json { ignoreUnknownKeys = true }
-    private val messageMapper = MessageMapper(json)
+    private val messageMapper = MessageMapper()
 
     @Test
     fun `maps user message with model ref`() {

--- a/app/src/test/java/dev/blazelight/p4oc/data/session/SessionRepositoryProviderTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/data/session/SessionRepositoryProviderTest.kt
@@ -38,7 +38,6 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
-import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotSame
 import org.junit.Assert.assertSame
@@ -141,7 +140,7 @@ class SessionRepositoryProviderTest {
                 activeServerApiProvider = ActiveServerApiProvider { serverRef, generation ->
                     byKey[serverRef to generation]?.api ?: defaultApi
                 },
-                messageMapper = MessageMapper(Json { ignoreUnknownKeys = true }),
+                messageMapper = MessageMapper(),
                 serverConnectionRegistry = registry,
                 dispatcher = dispatcher,
                 repositoryDispatcher = dispatcher,
@@ -449,7 +448,7 @@ class SessionRepositoryProviderTest {
         val api = mockk<OpenCodeApi>(relaxed = true)
         val provider = SessionRepositoryProvider(
             activeServerApiProvider = ActiveServerApiProvider { _, _ -> api },
-            messageMapper = MessageMapper(Json { ignoreUnknownKeys = true }),
+            messageMapper = MessageMapper(),
             serverConnectionRegistry = registry,
             dispatcher = StandardTestDispatcher(testScheduler),
             repositoryDispatcher = StandardTestDispatcher(testScheduler),

--- a/app/src/test/java/dev/blazelight/p4oc/data/session/SessionRepositoryRecoveryTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/data/session/SessionRepositoryRecoveryTest.kt
@@ -29,7 +29,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
-import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -39,8 +38,7 @@ import org.junit.Test
 class SessionRepositoryRecoveryTest {
 
     private val sessionId = SessionId("s1")
-    private val json = Json { ignoreUnknownKeys = true }
-    private val mapper = MessageMapper(json)
+    private val mapper = MessageMapper()
 
     @Test
     fun `reconnect recovers messages for actively leased session with bounded default limit`() = runTest {

--- a/app/src/test/java/dev/blazelight/p4oc/ui/screens/chat/ChatViewModelDraftPersistenceTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/ui/screens/chat/ChatViewModelDraftPersistenceTest.kt
@@ -85,7 +85,7 @@ class ChatViewModelDraftPersistenceTest {
         every { AppLog.e(any(), any<String>()) } returns Unit
         every { AppLog.e(any(), any<String>(), any()) } returns Unit
 
-        messageMapper = MessageMapper(Json { ignoreUnknownKeys = true })
+        messageMapper = MessageMapper()
         settingsDataStore = mockk()
         events = MutableSharedFlow(extraBufferCapacity = 32)
         api = mockk(relaxed = true)

--- a/app/src/test/java/dev/blazelight/p4oc/ui/screens/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/ui/screens/chat/ChatViewModelTest.kt
@@ -83,7 +83,6 @@ import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import kotlinx.coroutines.withContext
-import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import okhttp3.ResponseBody.Companion.toResponseBody
@@ -130,7 +129,7 @@ class ChatViewModelTest {
         every { AppLog.e(any(), any<String>()) } returns Unit
         every { AppLog.e(any(), any<String>(), any()) } returns Unit
 
-        messageMapper = MessageMapper(Json { ignoreUnknownKeys = true })
+        messageMapper = MessageMapper()
         settingsDataStore = mockk()
         events = MutableSharedFlow(extraBufferCapacity = 32)
         api = mockk(relaxed = true)

--- a/app/src/test/java/dev/blazelight/p4oc/ui/screens/sessions/SessionListViewModelTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/ui/screens/sessions/SessionListViewModelTest.kt
@@ -14,7 +14,6 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import kotlinx.serialization.json.Json
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -448,7 +447,7 @@ class SessionListViewModelTest {
 
     private fun repository(client: FakeWorkspaceClient): SessionRepositoryImpl = SessionRepositoryImpl(
         client = client,
-        messageMapper = MessageMapper(Json { ignoreUnknownKeys = true }),
+        messageMapper = MessageMapper(),
         dispatcher = dispatcher,
     )
 }


### PR DESCRIPTION
## Summary
- stop retaining polymorphic upstream message `summary` payloads, including multi-megabyte diff patches
- let the configured streaming JSON decoder skip the unused value as an unknown key
- keep session-level summaries and file diffs unchanged
- make `MessageMapper` stateless and map unused message-level summaries to `null`
- cover object and boolean summary wire shapes plus a deterministic 3 MiB non-retention contract

## Verification
- focused DTO/mapper tests: `artifact://2198`
- `compileDebugKotlin`, detekt, and full unit suite: `artifact://2228`
- final Sol review: SHIP

Closes #33.