### PR TITLE
Add workspace-wide file search

### DIFF
--- a/app/src/main/java/dev/blazelight/p4oc/data/files/FileRepository.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/data/files/FileRepository.kt
@@ -16,6 +16,7 @@ import java.io.InputStream
 interface FileRepository {
     suspend fun listFiles(path: String): FileOperationResult<FileList>
     suspend fun readFile(path: String): FileOperationResult<FileContent>
+    suspend fun searchFiles(query: String): FileOperationResult<List<FileNode>>
     suspend fun searchSymbols(query: String): FileOperationResult<List<Symbol>>
     suspend fun writeFile(request: FileWriteRequest): FileOperationResult<FileWriteResult>
     suspend fun createDirectory(path: String): FileOperationResult<Unit>
@@ -117,6 +118,16 @@ class WorkspaceFileRepository internal constructor(
         }
     }
 
+    override suspend fun searchFiles(query: String): FileOperationResult<List<FileNode>> {
+        val normalizedQuery = query.trim()
+        if (normalizedQuery.isBlank()) return FileOperationResult.Ok(emptyList())
+
+        return when (val result = safeApiCall { client.searchFiles(normalizedQuery) }) {
+            is ApiResult.Success -> FileOperationResult.Ok(result.data.toFileNodes())
+            is ApiResult.Error -> FileOperationResult.Failed(result.message, result.throwable)
+        }
+    }
+
     override suspend fun searchSymbols(query: String): FileOperationResult<List<Symbol>> {
         val normalizedQuery = query.trim()
         if (normalizedQuery.isBlank()) return FileOperationResult.Ok(emptyList())
@@ -177,6 +188,22 @@ class WorkspaceFileRepository internal constructor(
         encoding = encoding,
     )
 
+    private fun List<String>.toFileNodes(): List<FileNode> = buildList(size) {
+        val seenPaths = HashSet<String>(size)
+        for (path in this@toFileNodes) {
+            val normalizedPath = FilePathValidator.normalizeForReadOrList(path).getOrNull()
+            if (normalizedPath.isNullOrEmpty() || !seenPaths.add(normalizedPath)) continue
+
+            add(
+                FileNode(
+                    name = normalizedPath.substringAfterLast('/'),
+                    path = normalizedPath,
+                    type = "file",
+                )
+            )
+        }
+    }
+
     private companion object {
         const val ROOT_API_PATH = "."
         const val INVALID_PATH_MESSAGE = "Invalid file path"
@@ -188,6 +215,7 @@ internal interface FileWorkspaceClient {
     suspend fun listFiles(path: String): List<FileNodeDto>
     suspend fun readFile(path: String): FileContentDto
     suspend fun getFileStatus(): List<FileStatusDto>
+    suspend fun searchFiles(query: String): List<String>
     suspend fun searchSymbols(query: String): List<SymbolDto>
 }
 
@@ -199,6 +227,8 @@ private class WorkspaceClientFileAdapter(
     override suspend fun readFile(path: String): FileContentDto = workspaceClient.readFile(path)
 
     override suspend fun getFileStatus(): List<FileStatusDto> = workspaceClient.getFileStatus()
+
+    override suspend fun searchFiles(query: String): List<String> = workspaceClient.searchFiles(query)
 
     override suspend fun searchSymbols(query: String): List<SymbolDto> = workspaceClient.searchSymbols(query)
 }

--- a/app/src/main/java/dev/blazelight/p4oc/data/files/ofish/OfishFileRepository.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/data/files/ofish/OfishFileRepository.kt
@@ -9,6 +9,7 @@ import dev.blazelight.p4oc.data.files.FileUploadResult
 import dev.blazelight.p4oc.data.files.FileWriteRequest
 import dev.blazelight.p4oc.data.files.FileWriteResult
 import dev.blazelight.p4oc.domain.model.FileContent
+import dev.blazelight.p4oc.domain.model.FileNode
 import dev.blazelight.p4oc.domain.model.Symbol
 
 internal class OfishFileRepository(
@@ -37,6 +38,8 @@ internal class OfishFileRepository(
         val hash = mutationClient.hashFile(path)
         return FileOperationResult.Ok(content.copy(hash = hash))
     }
+
+    override suspend fun searchFiles(query: String): FileOperationResult<List<FileNode>> = delegate.searchFiles(query)
 
     override suspend fun searchSymbols(query: String): FileOperationResult<List<Symbol>> = delegate.searchSymbols(query)
 

--- a/app/src/main/java/dev/blazelight/p4oc/data/workspace/WorkspaceClient.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/data/workspace/WorkspaceClient.kt
@@ -262,5 +262,14 @@ class WorkspaceClient(
 
     suspend fun getFileStatus(): List<FileStatusDto> = api.getFileStatus(directory, workspace = null)
 
+    suspend fun searchFiles(query: String): List<String> = api.searchFiles(
+        query = query,
+        directory = workspace.directory,
+        workspace = null,
+        dirs = "false",
+        type = "file",
+        limit = 200,
+    )
+
     suspend fun searchSymbols(query: String): List<SymbolDto> = api.searchSymbols(query, directory, workspace = null)
 }

--- a/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ChatViewModel.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ChatViewModel.kt
@@ -102,6 +102,38 @@ class ChatViewModel constructor(
     val hasUnreadResponse: StateFlow<Boolean> = _hasUnreadResponse.asStateFlow()
     private val _isActiveTab = MutableStateFlow(false)
 
+    // Repository emissions may be collected immediately from init, so every field read by
+    // applyRepositorySessionState must be initialized before any collector can launch.
+    private var lastResponseCompletedToken = 0L
+    private var hasResponseTokenBaseline = false
+    private var responseReconciliationJob: Job? = null
+    private var initOperationGeneration = 0L
+    private var currentInitOperationGeneration: Long? = null
+    private var currentInitCommandDispatchOwner: Long? = null
+    private var initRequestJob: Job? = null
+    private var initTerminalTokenBaseline: Long? = null
+    private val commandDispatchGeneration = AtomicLong(NO_COMMAND_DISPATCH_OWNER)
+    private val commandDispatchOwner = AtomicLong(NO_COMMAND_DISPATCH_OWNER)
+    private var composerSubmissionGeneration = 0L
+    private var pendingComposerSubmission: PendingComposerSubmission? = null
+
+    private data class ComposerSubmission(
+        val generation: Long,
+        val draft: String,
+    )
+
+    private data class PendingComposerSubmission(
+        val submission: ComposerSubmission,
+        val clearAcknowledged: Boolean = false,
+        val failed: Boolean = false,
+    )
+
+    // True from the moment a send clears the previous run's UI error until the run is confirmed
+    // active (Busy/Retry) or reaches a genuine terminal boundary. While set, repository emissions
+    // that still carry the previous run's error (todos, permissions, session updates arriving
+    // before the synthetic Busy clears it) must not flicker that stale error back into the UI.
+    private var suppressStaleRunErrors = false
+
     init {
         serverConnectionRegistry?.let(::observeCommandCatalogEvents)
     }
@@ -426,36 +458,6 @@ class ChatViewModel constructor(
             repositorySessionState.collect { state -> applyRepositorySessionState(state) }
         }
     }
-
-    private var lastResponseCompletedToken = 0L
-    private var hasResponseTokenBaseline = false
-    private var responseReconciliationJob: Job? = null
-    private var initOperationGeneration = 0L
-    private var currentInitOperationGeneration: Long? = null
-    private var currentInitCommandDispatchOwner: Long? = null
-    private var initRequestJob: Job? = null
-    private var initTerminalTokenBaseline: Long? = null
-    private val commandDispatchGeneration = AtomicLong(NO_COMMAND_DISPATCH_OWNER)
-    private val commandDispatchOwner = AtomicLong(NO_COMMAND_DISPATCH_OWNER)
-    private var composerSubmissionGeneration = 0L
-    private var pendingComposerSubmission: PendingComposerSubmission? = null
-
-    private data class ComposerSubmission(
-        val generation: Long,
-        val draft: String,
-    )
-
-    private data class PendingComposerSubmission(
-        val submission: ComposerSubmission,
-        val clearAcknowledged: Boolean = false,
-        val failed: Boolean = false,
-    )
-
-    // True from the moment a send clears the previous run's UI error until the run is confirmed
-    // active (Busy/Retry) or reaches a genuine terminal boundary. While set, repository emissions
-    // that still carry the previous run's error (todos, permissions, session updates arriving
-    // before the synthetic Busy clears it) must not flicker that stale error back into the UI.
-    private var suppressStaleRunErrors = false
 
     @Suppress("CyclomaticComplexMethod")
     private fun applyRepositorySessionState(state: dev.blazelight.p4oc.data.session.SessionUiState) {

--- a/app/src/main/java/dev/blazelight/p4oc/ui/screens/files/FileExplorerScreen.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/screens/files/FileExplorerScreen.kt
@@ -74,6 +74,7 @@ fun FileExplorerScreen(
 ) {
     val theme = LocalOpenCodeTheme.current
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val fileSearchResults by viewModel.fileSearchResults.collectAsStateWithLifecycle()
     val symbolResults by viewModel.symbolResults.collectAsStateWithLifecycle()
     val uploadState by viewModel.uploadState.collectAsStateWithLifecycle()
     val searchQuery = uiState.searchQuery
@@ -96,14 +97,8 @@ fun FileExplorerScreen(
         }
     }
 
-    val filteredFiles = remember(uiState.files, searchQuery) {
-        if (searchQuery.isBlank()) {
-            uiState.files.sortedWith(compareBy({ !it.isDirectory }, { it.name.lowercase() }))
-        } else {
-            uiState.files
-                .filter { it.name.contains(searchQuery, ignoreCase = true) }
-                .sortedWith(compareBy({ !it.isDirectory }, { it.name.lowercase() }))
-        }
+    val sortedFiles = remember(uiState.files) {
+        uiState.files.sortedWith(compareBy({ !it.isDirectory }, { it.name.lowercase() }))
     }
 
     Scaffold(
@@ -143,6 +138,7 @@ fun FileExplorerScreen(
                                 )
                             )
                         } else if (isSearchActive) {
+                            val searchFieldDescription = stringResource(R.string.files_search_placeholder)
                             OutlinedTextField(
                                 value = searchQuery,
                                 onValueChange = viewModel::updateSearchQuery,
@@ -153,7 +149,10 @@ fun FileExplorerScreen(
                                     )
                                 },
                                 singleLine = true,
-                                modifier = Modifier.fillMaxWidth(),
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .semantics { contentDescription = searchFieldDescription }
+                                    .testTag("files_search_field"),
                                 colors = OutlinedTextFieldDefaults.colors(
                                     focusedBorderColor = Color.Transparent,
                                     unfocusedBorderColor = Color.Transparent,
@@ -250,7 +249,7 @@ fun FileExplorerScreen(
                     }
                 )
 
-                if (uiState.currentPath.isNotBlank()) {
+                if (!isSearchActive && uiState.currentPath.isNotBlank()) {
                     BreadcrumbNavigation(
                         path = uiState.currentPath,
                         onNavigateTo = { viewModel.navigateTo(it) }
@@ -264,7 +263,7 @@ fun FileExplorerScreen(
                 .fillMaxSize()
                 .padding(padding)
         ) {
-            if (uiState.pathRestoreError != null) {
+            if (!isSearchActive && uiState.pathRestoreError != null) {
                 Surface(
                     modifier = Modifier
                         .align(Alignment.TopCenter)
@@ -346,6 +345,17 @@ fun FileExplorerScreen(
                         }
                     }
                 }
+            } else if (isSearchActive) {
+                FileSearchContent(
+                    state = FileSearchContentState(
+                        query = searchQuery,
+                        results = fileSearchResults,
+                        isLoading = uiState.isFileSearchLoading,
+                        hasError = uiState.fileSearchError != null,
+                    ),
+                    onRetry = viewModel::refresh,
+                    onFileClick = onFileClick,
+                )
             } else {
                 when {
                     uiState.isLoading -> {
@@ -384,31 +394,24 @@ fun FileExplorerScreen(
                             }
                         }
                     }
-                    filteredFiles.isEmpty() -> {
+                    sortedFiles.isEmpty() -> {
                         Column(
                             modifier = Modifier.align(Alignment.Center),
                             horizontalAlignment = Alignment.CenterHorizontally,
                             verticalArrangement = Arrangement.spacedBy(Spacing.md)
                         ) {
                             Text(
-                                text = if (searchQuery.isNotBlank()) "∅" else "□",
+                                text = "□",
                                 style = MaterialTheme.typography.displayMedium,
                                 color = theme.textMuted
                             )
-                            val emptyText = if (searchQuery.isNotBlank()) {
-                                stringResource(R.string.files_no_matching_files)
-                            } else {
-                                stringResource(R.string.files_empty_folder)
-                            }
-                            Text(text = emptyText, color = theme.textMuted)
-                            if (searchQuery.isBlank()) {
-                                EmptyFolderActions(
-                                    canCreateFile = uiState.capabilities.canWrite,
-                                    canUpload = uiState.capabilities.canUpload,
-                                    onCreateFile = { createDialog = FileCreateKind.File },
-                                    onUpload = { uploadLauncher.launch(arrayOf("*/*")) },
-                                )
-                            }
+                            Text(text = stringResource(R.string.files_empty_folder), color = theme.textMuted)
+                            EmptyFolderActions(
+                                canCreateFile = uiState.capabilities.canWrite,
+                                canUpload = uiState.capabilities.canUpload,
+                                onCreateFile = { createDialog = FileCreateKind.File },
+                                onUpload = { uploadLauncher.launch(arrayOf("*/*")) },
+                            )
                         }
                     }
                     else -> {
@@ -443,7 +446,7 @@ fun FileExplorerScreen(
                                 contentPadding = PaddingValues(Spacing.md),
                                 verticalArrangement = Arrangement.spacedBy(Spacing.xxs)
                             ) {
-                                items(filteredFiles, key = { it.path }) { file ->
+                                items(sortedFiles, key = { it.path }) { file ->
                                     TuiFileItem(
                                         file = file,
                                         actions = FileItemActions(
@@ -536,6 +539,218 @@ fun FileExplorerScreen(
         ) {
             Text(stringResource(R.string.files_operation_failed_hint), color = theme.textMuted)
         }
+    }
+}
+
+private data class FileSearchContentState(
+    val query: String,
+    val results: List<FileNode>,
+    val isLoading: Boolean,
+    val hasError: Boolean,
+)
+
+@Composable
+@Suppress("FunctionNaming")
+private fun FileSearchContent(
+    state: FileSearchContentState,
+    onRetry: () -> Unit,
+    onFileClick: (String) -> Unit,
+) {
+    Box(modifier = Modifier.fillMaxSize()) {
+        when {
+            state.query.isBlank() -> FileSearchMessage(
+                glyph = "⌕",
+                text = stringResource(R.string.files_search_blank_hint),
+                modifier = Modifier.align(Alignment.Center),
+            )
+            state.isLoading -> TuiLoadingScreen(
+                modifier = Modifier
+                    .align(Alignment.Center)
+                    .testTag("files_search_loading"),
+                text = stringResource(R.string.files_search_loading),
+            )
+            state.hasError -> FileSearchFailure(
+                onRetry = onRetry,
+                modifier = Modifier.align(Alignment.Center),
+            )
+            state.results.isEmpty() -> FileSearchMessage(
+                glyph = "∅",
+                text = stringResource(R.string.files_search_no_results),
+                modifier = Modifier.align(Alignment.Center),
+            )
+            else -> FileSearchResults(state.results, onFileClick)
+        }
+    }
+}
+
+@Composable
+@Suppress("FunctionNaming")
+private fun FileSearchFailure(
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val theme = LocalOpenCodeTheme.current
+
+    Column(
+        modifier = modifier
+            .padding(Spacing.lg)
+            .semantics { liveRegion = LiveRegionMode.Polite }
+            .testTag("files_search_error"),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(Spacing.md),
+    ) {
+        Icon(
+            imageVector = Icons.Default.ErrorOutline,
+            contentDescription = null,
+            tint = theme.error,
+            modifier = Modifier.size(Sizing.iconLg),
+        )
+        Text(
+            text = stringResource(R.string.files_search_failed),
+            style = MaterialTheme.typography.bodyMedium,
+            color = theme.error,
+        )
+        TuiButton(
+            onClick = onRetry,
+            modifier = Modifier.testTag("files_search_retry"),
+        ) {
+            Text(stringResource(R.string.retry))
+        }
+    }
+}
+
+@Composable
+@Suppress("FunctionNaming")
+private fun FileSearchResults(
+    results: List<FileNode>,
+    onFileClick: (String) -> Unit,
+) {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(Spacing.md),
+        verticalArrangement = Arrangement.spacedBy(Spacing.xxs),
+    ) {
+        items(results, key = { it.path }) { file ->
+            FileSearchResultItem(
+                file = file,
+                onClick = { onFileClick(file.path) },
+            )
+        }
+    }
+}
+
+@Composable
+@Suppress("FunctionNaming")
+private fun FileSearchMessage(
+    glyph: String,
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    val theme = LocalOpenCodeTheme.current
+
+    Column(
+        modifier = modifier.padding(Spacing.lg),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(Spacing.md),
+    ) {
+        Text(
+            text = glyph,
+            style = MaterialTheme.typography.displayMedium,
+            color = theme.textMuted,
+        )
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodyMedium,
+            color = theme.textMuted,
+        )
+    }
+}
+
+@Composable
+@Suppress("FunctionNaming")
+private fun FileSearchResultItem(
+    file: FileNode,
+    onClick: () -> Unit,
+) {
+    val theme = LocalOpenCodeTheme.current
+    val parentPath = file.path.substringBeforeLast('/', missingDelimiterValue = "")
+    val parentLabel = parentPath.ifBlank { stringResource(R.string.files_breadcrumb_root) }
+    val itemDescription = stringResource(
+        R.string.files_search_result_description,
+        file.name,
+        parentLabel,
+    )
+
+    Surface(
+        onClick = onClick,
+        modifier = Modifier
+            .fillMaxWidth()
+            .clearAndSetSemantics {
+                role = Role.Button
+                contentDescription = itemDescription
+                onClick {
+                    onClick()
+                    true
+                }
+            }
+            .testTag("files_search_result_${file.path}"),
+        color = Color.Transparent,
+        shape = RectangleShape,
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = Spacing.sm, vertical = Spacing.xs),
+            horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = "■",
+                style = MaterialTheme.typography.bodyMedium.copy(fontFamily = FontFamily.Monospace),
+                color = getFileIcon(file).second,
+                modifier = Modifier.width(Sizing.iconMd),
+            )
+            FileSearchResultLabels(
+                fileName = file.name,
+                parentLabel = parentLabel,
+                modifier = Modifier.weight(1f),
+            )
+            Text(
+                text = "›",
+                style = MaterialTheme.typography.titleMedium,
+                color = theme.border,
+            )
+        }
+    }
+}
+
+@Composable
+@Suppress("FunctionNaming")
+private fun FileSearchResultLabels(
+    fileName: String,
+    parentLabel: String,
+    modifier: Modifier = Modifier,
+) {
+    val theme = LocalOpenCodeTheme.current
+
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(Spacing.xxs),
+    ) {
+        Text(
+            text = fileName,
+            style = MaterialTheme.typography.bodyMedium.copy(fontFamily = FontFamily.Monospace),
+            color = theme.text,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+        Text(
+            text = parentLabel,
+            style = MaterialTheme.typography.labelSmall.copy(fontFamily = FontFamily.Monospace),
+            color = theme.textMuted,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
     }
 }
 

--- a/app/src/main/java/dev/blazelight/p4oc/ui/screens/files/FilesViewModel.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/screens/files/FilesViewModel.kt
@@ -13,6 +13,7 @@ import dev.blazelight.p4oc.ui.screens.files.upload.UploadCoordinator
 import dev.blazelight.p4oc.ui.screens.files.upload.UploadQueueState
 import dev.blazelight.p4oc.ui.screens.files.upload.UploadSource
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -33,7 +34,8 @@ class FilesViewModel constructor(
         FilesUiState(
             currentPath = savedStateHandle[KEY_CURRENT_PATH] ?: ROOT_PATH,
             searchQuery = savedStateHandle[KEY_SEARCH_QUERY] ?: "",
-            isSearchActive = savedStateHandle[KEY_SEARCH_ACTIVE] ?: false,
+            isSearchActive = (savedStateHandle[KEY_SEARCH_ACTIVE] ?: false) &&
+                !(savedStateHandle[KEY_SYMBOL_MODE] ?: false),
             isSymbolMode = savedStateHandle[KEY_SYMBOL_MODE] ?: false,
             symbolQuery = savedStateHandle[KEY_SYMBOL_QUERY] ?: "",
         )
@@ -45,11 +47,18 @@ class FilesViewModel constructor(
     private val _symbolResults = MutableStateFlow<List<Symbol>>(emptyList())
     val symbolResults: StateFlow<List<Symbol>> = _symbolResults.asStateFlow()
 
+    private val _fileSearchResults = MutableStateFlow<List<FileNode>>(emptyList())
+    val fileSearchResults: StateFlow<List<FileNode>> = _fileSearchResults.asStateFlow()
+
     private val pathStack = savedStateHandle.get<ArrayList<String>>(KEY_PATH_STACK)?.toMutableList() ?: mutableListOf()
     private var loadFilesJob: Job? = null
     private var loadContentJob: Job? = null
     private var saveJob: Job? = null
     private var mutationJob: Job? = null
+    private var fileSearchJob: Job? = null
+    private var symbolSearchJob: Job? = null
+    private var fileSearchGeneration = 0L
+    private var symbolSearchGeneration = 0L
 
     private val _editState = MutableStateFlow(restoredEditState())
     val editState: StateFlow<FileEditState> = _editState.asStateFlow()
@@ -59,7 +68,16 @@ class FilesViewModel constructor(
     init {
         loadCapabilities()
         loadFiles(savedStateHandle[KEY_CURRENT_PATH] ?: ROOT_PATH)
-        savedStateHandle.get<String>(KEY_SYMBOL_QUERY)?.takeIf { it.isNotBlank() }?.let(::searchSymbols)
+        when {
+            _uiState.value.isSymbolMode -> {
+                _uiState.value.symbolQuery.takeIf { it.isNotBlank() }?.let(::searchSymbols)
+            }
+            _uiState.value.isSearchActive -> {
+                _uiState.value.searchQuery.takeIf { it.isNotBlank() }?.let {
+                    searchFiles(it, debounce = true)
+                }
+            }
+        }
     }
 
     private fun restoredEditState(): FileEditState {
@@ -119,7 +137,12 @@ class FilesViewModel constructor(
     }
 
     fun refresh() {
-        loadFiles(_uiState.value.currentPath)
+        val state = _uiState.value
+        when {
+            state.isSymbolMode -> searchSymbols(state.symbolQuery)
+            state.isSearchActive -> searchFiles(state.searchQuery, debounce = false)
+            else -> loadFiles(state.currentPath)
+        }
     }
 
     fun navigateTo(path: String) {
@@ -137,32 +160,79 @@ class FilesViewModel constructor(
 
     fun setSearchActive(active: Boolean) {
         savedStateHandle[KEY_SEARCH_ACTIVE] = active
-        _uiState.update { it.copy(isSearchActive = active) }
+        if (active) {
+            savedStateHandle[KEY_SYMBOL_MODE] = false
+            cancelSymbolSearch()
+            _symbolResults.value = emptyList()
+            _uiState.update {
+                it.copy(
+                    isSearchActive = true,
+                    isSymbolMode = false,
+                    symbolError = null,
+                )
+            }
+            searchFiles(_uiState.value.searchQuery, debounce = true)
+        } else {
+            cancelFileSearch()
+            _fileSearchResults.value = emptyList()
+            _uiState.update {
+                it.copy(
+                    isSearchActive = false,
+                    isFileSearchLoading = false,
+                    fileSearchError = null,
+                )
+            }
+        }
     }
 
     fun updateSearchQuery(query: String) {
         val bounded = query.take(MAX_PERSISTED_QUERY_CHARS)
         savedStateHandle[KEY_SEARCH_QUERY] = bounded
         _uiState.update { it.copy(searchQuery = bounded) }
+        if (_uiState.value.isSearchActive) {
+            searchFiles(bounded, debounce = true)
+        }
     }
 
     fun setSymbolMode(active: Boolean) {
         savedStateHandle[KEY_SYMBOL_MODE] = active
-        _uiState.update { it.copy(isSymbolMode = active) }
+        if (active) {
+            savedStateHandle[KEY_SEARCH_ACTIVE] = false
+            cancelFileSearch()
+            _fileSearchResults.value = emptyList()
+            _uiState.update {
+                it.copy(
+                    isSearchActive = false,
+                    isSymbolMode = true,
+                    isFileSearchLoading = false,
+                    fileSearchError = null,
+                )
+            }
+            searchSymbols(_uiState.value.symbolQuery)
+        } else {
+            cancelSymbolSearch()
+            _symbolResults.value = emptyList()
+            _uiState.update { it.copy(isSymbolMode = false, symbolError = null) }
+        }
     }
 
     fun updateSymbolQuery(query: String) {
         val bounded = query.take(MAX_PERSISTED_QUERY_CHARS)
         savedStateHandle[KEY_SYMBOL_QUERY] = bounded
         _uiState.update { it.copy(symbolQuery = bounded) }
-        searchSymbols(bounded)
+        if (_uiState.value.isSymbolMode) {
+            searchSymbols(bounded)
+        }
     }
 
     fun clearFilters() {
+        cancelFileSearch()
+        cancelSymbolSearch()
         savedStateHandle[KEY_SEARCH_ACTIVE] = false
         savedStateHandle[KEY_SYMBOL_MODE] = false
         savedStateHandle[KEY_SEARCH_QUERY] = ""
         savedStateHandle[KEY_SYMBOL_QUERY] = ""
+        _fileSearchResults.value = emptyList()
         _symbolResults.value = emptyList()
         _uiState.update {
             it.copy(
@@ -170,6 +240,8 @@ class FilesViewModel constructor(
                 isSymbolMode = false,
                 searchQuery = "",
                 symbolQuery = "",
+                isFileSearchLoading = false,
+                fileSearchError = null,
                 symbolError = null,
             )
         }
@@ -228,13 +300,56 @@ class FilesViewModel constructor(
         }
     }
 
-    fun searchSymbols(query: String) {
-        viewModelScope.launch {
-            _symbolResults.value = emptyList()
-            _uiState.update { it.copy(symbolError = null) }
-            if (query.isBlank()) return@launch
+    private fun searchFiles(query: String, debounce: Boolean) {
+        cancelFileSearch()
+        val generation = fileSearchGeneration
+        _fileSearchResults.value = emptyList()
+        if (query.isBlank()) {
+            _uiState.update {
+                it.copy(isFileSearchLoading = false, fileSearchError = null)
+            }
+            return
+        }
 
-            when (val result = fileRepository.searchSymbols(query)) {
+        _uiState.update {
+            it.copy(isFileSearchLoading = true, fileSearchError = null)
+        }
+        fileSearchJob = viewModelScope.launch {
+            if (debounce) delay(FILE_SEARCH_DEBOUNCE_MS)
+            val result = fileRepository.searchFiles(query)
+            if (!isCurrentFileSearch(generation, query)) return@launch
+            when (result) {
+                is FileOperationResult.Ok -> {
+                    _fileSearchResults.value = result.data
+                    _uiState.update {
+                        it.copy(isFileSearchLoading = false, fileSearchError = null)
+                    }
+                }
+                is FileOperationResult.Conflict -> {
+                    _uiState.update {
+                        it.copy(isFileSearchLoading = false, fileSearchError = result.message)
+                    }
+                }
+                is FileOperationResult.Failed -> {
+                    _uiState.update {
+                        it.copy(isFileSearchLoading = false, fileSearchError = result.message)
+                    }
+                }
+            }
+        }
+    }
+
+    fun searchSymbols(query: String) {
+        cancelSymbolSearch()
+        val generation = symbolSearchGeneration
+        _symbolResults.value = emptyList()
+        _uiState.update { it.copy(symbolError = null) }
+        if (query.isBlank()) return
+
+        symbolSearchJob = viewModelScope.launch {
+            val result = fileRepository.searchSymbols(query)
+            if (!isCurrentSymbolSearch(generation, query)) return@launch
+            when (result) {
                 is FileOperationResult.Ok -> {
                     _symbolResults.value = result.data
                 }
@@ -242,6 +357,32 @@ class FilesViewModel constructor(
                 is FileOperationResult.Failed -> _uiState.update { it.copy(symbolError = result.message) }
             }
         }
+    }
+
+    private fun cancelFileSearch() {
+        fileSearchGeneration++
+        fileSearchJob?.cancel()
+        fileSearchJob = null
+    }
+
+    private fun cancelSymbolSearch() {
+        symbolSearchGeneration++
+        symbolSearchJob?.cancel()
+        symbolSearchJob = null
+    }
+
+    private fun isCurrentFileSearch(generation: Long, query: String): Boolean {
+        val state = _uiState.value
+        return generation == fileSearchGeneration &&
+            state.isSearchActive &&
+            state.searchQuery == query
+    }
+
+    private fun isCurrentSymbolSearch(generation: Long, query: String): Boolean {
+        val state = _uiState.value
+        return generation == symbolSearchGeneration &&
+            state.isSymbolMode &&
+            state.symbolQuery == query
     }
 
     fun loadFileContent(path: String) {
@@ -522,6 +663,7 @@ class FilesViewModel constructor(
     }
 
     companion object {
+        private const val FILE_SEARCH_DEBOUNCE_MS = 250L
         private const val MAX_PERSISTED_QUERY_CHARS = 1_024
         private const val MAX_PERSISTED_PATH_DEPTH = 128
         const val ROOT_PATH = ""
@@ -552,6 +694,8 @@ data class FilesUiState(
     val error: String? = null,
     val pathRestoreError: String? = null,
     val symbolError: String? = null,
+    val fileSearchError: String? = null,
+    val isFileSearchLoading: Boolean = false,
     val searchQuery: String = "",
     val isSearchActive: Boolean = false,
     val isSymbolMode: Boolean = false,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -346,7 +346,12 @@
     <string name="open_sub_agent">Open Sub-Agent</string>
     
     <!-- File Explorer Screen -->
-    <string name="files_search_placeholder">Search files…</string>
+    <string name="files_search_placeholder">Search workspace files…</string>
+    <string name="files_search_blank_hint">Search filenames across this workspace.</string>
+    <string name="files_search_loading">Searching workspace…</string>
+    <string name="files_search_failed">Could not search workspace files. Check the connection and try again.</string>
+    <string name="files_search_no_results">No files found in this workspace.</string>
+    <string name="files_search_result_description">%1$s, file in %2$s</string>
     <string name="files_workspace_global">Global workspace</string>
     <string name="files_breadcrumb_root">Workspace root</string>
     <string name="files_copy_path">Copy Path</string>
@@ -355,7 +360,7 @@
     <string name="files_type_folder">Folder</string>
     <string name="files_item_description">%1$s, %2$s, path %3$s</string>
     <string name="files_item_description_git">%1$s, %2$s, path %3$s, Git status %4$s</string>
-    <string name="files_no_matching_files">-- no matching files --</string>
+
     <string name="files_empty_folder">-- empty folder --</string>
     <string name="files_symbol_search_failed">Could not search symbols. Check the connection and try again.</string>
     <string name="files_restored_path_unavailable">Restored path is unavailable; showing workspace root.</string>

--- a/app/src/test/java/dev/blazelight/p4oc/data/files/WorkspaceFileRepositoryTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/data/files/WorkspaceFileRepositoryTest.kt
@@ -95,6 +95,78 @@ class WorkspaceFileRepositoryTest {
     }
 
     @Test
+    fun `searchFiles trims query and returns empty without a client call for blank query`() = runTest {
+        val client = FakeFileWorkspaceClient(searchPaths = listOf("src/Main.kt"))
+        val repository = WorkspaceFileRepository(client)
+
+        val blankResult = repository.searchFiles("   \t\n") as FileOperationResult.Ok
+        assertTrue(blankResult.data.isEmpty())
+        assertTrue(client.fileSearchQueries.isEmpty())
+
+        val result = repository.searchFiles("  Main  ") as FileOperationResult.Ok
+        assertEquals(listOf("Main"), client.fileSearchQueries)
+        assertEquals(listOf("src/Main.kt"), result.data.map { it.path })
+    }
+
+    @Test
+    fun `searchFiles preserves relevance order and maps paths to file nodes`() = runTest {
+        val client = FakeFileWorkspaceClient(
+            searchPaths = listOf(
+                "feature/LeastAlphabetical.kt",
+                "app/src/MostRelevant.kt",
+                "README.md",
+            )
+        )
+        val repository = WorkspaceFileRepository(client)
+
+        val result = repository.searchFiles("kt") as FileOperationResult.Ok
+
+        assertEquals(
+            listOf("feature/LeastAlphabetical.kt", "app/src/MostRelevant.kt", "README.md"),
+            result.data.map { it.path },
+        )
+        assertEquals(listOf("LeastAlphabetical.kt", "MostRelevant.kt", "README.md"), result.data.map { it.name })
+        assertTrue(result.data.all { it.type == "file" })
+    }
+
+    @Test
+    fun `searchFiles normalizes and deduplicates paths while discarding unsafe and root results`() = runTest {
+        val client = FakeFileWorkspaceClient(
+            searchPaths = listOf(
+                "src//./Main.kt",
+                "../secret.txt",
+                "src/Main.kt",
+                ".",
+                "/absolute.txt",
+                "safe/../escape.txt",
+                "src//Second.kt",
+                "https://example.com/file.kt",
+                "~/.private",
+                " / ",
+            )
+        )
+        val repository = WorkspaceFileRepository(client)
+
+        val result = repository.searchFiles("src") as FileOperationResult.Ok
+
+        assertEquals(listOf("src/Main.kt", "src/Second.kt"), result.data.map { it.path })
+    }
+
+    @Test
+    fun `searchFiles propagates client failure as human readable failed result`() = runTest {
+        val failure = IllegalStateException("file search unavailable")
+        val client = FakeFileWorkspaceClient().apply { searchFileFailure = failure }
+        val repository = WorkspaceFileRepository(client)
+
+        val result = repository.searchFiles("Main")
+
+        assertTrue(result is FileOperationResult.Failed)
+        result as FileOperationResult.Failed
+        assertEquals("file search unavailable", result.message)
+        assertEquals(failure, result.cause)
+    }
+
+    @Test
     fun `searchSymbols trims query and returns empty for blank query`() = runTest {
         val client = FakeFileWorkspaceClient(symbols = listOf(symbolDto("Main")))
         val repository = WorkspaceFileRepository(client)
@@ -159,12 +231,15 @@ class WorkspaceFileRepositoryTest {
         var files: List<FileNodeDto> = emptyList(),
         var content: FileContentDto = FileContentDto(type = "text", content = ""),
         var statuses: List<FileStatusDto> = emptyList(),
+        var searchPaths: List<String> = emptyList(),
         var symbols: List<SymbolDto> = emptyList(),
         var filesFailure: Throwable? = null,
     ) : FileWorkspaceClient {
         var statusFailure: Throwable? = null
+        var searchFileFailure: Throwable? = null
         val listFilesPaths = mutableListOf<String>()
         val readFilePaths = mutableListOf<String>()
+        val fileSearchQueries = mutableListOf<String>()
         val searchQueries = mutableListOf<String>()
 
         override suspend fun listFiles(path: String): List<FileNodeDto> {
@@ -181,6 +256,12 @@ class WorkspaceFileRepositoryTest {
         override suspend fun getFileStatus(): List<FileStatusDto> {
             statusFailure?.let { throw it }
             return statuses
+        }
+
+        override suspend fun searchFiles(query: String): List<String> {
+            fileSearchQueries += query
+            searchFileFailure?.let { throw it }
+            return searchPaths
         }
 
         override suspend fun searchSymbols(query: String): List<SymbolDto> {

--- a/app/src/test/java/dev/blazelight/p4oc/data/files/ofish/OfishFileRepositoryTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/data/files/ofish/OfishFileRepositoryTest.kt
@@ -17,6 +17,7 @@ import dev.blazelight.p4oc.data.remote.dto.SessionDto
 import dev.blazelight.p4oc.data.remote.dto.ShellCommandRequest
 import dev.blazelight.p4oc.data.remote.dto.TimeDto
 import dev.blazelight.p4oc.domain.model.FileContent
+import dev.blazelight.p4oc.domain.model.FileNode
 import dev.blazelight.p4oc.domain.model.Symbol
 import dev.blazelight.p4oc.domain.server.ServerRef
 import dev.blazelight.p4oc.domain.workspace.Workspace
@@ -175,6 +176,9 @@ class OfishFileRepositoryTest {
             FileOperationResult.Ok(FileList(path, emptyList()))
 
         override suspend fun readFile(path: String): FileOperationResult<FileContent> = readResult
+
+        override suspend fun searchFiles(query: String): FileOperationResult<List<FileNode>> =
+            FileOperationResult.Ok(emptyList())
 
         override suspend fun searchSymbols(query: String): FileOperationResult<List<Symbol>> =
             FileOperationResult.Ok(emptyList())

--- a/app/src/test/java/dev/blazelight/p4oc/data/workspace/WorkspaceClientTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/data/workspace/WorkspaceClientTest.kt
@@ -156,6 +156,44 @@ class WorkspaceClientTest {
     }
 
     @Test
+    fun `file search forwards query and exact workspace file scope at server limit`() = runTest {
+        val api = mockk<OpenCodeApi>()
+        val expected = listOf("app/src/Main.kt", "README.md")
+        coEvery {
+            api.searchFiles(
+                query = "main",
+                directory = "/repo/exact-workspace",
+                workspace = null,
+                dirs = "false",
+                type = "file",
+                limit = 200,
+            )
+        } returns expected
+        val client = WorkspaceClient(
+            workspace = Workspace(
+                server = ServerRef.fromEndpointKey("http://test.local"),
+                directory = "/repo/exact-workspace",
+            ),
+            generation = ServerGeneration(1L),
+            apiProvider = ActiveServerApiProvider { _, _ -> api },
+            connectionState = MutableStateFlow(ConnectionState.Connected),
+        )
+
+        assertEquals(expected, client.searchFiles("main"))
+
+        coVerify(exactly = 1) {
+            api.searchFiles(
+                query = "main",
+                directory = "/repo/exact-workspace",
+                workspace = null,
+                dirs = "false",
+                type = "file",
+                limit = 200,
+            )
+        }
+    }
+
+    @Test
     fun `clients with identical session ids keep distinct api and connection authority`() = runTest {
         val firstApi = mockk<OpenCodeApi>()
         val secondApi = mockk<OpenCodeApi>()

--- a/app/src/test/java/dev/blazelight/p4oc/ui/screens/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/ui/screens/chat/ChatViewModelTest.kt
@@ -76,6 +76,7 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
@@ -906,6 +907,22 @@ class ChatViewModelTest {
         emitEvent(OpenCodeEvent.SessionStatusChanged("session-1", SessionStatus.Busy))
         flushMessages()
         assertNull(vm.uiState.value.runNotice)
+        assertTrue(vm.uiState.value.isBusy)
+    }
+
+    @Test
+    fun constructor_withImmediateRepositoryState_adoptsInitialStateWithoutCrash() = runTest {
+        val repo = SessionRepositoryImpl(
+            workspaceClient,
+            messageMapper,
+            dispatcher = StandardTestDispatcher(testScheduler),
+        )
+        repo.acceptEvent(OpenCodeEvent.SessionStatusChanged("session-1", SessionStatus.Busy))
+        assertTrue(repo.sessionUiState(SessionId("session-1")).value.status is SessionStatus.Busy)
+        Dispatchers.setMain(UnconfinedTestDispatcher(testScheduler))
+
+        val vm = createViewModel(repository = repo)
+
         assertTrue(vm.uiState.value.isBusy)
     }
 

--- a/app/src/test/java/dev/blazelight/p4oc/ui/screens/files/FilesViewModelEditTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/ui/screens/files/FilesViewModelEditTest.kt
@@ -10,6 +10,7 @@ import dev.blazelight.p4oc.data.files.FileUploadResult
 import dev.blazelight.p4oc.data.files.FileWriteRequest
 import dev.blazelight.p4oc.data.files.FileWriteResult
 import dev.blazelight.p4oc.domain.model.FileContent
+import dev.blazelight.p4oc.domain.model.FileNode
 import dev.blazelight.p4oc.domain.model.Symbol
 import dev.blazelight.p4oc.ui.screens.files.upload.UploadCoordinator
 import kotlinx.coroutines.CoroutineScope
@@ -289,7 +290,7 @@ class FilesViewModelEditTest {
         val recreated = FilesViewModel(repo, testUploadCoordinator(repo), savedStateHandle)
 
         assertEquals("src/main", recreated.uiState.value.currentPath)
-        assertTrue(recreated.uiState.value.isSearchActive)
+        assertFalse(recreated.uiState.value.isSearchActive)
         assertEquals("view", recreated.uiState.value.searchQuery)
         assertTrue(recreated.uiState.value.isSymbolMode)
         assertEquals("Main", recreated.uiState.value.symbolQuery)
@@ -374,6 +375,9 @@ class FilesViewModelEditTest {
 
         override suspend fun readFile(path: String): FileOperationResult<FileContent> =
             FileOperationResult.Ok(FileContent(content = content, hash = hash))
+
+        override suspend fun searchFiles(query: String): FileOperationResult<List<FileNode>> =
+            FileOperationResult.Ok(emptyList())
 
         override suspend fun searchSymbols(query: String): FileOperationResult<List<Symbol>> {
             symbolQueries += query

--- a/app/src/test/java/dev/blazelight/p4oc/ui/screens/files/FilesViewModelSearchTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/ui/screens/files/FilesViewModelSearchTest.kt
@@ -1,0 +1,423 @@
+package dev.blazelight.p4oc.ui.screens.files
+
+import androidx.lifecycle.SavedStateHandle
+import dev.blazelight.p4oc.data.files.FileCapabilities
+import dev.blazelight.p4oc.data.files.FileList
+import dev.blazelight.p4oc.data.files.FileOperationResult
+import dev.blazelight.p4oc.data.files.FileRepository
+import dev.blazelight.p4oc.data.files.FileUploadRequest
+import dev.blazelight.p4oc.data.files.FileUploadResult
+import dev.blazelight.p4oc.data.files.FileWriteRequest
+import dev.blazelight.p4oc.data.files.FileWriteResult
+import dev.blazelight.p4oc.domain.model.FileContent
+import dev.blazelight.p4oc.domain.model.FileNode
+import dev.blazelight.p4oc.domain.model.Symbol
+import dev.blazelight.p4oc.domain.model.SymbolRange
+import dev.blazelight.p4oc.ui.screens.files.upload.UploadCoordinator
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class FilesViewModelSearchTest {
+    private val dispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun rapidTypingDebouncesToOnlyTheLatestRepositoryCall() = runTest(dispatcher) {
+        val repository = FakeSearchRepository().apply {
+            fileSearchHandler = { query ->
+                FileOperationResult.Ok(listOf(fileNode("src/$query.kt")))
+            }
+        }
+        val viewModel = viewModel(repository)
+        runCurrent()
+
+        viewModel.setSearchActive(true)
+        viewModel.updateSearchQuery("old")
+        advanceTimeBy(200)
+        viewModel.updateSearchQuery("latest")
+
+        assertTrue(viewModel.uiState.value.isFileSearchLoading)
+        advanceTimeBy(249)
+        assertTrue(repository.fileSearchCalls.isEmpty())
+
+        advanceTimeBy(1)
+        runCurrent()
+
+        assertEquals(listOf("latest"), repository.fileSearchCalls)
+        assertEquals(listOf("src/latest.kt"), viewModel.fileSearchResults.value.map { it.path })
+        assertFalse(viewModel.uiState.value.isFileSearchLoading)
+        assertNull(viewModel.uiState.value.fileSearchError)
+    }
+
+    @Test
+    fun nonCooperativeFileSearchCannotOverwriteTheLatestResult() = runTest(dispatcher) {
+        var completeFirst: ((FileOperationResult<List<FileNode>>) -> Unit)? = null
+        val repository = FakeSearchRepository().apply {
+            fileSearchHandler = { query ->
+                if (query == "first") {
+                    suspendCoroutine { continuation ->
+                        completeFirst = { result -> continuation.resume(result) }
+                    }
+                } else {
+                    FileOperationResult.Ok(listOf(fileNode("second.kt")))
+                }
+            }
+        }
+        val viewModel = viewModel(repository)
+        runCurrent()
+        viewModel.setSearchActive(true)
+
+        viewModel.updateSearchQuery("first")
+        advanceTimeBy(250)
+        runCurrent()
+        assertEquals(listOf("first"), repository.fileSearchCalls)
+
+        viewModel.updateSearchQuery("second")
+        advanceTimeBy(250)
+        runCurrent()
+        assertEquals(listOf("first", "second"), repository.fileSearchCalls)
+        assertEquals(listOf("second.kt"), viewModel.fileSearchResults.value.map { it.path })
+
+        checkNotNull(completeFirst).invoke(FileOperationResult.Ok(listOf(fileNode("stale.kt"))))
+        runCurrent()
+
+        assertEquals(listOf("second.kt"), viewModel.fileSearchResults.value.map { it.path })
+        assertFalse(viewModel.uiState.value.isFileSearchLoading)
+    }
+
+    @Test
+    fun nonCooperativeSymbolSearchCannotOverwriteTheLatestResultOrError() = runTest(dispatcher) {
+        var completeFirst: ((FileOperationResult<List<Symbol>>) -> Unit)? = null
+        val repository = FakeSearchRepository().apply {
+            symbolSearchHandler = { query ->
+                if (query == "First") {
+                    suspendCoroutine { continuation ->
+                        completeFirst = { result -> continuation.resume(result) }
+                    }
+                } else {
+                    FileOperationResult.Ok(listOf(symbol("Second")))
+                }
+            }
+        }
+        val viewModel = viewModel(repository)
+        runCurrent()
+        viewModel.setSymbolMode(true)
+
+        viewModel.updateSymbolQuery("First")
+        runCurrent()
+        assertEquals(listOf("First"), repository.symbolSearchCalls)
+
+        viewModel.updateSymbolQuery("Second")
+        runCurrent()
+        assertEquals(listOf("First", "Second"), repository.symbolSearchCalls)
+        assertEquals(listOf("Second"), viewModel.symbolResults.value.map { it.name })
+
+        checkNotNull(completeFirst).invoke(FileOperationResult.Failed("stale failure"))
+        runCurrent()
+
+        assertEquals(listOf("Second"), viewModel.symbolResults.value.map { it.name })
+        assertNull(viewModel.uiState.value.symbolError)
+    }
+
+    @Test
+    fun blankQueryClearsResultsAndErrorWithoutCallingRepository() = runTest(dispatcher) {
+        val repository = FakeSearchRepository().apply {
+            fileSearchHandler = { FileOperationResult.Ok(listOf(fileNode("match.kt"))) }
+        }
+        val viewModel = viewModel(repository)
+        runCurrent()
+        viewModel.setSearchActive(true)
+
+        viewModel.updateSearchQuery("match")
+        advanceTimeBy(250)
+        runCurrent()
+        assertEquals(listOf("match.kt"), viewModel.fileSearchResults.value.map { it.path })
+
+        viewModel.updateSearchQuery("   ")
+
+        assertTrue(viewModel.fileSearchResults.value.isEmpty())
+        assertFalse(viewModel.uiState.value.isFileSearchLoading)
+        assertNull(viewModel.uiState.value.fileSearchError)
+        assertEquals(listOf("match"), repository.fileSearchCalls)
+
+        repository.fileSearchHandler = { FileOperationResult.Failed("offline") }
+        viewModel.updateSearchQuery("failure")
+        advanceTimeBy(250)
+        runCurrent()
+        assertEquals("offline", viewModel.uiState.value.fileSearchError)
+
+        viewModel.updateSearchQuery("")
+
+        assertNull(viewModel.uiState.value.fileSearchError)
+        assertFalse(viewModel.uiState.value.isFileSearchLoading)
+        assertEquals(listOf("match", "failure"), repository.fileSearchCalls)
+    }
+
+    @Test
+    fun failedSearchEndsLoadingAndExposesTheFailure() = runTest(dispatcher) {
+        val repository = FakeSearchRepository().apply {
+            fileSearchHandler = { FileOperationResult.Failed("workspace unavailable") }
+        }
+        val viewModel = viewModel(repository)
+        runCurrent()
+        viewModel.setSearchActive(true)
+
+        viewModel.updateSearchQuery("needle")
+
+        assertTrue(viewModel.uiState.value.isFileSearchLoading)
+        assertNull(viewModel.uiState.value.fileSearchError)
+        assertTrue(viewModel.fileSearchResults.value.isEmpty())
+
+        advanceTimeBy(250)
+        runCurrent()
+
+        assertFalse(viewModel.uiState.value.isFileSearchLoading)
+        assertEquals("workspace unavailable", viewModel.uiState.value.fileSearchError)
+        assertTrue(viewModel.fileSearchResults.value.isEmpty())
+    }
+
+    @Test
+    fun refreshRerunsActiveFileSearchWithoutReloadingDirectory() = runTest(dispatcher) {
+        val repository = FakeSearchRepository().apply {
+            fileSearchHandler = { query ->
+                FileOperationResult.Ok(listOf(fileNode("$query-${fileSearchCalls.size}.kt")))
+            }
+        }
+        val viewModel = viewModel(repository)
+        runCurrent()
+        val initialDirectoryLoads = repository.listFilesCalls.size
+        viewModel.setSearchActive(true)
+
+        viewModel.updateSearchQuery("needle")
+        advanceTimeBy(250)
+        runCurrent()
+        assertEquals(listOf("needle-1.kt"), viewModel.fileSearchResults.value.map { it.path })
+
+        viewModel.refresh()
+        assertTrue(viewModel.uiState.value.isFileSearchLoading)
+        runCurrent()
+
+        assertEquals(listOf("needle", "needle"), repository.fileSearchCalls)
+        assertEquals(listOf("needle-2.kt"), viewModel.fileSearchResults.value.map { it.path })
+        assertEquals(initialDirectoryLoads, repository.listFilesCalls.size)
+    }
+
+    @Test
+    fun symbolModeCancelsFileSearchAndRefreshesOnlySymbols() = runTest(dispatcher) {
+        val repository = FakeSearchRepository().apply {
+            symbolSearchHandler = { query ->
+                FileOperationResult.Ok(listOf(symbol("$query-${symbolSearchCalls.size}")))
+            }
+        }
+        val viewModel = viewModel(repository)
+        runCurrent()
+        val initialDirectoryLoads = repository.listFilesCalls.size
+
+        viewModel.setSearchActive(true)
+        viewModel.updateSearchQuery("pending")
+        viewModel.setSymbolMode(true)
+        viewModel.updateSymbolQuery("Widget")
+        runCurrent()
+        advanceTimeBy(250)
+        runCurrent()
+
+        assertFalse(viewModel.uiState.value.isSearchActive)
+        assertTrue(viewModel.uiState.value.isSymbolMode)
+        assertTrue(repository.fileSearchCalls.isEmpty())
+        assertEquals(listOf("Widget"), repository.symbolSearchCalls)
+
+        viewModel.refresh()
+        runCurrent()
+
+        assertEquals(listOf("Widget", "Widget"), repository.symbolSearchCalls)
+        assertEquals(listOf("Widget-2"), viewModel.symbolResults.value.map { it.name })
+        assertEquals(initialDirectoryLoads, repository.listFilesCalls.size)
+
+        viewModel.setSearchActive(true)
+        assertTrue(viewModel.uiState.value.isSearchActive)
+        assertFalse(viewModel.uiState.value.isSymbolMode)
+        assertTrue(viewModel.symbolResults.value.isEmpty())
+        viewModel.clearFilters()
+    }
+
+    @Test
+    fun clearFiltersCancelsPendingWorkAndResetsBothSearchModes() = runTest(dispatcher) {
+        val repository = FakeSearchRepository().apply {
+            fileSearchHandler = { FileOperationResult.Ok(listOf(fileNode("ready.kt"))) }
+            symbolSearchHandler = { FileOperationResult.Ok(listOf(symbol("ReadySymbol"))) }
+        }
+        val viewModel = viewModel(repository)
+        runCurrent()
+
+        viewModel.setSearchActive(true)
+        viewModel.updateSearchQuery("ready")
+        advanceTimeBy(250)
+        runCurrent()
+        assertTrue(viewModel.fileSearchResults.value.isNotEmpty())
+
+        viewModel.clearFilters()
+        assertSearchStateCleared(viewModel)
+
+        viewModel.setSymbolMode(true)
+        viewModel.updateSymbolQuery("ReadySymbol")
+        runCurrent()
+        assertTrue(viewModel.symbolResults.value.isNotEmpty())
+
+        viewModel.clearFilters()
+        assertSearchStateCleared(viewModel)
+
+        viewModel.setSearchActive(true)
+        viewModel.updateSearchQuery("cancelled-before-debounce")
+        viewModel.clearFilters()
+        advanceTimeBy(250)
+        runCurrent()
+
+        assertEquals(listOf("ready"), repository.fileSearchCalls)
+        assertSearchStateCleared(viewModel)
+    }
+
+    @Test
+    fun restoredActiveFileQueryIsSearchedAfterDebounce() = runTest(dispatcher) {
+        val repository = FakeSearchRepository().apply {
+            fileSearchHandler = { query ->
+                FileOperationResult.Ok(listOf(fileNode("restored/$query.kt")))
+            }
+        }
+        val savedStateHandle = SavedStateHandle(
+            mapOf(
+                FilesViewModel.KEY_SEARCH_ACTIVE to true,
+                FilesViewModel.KEY_SEARCH_QUERY to "needle",
+                FilesViewModel.KEY_SYMBOL_MODE to false,
+            )
+        )
+
+        val viewModel = viewModel(repository, savedStateHandle)
+        runCurrent()
+
+        assertTrue(viewModel.uiState.value.isSearchActive)
+        assertEquals("needle", viewModel.uiState.value.searchQuery)
+        assertTrue(viewModel.uiState.value.isFileSearchLoading)
+        advanceTimeBy(249)
+        assertTrue(repository.fileSearchCalls.isEmpty())
+
+        advanceTimeBy(1)
+        runCurrent()
+
+        assertEquals(listOf("needle"), repository.fileSearchCalls)
+        assertEquals(listOf("restored/needle.kt"), viewModel.fileSearchResults.value.map { it.path })
+        assertFalse(viewModel.uiState.value.isFileSearchLoading)
+    }
+
+    private fun viewModel(
+        repository: FileRepository,
+        savedStateHandle: SavedStateHandle = SavedStateHandle(),
+    ) = FilesViewModel(
+        fileRepository = repository,
+        uploadCoordinator = UploadCoordinator(
+            scope = CoroutineScope(Dispatchers.Main),
+            repositoryFactory = { repository },
+        ),
+        savedStateHandle = savedStateHandle,
+    )
+
+    private fun assertSearchStateCleared(viewModel: FilesViewModel) {
+        val state = viewModel.uiState.value
+        assertFalse(state.isSearchActive)
+        assertFalse(state.isSymbolMode)
+        assertEquals("", state.searchQuery)
+        assertEquals("", state.symbolQuery)
+        assertFalse(state.isFileSearchLoading)
+        assertNull(state.fileSearchError)
+        assertNull(state.symbolError)
+        assertTrue(viewModel.fileSearchResults.value.isEmpty())
+        assertTrue(viewModel.symbolResults.value.isEmpty())
+    }
+
+    private class FakeSearchRepository : FileRepository {
+        val listFilesCalls = mutableListOf<String>()
+        val fileSearchCalls = mutableListOf<String>()
+        val symbolSearchCalls = mutableListOf<String>()
+        var fileSearchHandler: suspend (String) -> FileOperationResult<List<FileNode>> = {
+            FileOperationResult.Ok(emptyList())
+        }
+        var symbolSearchHandler: suspend (String) -> FileOperationResult<List<Symbol>> = {
+            FileOperationResult.Ok(emptyList())
+        }
+
+        override suspend fun listFiles(path: String): FileOperationResult<FileList> {
+            listFilesCalls += path
+            return FileOperationResult.Ok(FileList(path, emptyList()))
+        }
+
+        override suspend fun readFile(path: String): FileOperationResult<FileContent> =
+            FileOperationResult.Ok(FileContent(content = ""))
+
+        override suspend fun searchFiles(query: String): FileOperationResult<List<FileNode>> {
+            fileSearchCalls += query
+            return fileSearchHandler(query)
+        }
+
+        override suspend fun searchSymbols(query: String): FileOperationResult<List<Symbol>> {
+            symbolSearchCalls += query
+            return symbolSearchHandler(query)
+        }
+
+        override suspend fun writeFile(request: FileWriteRequest): FileOperationResult<FileWriteResult> =
+            FileOperationResult.Ok(FileWriteResult(request.path))
+
+        override suspend fun createDirectory(path: String): FileOperationResult<Unit> =
+            FileOperationResult.Ok(Unit)
+
+        override suspend fun renameFile(fromPath: String, toPath: String): FileOperationResult<Unit> =
+            FileOperationResult.Ok(Unit)
+
+        override suspend fun deleteFile(path: String): FileOperationResult<Unit> =
+            FileOperationResult.Ok(Unit)
+
+        override suspend fun uploadFile(request: FileUploadRequest): FileOperationResult<FileUploadResult> =
+            FileOperationResult.Ok(FileUploadResult(request.path))
+
+        override suspend fun capabilities(): FileCapabilities = FileCapabilities()
+    }
+
+    private companion object {
+        fun fileNode(path: String) = FileNode(
+            name = path.substringAfterLast('/'),
+            path = path,
+            type = "file",
+        )
+
+        fun symbol(name: String) = Symbol(
+            name = name,
+            kind = 12,
+            uri = "file:///src/$name.kt",
+            range = SymbolRange(0, 0, 0, 1),
+        )
+    }
+}

--- a/app/src/test/java/dev/blazelight/p4oc/ui/screens/files/upload/UploadOrchestratorTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/ui/screens/files/upload/UploadOrchestratorTest.kt
@@ -11,6 +11,7 @@ import dev.blazelight.p4oc.data.files.FileWriteResult
 import dev.blazelight.p4oc.data.files.ofish.MAX_UPLOAD_SOURCE_BYTES
 import dev.blazelight.p4oc.data.files.ofish.UPLOAD_TOO_LARGE_MESSAGE
 import dev.blazelight.p4oc.domain.model.FileContent
+import dev.blazelight.p4oc.domain.model.FileNode
 import dev.blazelight.p4oc.domain.model.Symbol
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -342,6 +343,8 @@ private class FakeFileRepository(
         FileOperationResult.Ok(FileList(path = path, files = emptyList()))
     override suspend fun readFile(path: String) =
         FileOperationResult.Ok(FileContent(type = "text", content = "", diff = null, mimeType = null))
+    override suspend fun searchFiles(query: String) =
+        FileOperationResult.Ok<List<FileNode>>(emptyList())
     override suspend fun searchSymbols(query: String) =
         FileOperationResult.Ok<List<Symbol>>(emptyList())
     override suspend fun writeFile(request: FileWriteRequest) =
@@ -374,6 +377,7 @@ private class GatedFileRepository : FileRepository {
     override suspend fun listFiles(path: String) = FileOperationResult.Ok(FileList(path, emptyList()))
     override suspend fun readFile(path: String) =
         FileOperationResult.Ok(FileContent(type = "text", content = "", diff = null, mimeType = null))
+    override suspend fun searchFiles(query: String) = FileOperationResult.Ok<List<FileNode>>(emptyList())
     override suspend fun searchSymbols(query: String) = FileOperationResult.Ok<List<Symbol>>(emptyList())
     override suspend fun writeFile(request: FileWriteRequest) =
         FileOperationResult.Ok(FileWriteResult(path = request.path, hash = null))


### PR DESCRIPTION
## Summary
- route filename search through the exact tab-owned workspace client and repository
- add debounced, cancellation-safe file-search state with stale-result generation guards
- render dedicated loading, error, empty, and compact result states that open the exact matched path
- fix ChatViewModel initialization order uncovered during physical smoke testing

## Server compatibility
- send both `dirs=false` (legacy files-only selector) and `type=file` (current selector)
- current OpenCode accepts both; when `type` is present it is authoritative, while older servers can use `dirs`
- workspace symbol search is pre-existing and unchanged by this PR

## Verification
- `./gradlew :app:compileDebugKotlin :app:detekt :app:testDebugUnitTest --rerun-tasks`
- installed the final build on Samsung SM-A155F (`R58X70XHB9P`)
- connected to a real OpenCode server rooted at this worktree
- exact `/find/file` request with `dirs=false&type=file&limit=200` returned `app/src/main/java/dev/blazelight/p4oc/ui/screens/files/FileExplorerScreen.kt`
- searched for `FileExplorerScreen` in-app and opened that exact file
- crash buffer remained empty after the complete journey