### PR TITLE
fix: scope session tab reuse to workspace

### DIFF
--- a/app/src/main/java/dev/blazelight/p4oc/ui/tabs/MainTabScreen.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/tabs/MainTabScreen.kt
@@ -1189,7 +1189,11 @@ private fun mainTabHomeContent(
             onSettings = params.onSettings,
             onFocusTab = params.deps.tabManager::focusTab,
             onResumeSession = { session ->
-                val existing = params.deps.tabManager.findTabBySessionId(session.sessionId.value)
+                val existing = params.deps.tabManager.findSessionTab(
+                    serverRef = session.serverRef,
+                    workspaceKey = session.workspaceKey,
+                    sessionId = session.sessionId.value,
+                )
                 if (existing != null) {
                     params.deps.tabManager.focusTab(existing.id)
                 } else {

--- a/app/src/main/java/dev/blazelight/p4oc/ui/tabs/TabManager.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/tabs/TabManager.kt
@@ -125,10 +125,6 @@ class TabManager {
         }
     }
 
-    /**
-     * Find a tab that's showing the given session.
-     */
-
     fun findFilesTab(serverRef: ServerRef, workspaceKey: WorkspaceKey): TabInstance? =
         _tabs.value.firstOrNull {
             !it.isPinnedHome &&
@@ -158,8 +154,15 @@ class TabManager {
                 it.workspaceKey == workspaceKey &&
                 it.startRoute.startsWith("terminal/")
         }
-    fun findTabBySessionId(sessionId: String): TabInstance? {
-        return _tabs.value.find { it.sessionId == sessionId }
+
+    fun findSessionTab(
+        serverRef: ServerRef,
+        workspaceKey: WorkspaceKey,
+        sessionId: String,
+    ): TabInstance? = _tabs.value.firstOrNull {
+        it.serverRef?.endpointKey == serverRef.endpointKey &&
+            it.workspaceKey == workspaceKey &&
+            it.sessionId == sessionId
     }
 
     fun findTabByNotificationRoute(route: dev.blazelight.p4oc.core.notification.NotificationRoute): TabInstance? =

--- a/app/src/main/java/dev/blazelight/p4oc/ui/tabs/TabNavHost.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/tabs/TabNavHost.kt
@@ -269,7 +269,11 @@ fun TabNavHost(
                     onSessionClick = { sessionId, directory ->
                         val selection = directory.toNavigationWorkspaceSelection()
                             ?: return@SessionListScreen
-                        val existingTab = tabManager.findTabBySessionId(sessionId)
+                        val existingTab = tabManager.findSessionTab(
+                            serverRef = serverRef,
+                            workspaceKey = selection.workspaceKey,
+                            sessionId = sessionId,
+                        )
                         if (existingTab != null && existingTab.id != tabId) {
                             tabManager.focusTab(existingTab.id)
                         } else {
@@ -379,7 +383,11 @@ fun TabNavHost(
                     onSessionClick = { sessionId, directory ->
                         val selection = directory.toNavigationWorkspaceSelection()
                             ?: return@SessionListScreen
-                        val existingTab = tabManager.findTabBySessionId(sessionId)
+                        val existingTab = tabManager.findSessionTab(
+                            serverRef = serverRef,
+                            workspaceKey = selection.workspaceKey,
+                            sessionId = sessionId,
+                        )
                         if (existingTab != null && existingTab.id != tabId) {
                             tabManager.focusTab(existingTab.id)
                         } else {
@@ -495,7 +503,11 @@ fun TabNavHost(
                     },
                     onOpenSubSession = { subSessionId ->
                         // Check if sub-session is already open in another tab
-                        val existingTab = tabManager.findTabBySessionId(subSessionId)
+                        val existingTab = tabManager.findSessionTab(
+                            serverRef = serverRef,
+                            workspaceKey = workspaceOwner.workspace.key,
+                            sessionId = subSessionId,
+                        )
                         if (existingTab != null && existingTab.id != tabId) {
                             // Focus the existing tab
                             tabManager.focusTab(existingTab.id)

--- a/app/src/test/java/dev/blazelight/p4oc/ui/tabs/NotificationRouteOwnershipTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/ui/tabs/NotificationRouteOwnershipTest.kt
@@ -65,6 +65,55 @@ class NotificationRouteOwnershipTest {
         assertNull(manager.findTabByNotificationRoute(route.copy(workspaceKey = WorkspaceKey.Directory("/other"))))
     }
 
+    @Test
+    fun `session lookup matches endpoint workspace and session exactly`() {
+        val savedServer = ServerRef.fromEndpointKey("https://saved.example", "Saved server")
+        val renamedSavedServer = ServerRef.fromEndpointKey("https://saved.example", "Renamed server")
+        val otherServer = ServerRef.fromEndpointKey("https://other.example")
+        val targetWorkspace = WorkspaceKey.Directory("/target")
+        val otherWorkspace = WorkspaceKey.Directory("/other")
+        val manager = TabManager()
+        manager.restoreState(
+            state = PersistedTabState(
+                serverEndpointKey = savedServer.endpointKey,
+                activeTabId = null,
+                tabs = listOf(
+                    sessionTab("other-server", otherServer, targetWorkspace),
+                    sessionTab("other-workspace", savedServer, otherWorkspace),
+                    sessionTab("exact", savedServer, targetWorkspace),
+                ),
+            ),
+            availableServers = mapOf(
+                savedServer.endpointKey to savedServer,
+                otherServer.endpointKey to otherServer,
+            ),
+        )
+
+        assertEquals("exact", manager.findSessionTab(renamedSavedServer, targetWorkspace, "session")?.id)
+        assertNull(manager.findSessionTab(otherServer, otherWorkspace, "session"))
+        assertNull(
+            manager.findSessionTab(
+                ServerRef.fromEndpointKey("https://missing.example"),
+                targetWorkspace,
+                "session",
+            ),
+        )
+        assertNull(manager.findSessionTab(savedServer, WorkspaceKey.Directory("/missing"), "session"))
+        assertNull(manager.findSessionTab(savedServer, targetWorkspace, "missing-session"))
+    }
+
+    private fun sessionTab(
+        id: String,
+        serverRef: ServerRef,
+        workspaceKey: WorkspaceKey.Directory,
+    ) = PersistedTab(
+        id = id,
+        startRoute = "chat/session",
+        sessionId = "session",
+        serverEndpointKey = serverRef.endpointKey,
+        workspaceKey = PersistedWorkspaceKey(PersistedWorkspaceKey.Type.DIRECTORY, workspaceKey.value),
+    )
+
     private fun server(endpointKey: String) = SavedServer(
         id = endpointKey,
         endpoint = endpointKey,


### PR DESCRIPTION
## Summary
- key normal session-tab reuse by server endpoint, workspace, and session ID
- pass exact ownership from Home resume, regular and filtered session lists, and sub-session navigation
- prevent equal session IDs on different servers/workspaces from focusing the wrong tab
- add focused duplicate-owner regression coverage

## Verification
- `compileDebugKotlin`, detekt, scoped ownership tests, workspace tests, tab persistence, and Start Work context: `artifact://2256`
- final Sol review: SHIP

Closes #4.