### PR TITLE
fix: bound legacy question fallback

### DIFF
--- a/app/src/main/java/dev/blazelight/p4oc/core/network/OpenCodeApi.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/core/network/OpenCodeApi.kt
@@ -1,6 +1,7 @@
 package dev.blazelight.p4oc.core.network
 
 import dev.blazelight.p4oc.data.remote.dto.*
+import okhttp3.ResponseBody
 import retrofit2.Response
 import retrofit2.http.*
 
@@ -258,20 +259,20 @@ interface OpenCodeApi {
         @Body request: QuestionReplyRequest,
         @Query("directory") directory: String?,
         @Query("workspace") workspace: String?
-    ): Response<Boolean>
+    ): Response<ResponseBody>
 
     @POST("question/{requestId}/reject")
     suspend fun rejectQuestion(
         @Path("requestId") requestId: String,
         @Query("directory") directory: String?,
         @Query("workspace") workspace: String?
-    ): Response<Boolean>
+    ): Response<ResponseBody>
 
     @GET("question")
     suspend fun listPendingQuestions(
         @Query("directory") directory: String?,
         @Query("workspace") workspace: String?
-    ): Response<List<QuestionRequestDto>>
+    ): Response<ResponseBody>
 
     @GET("command")
     suspend fun listCommands(

--- a/app/src/main/java/dev/blazelight/p4oc/data/session/SessionRepositoryProvider.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/data/session/SessionRepositoryProvider.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
+import kotlinx.serialization.json.Json
 
 class SessionRepositoryProvider(
     private val activeServerApiProvider: ActiveServerApiProvider,
@@ -24,6 +25,7 @@ class SessionRepositoryProvider(
     private val serverConnectionRegistry: ServerConnectionRegistry,
     private val dispatcher: CoroutineDispatcher = Dispatchers.Default,
     private val repositoryDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val json: Json = Json.Default,
 ) {
     data class Lease(
         val workspaceClient: WorkspaceClient,
@@ -59,6 +61,7 @@ class SessionRepositoryProvider(
                 generation = generation,
                 apiProvider = activeServerApiProvider,
                 connectionState = serverConnectionRegistry.connectionState(workspace.server, generation),
+                json = json,
             )
             val repository = SessionRepositoryImpl(
                 workspaceClient,

--- a/app/src/main/java/dev/blazelight/p4oc/data/workspace/WorkspaceClient.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/data/workspace/WorkspaceClient.kt
@@ -42,7 +42,9 @@ import dev.blazelight.p4oc.data.server.ActiveServerApiProvider
 import dev.blazelight.p4oc.domain.server.ServerGeneration
 import dev.blazelight.p4oc.domain.workspace.Workspace
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.serialization.SerializationException
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import okhttp3.ResponseBody
 
 import retrofit2.HttpException
 import java.io.IOException
@@ -52,6 +54,7 @@ class WorkspaceClient(
     val generation: ServerGeneration,
     private val apiProvider: ActiveServerApiProvider,
     val connectionState: StateFlow<ConnectionState>,
+    private val json: Json = Json.Default,
 ) : SessionWorkspaceClient {
     private val api: OpenCodeApi
         get() = apiProvider.apiFor(workspace.server, generation)
@@ -189,38 +192,31 @@ class WorkspaceClient(
         requestId: String,
         request: QuestionReplyRequest,
     ): Boolean {
-        try {
-            val legacy = api.respondToQuestion(requestId, request, directory, workspace = null)
-            if (legacy.isUsableQuestionResponse()) return legacy.body() == true
-            if (!legacy.isUnavailableQuestionEndpoint()) throw HttpException(legacy)
-        } catch (_: SerializationException) {
-            // Matches the bounded HTML-route endpoint-unavailable behavior used by question endpoints.
+        val legacy = api.respondToQuestion(requestId, request, directory, workspace = null)
+        when (legacy.classifyLegacyQuestionResponse()) {
+            LegacyQuestionResponseDisposition.Decode -> return legacy.decodeLegacyBoolean()
+            LegacyQuestionResponseDisposition.Fallback -> Unit
         }
 
         return api.respondToQuestionV2(sessionId, requestId, request).requireUsableV2Response()
     }
 
     suspend fun rejectQuestion(sessionId: String, requestId: String): Boolean {
-        try {
-            val legacy = api.rejectQuestion(requestId, directory, workspace = null)
-            if (legacy.isUsableQuestionResponse()) return legacy.body() == true
-            if (!legacy.isUnavailableQuestionEndpoint()) throw HttpException(legacy)
-        } catch (_: SerializationException) {
-            // Matches the bounded HTML-route endpoint-unavailable behavior used by question endpoints.
+        val legacy = api.rejectQuestion(requestId, directory, workspace = null)
+        when (legacy.classifyLegacyQuestionResponse()) {
+            LegacyQuestionResponseDisposition.Decode -> return legacy.decodeLegacyBoolean()
+            LegacyQuestionResponseDisposition.Fallback -> Unit
         }
 
         return api.rejectQuestionV2(sessionId, requestId).requireUsableV2Response()
     }
 
     override suspend fun listSessionQuestions(sessionId: String): List<QuestionRequestDto> {
-        try {
-            val legacy = api.listPendingQuestions(directory, workspace = null)
-            if (legacy.isUsableQuestionResponse()) {
-                return legacy.body().orEmpty().filter { it.sessionID == sessionId }
-            }
-            if (!legacy.isUnavailableQuestionEndpoint()) throw HttpException(legacy)
-        } catch (_: SerializationException) {
-            // Matches the bounded HTML-route endpoint-unavailable behavior used by question endpoints.
+        val legacy = api.listPendingQuestions(directory, workspace = null)
+        when (legacy.classifyLegacyQuestionResponse()) {
+            LegacyQuestionResponseDisposition.Decode ->
+                return legacy.decodeLegacyQuestions().filter { it.sessionID == sessionId }
+            LegacyQuestionResponseDisposition.Fallback -> Unit
         }
 
         val response = api.listSessionQuestionsV2(sessionId)
@@ -228,20 +224,59 @@ class WorkspaceClient(
         return response.body()?.data.orEmpty()
     }
 
-    suspend fun listPendingQuestions(): List<QuestionRequestDto> =
-        api.listPendingQuestions(directory, workspace = null).let { response ->
-            if (!response.isUsableQuestionResponse()) throw HttpException(response)
-            response.body().orEmpty()
+    suspend fun listPendingQuestions(): List<QuestionRequestDto> {
+        val response = api.listPendingQuestions(directory, workspace = null)
+        return when (response.classifyLegacyQuestionResponse()) {
+            LegacyQuestionResponseDisposition.Decode -> response.decodeLegacyQuestions()
+            LegacyQuestionResponseDisposition.Fallback -> throw HttpException(response)
         }
+    }
 
     private fun retrofit2.Response<*>.isUsableV2Response(): Boolean =
         isSuccessful && !headers()["Content-Type"].orEmpty().startsWith("text/html")
 
-    private fun retrofit2.Response<*>.isUsableQuestionResponse(): Boolean =
-        isSuccessful && !headers()["Content-Type"].orEmpty().startsWith("text/html")
+    private enum class LegacyQuestionResponseDisposition { Decode, Fallback }
 
-    private fun retrofit2.Response<*>.isUnavailableQuestionEndpoint(): Boolean =
-        code() == 404 || headers()["Content-Type"].orEmpty().startsWith("text/html")
+    private fun retrofit2.Response<ResponseBody>.classifyLegacyQuestionResponse():
+        LegacyQuestionResponseDisposition = when {
+        code() == 404 -> {
+            closeLegacyQuestionBodies()
+            LegacyQuestionResponseDisposition.Fallback
+        }
+        !isSuccessful -> {
+            closeLegacyQuestionBodies()
+            throw HttpException(this)
+        }
+        isSuccessfulHtmlQuestionResponse() -> {
+            closeLegacyQuestionBodies()
+            LegacyQuestionResponseDisposition.Fallback
+        }
+        else -> LegacyQuestionResponseDisposition.Decode
+    }
+
+    private fun retrofit2.Response<ResponseBody>.isSuccessfulHtmlQuestionResponse(): Boolean =
+        isSuccessful && (
+            headers()["Content-Type"].isHtmlContentType() ||
+                body()?.contentType()?.toString().isHtmlContentType()
+            )
+
+    private fun String?.isHtmlContentType(): Boolean =
+        this?.substringBefore(';')?.trim()?.equals("text/html", ignoreCase = true) == true
+
+    private fun retrofit2.Response<ResponseBody>.closeLegacyQuestionBodies() {
+        body()?.close()
+        errorBody()?.close()
+    }
+
+    private fun retrofit2.Response<ResponseBody>.decodeLegacyBoolean(): Boolean {
+        val content = body()?.string() ?: return false
+        return json.decodeFromString<Boolean?>(content) == true
+    }
+
+    private fun retrofit2.Response<ResponseBody>.decodeLegacyQuestions(): List<QuestionRequestDto> {
+        val content = body()?.string() ?: return emptyList()
+        return json.decodeFromString<List<QuestionRequestDto>?>(content).orEmpty()
+    }
 
     private fun retrofit2.Response<Unit>.requireUsableV2Response(): Boolean {
         if (!isUsableV2Response()) throw HttpException(this)

--- a/app/src/main/java/dev/blazelight/p4oc/di/KoinModules.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/di/KoinModules.kt
@@ -99,7 +99,7 @@ val networkModule = module {
             )
         }
     }
-    single { SessionRepositoryProvider(get(), get(), get()) }
+    single { SessionRepositoryProvider(get(), get(), get(), json = get()) }
 }
 
 val viewModelModule = module {

--- a/app/src/test/java/dev/blazelight/p4oc/data/session/SessionRepositoryProviderTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/data/session/SessionRepositoryProviderTest.kt
@@ -38,11 +38,15 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotSame
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import retrofit2.Response
 
 class SessionRepositoryProviderTest {
     private val server = ServerRef.fromEndpointKey("http://fake.test")
@@ -130,6 +134,7 @@ class SessionRepositoryProviderTest {
         fun provider(
             scopedEvents: Flow<ScopedEvent> = this.scopedEvents,
             dispatcher: CoroutineDispatcher = StandardTestDispatcher(),
+            json: Json = Json.Default,
         ): SessionRepositoryProvider {
             // Ensure the default (server, generation) binding exists so a relaxed registry mock
             // never returns Nothing for connectionEpoch/connectionState.
@@ -144,7 +149,45 @@ class SessionRepositoryProviderTest {
                 serverConnectionRegistry = registry,
                 dispatcher = dispatcher,
                 repositoryDispatcher = dispatcher,
+                json = json,
             )
+        }
+    }
+
+    @Test
+    fun `provider forwards configured json to workspace client legacy question decoding`() = runTest {
+        val harness = harness()
+        val bound = harness.bind()
+        val provider = harness.provider(json = Json { ignoreUnknownKeys = true })
+        val response = """
+            [
+              {
+                "id": "question-1",
+                "sessionID": "session-1",
+                "questions": [
+                  {
+                    "header": "Confirm",
+                    "question": "Continue?",
+                    "options": [],
+                    "unknownQuestionField": "ignored"
+                  }
+                ],
+                "unknownRequestField": "ignored"
+              }
+            ]
+        """.trimIndent()
+        coEvery { bound.api.listPendingQuestions("/repo", null) } returns Response.success(
+            response.toResponseBody("application/json".toMediaType()),
+        )
+
+        val lease = provider.acquire(workspace, generation)
+        try {
+            val questions = lease.workspaceClient.listSessionQuestions("session-1")
+
+            assertEquals(listOf("question-1"), questions.map { it.id })
+            assertEquals("Continue?", questions.single().questions.single().question)
+        } finally {
+            provider.release(workspace, generation)
         }
     }
 

--- a/app/src/test/java/dev/blazelight/p4oc/data/workspace/WorkspaceClientTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/data/workspace/WorkspaceClientTest.kt
@@ -18,12 +18,16 @@ import dev.blazelight.p4oc.domain.server.ServerRef
 import dev.blazelight.p4oc.domain.workspace.Workspace
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.ResponseBody
 import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.Assert.assertEquals
 import org.junit.Assert.fail
@@ -53,9 +57,10 @@ class WorkspaceClientTest {
         val question = questionRequest("ses_1")
         val otherQuestion = questionRequest("ses_other")
         val reply = QuestionReplyRequest(listOf(listOf("Yes")))
-        coEvery { api.listPendingQuestions("/repo", null) } returns Response.success(listOf(question, otherQuestion))
-        coEvery { api.respondToQuestion("que_1", reply, "/repo", null) } returns Response.success(true)
-        coEvery { api.rejectQuestion("que_1", "/repo", null) } returns Response.success(true)
+        coEvery { api.listPendingQuestions("/repo", null) } returns
+            jsonResponse(Json.Default.encodeToString(listOf(question, otherQuestion)))
+        coEvery { api.respondToQuestion("que_1", reply, "/repo", null) } returns jsonResponse("true")
+        coEvery { api.rejectQuestion("que_1", "/repo", null) } returns jsonResponse("true")
         val client = questionClient(api)
 
         assertEquals(listOf(question), client.listSessionQuestions("ses_1"))
@@ -90,6 +95,87 @@ class WorkspaceClientTest {
     }
 
     @Test
+    fun `question operations fall back for successful legacy html responses`() = runTest {
+        val api = mockk<OpenCodeApi>()
+        val question = questionRequest("ses_1")
+        val reply = QuestionReplyRequest(listOf(listOf("Yes")))
+        coEvery { api.listPendingQuestions("/repo", null) } returns htmlSuccessFromBodyContentType()
+        coEvery { api.respondToQuestion("que_1", reply, "/repo", null) } returns htmlSuccessFromHeader()
+        coEvery { api.rejectQuestion("que_1", "/repo", null) } returns htmlSuccessFromBodyContentType()
+        coEvery { api.listSessionQuestionsV2("ses_1") } returns
+            Response.success(QuestionV2RequestListResponseDto(listOf(question)))
+        coEvery { api.respondToQuestionV2("ses_1", "que_1", reply) } returns Response.success(Unit)
+        coEvery { api.rejectQuestionV2("ses_1", "que_1") } returns Response.success(Unit)
+        val client = questionClient(api)
+
+        assertEquals(listOf(question), client.listSessionQuestions("ses_1"))
+        assertEquals(true, client.respondToQuestion("ses_1", "que_1", reply))
+        assertEquals(true, client.rejectQuestion("ses_1", "que_1"))
+
+        coVerify(exactly = 1) { api.listSessionQuestionsV2("ses_1") }
+        coVerify(exactly = 1) { api.respondToQuestionV2("ses_1", "que_1", reply) }
+        coVerify(exactly = 1) { api.rejectQuestionV2("ses_1", "que_1") }
+    }
+
+    @Test
+    fun `terminal legacy routing closes fallback and error bodies`() = runTest {
+        val api = mockk<OpenCodeApi>()
+        val reply = QuestionReplyRequest(listOf(listOf("Yes")))
+        val notFoundBody = mockk<ResponseBody>(relaxed = true)
+        val successfulHtmlBody = mockk<ResponseBody>(relaxed = true)
+        val serverErrorBody = mockk<ResponseBody>(relaxed = true)
+        every { successfulHtmlBody.contentType() } returns "text/html".toMediaType()
+        every { serverErrorBody.contentType() } returns "text/html".toMediaType()
+        coEvery { api.respondToQuestion("que_1", reply, "/repo", null) } returns
+            Response.error(404, notFoundBody)
+        coEvery { api.respondToQuestionV2("ses_1", "que_1", reply) } returns Response.success(Unit)
+        coEvery { api.rejectQuestion("que_1", "/repo", null) } returns Response.success(successfulHtmlBody)
+        coEvery { api.rejectQuestionV2("ses_1", "que_1") } returns Response.success(Unit)
+        coEvery { api.listPendingQuestions("/repo", null) } returns Response.error(500, serverErrorBody)
+        val client = questionClient(api)
+
+        assertEquals(true, client.respondToQuestion("ses_1", "que_1", reply))
+        assertEquals(true, client.rejectQuestion("ses_1", "que_1"))
+        assertHttpError(500) { client.listSessionQuestions("ses_1") }
+
+        verify(exactly = 1) { notFoundBody.close() }
+        verify(exactly = 1) { successfulHtmlBody.close() }
+        verify(exactly = 1) { serverErrorBody.close() }
+    }
+
+    @Test
+    fun `direct pending question html closes body before throwing`() = runTest {
+        val api = mockk<OpenCodeApi>()
+        val successfulHtmlBody = mockk<ResponseBody>(relaxed = true)
+        every { successfulHtmlBody.contentType() } returns "text/html".toMediaType()
+        coEvery { api.listPendingQuestions("/repo", null) } returns Response.success(successfulHtmlBody)
+        val client = questionClient(api)
+
+        assertHttpError(200) { client.listPendingQuestions() }
+
+        verify(exactly = 1) { successfulHtmlBody.close() }
+        coVerify(exactly = 0) { api.listSessionQuestionsV2(any()) }
+    }
+
+    @Test
+    fun `question legacy null values preserve empty and false semantics`() = runTest {
+        val api = mockk<OpenCodeApi>()
+        val reply = QuestionReplyRequest(listOf(listOf("Yes")))
+        coEvery { api.listPendingQuestions("/repo", null) } returns jsonResponse("null")
+        coEvery { api.respondToQuestion("que_1", reply, "/repo", null) } returns jsonResponse("false")
+        coEvery { api.rejectQuestion("que_1", "/repo", null) } returns jsonResponse("null")
+        val client = questionClient(api)
+
+        assertEquals(emptyList<QuestionRequestDto>(), client.listSessionQuestions("ses_1"))
+        assertEquals(false, client.respondToQuestion("ses_1", "que_1", reply))
+        assertEquals(false, client.rejectQuestion("ses_1", "que_1"))
+
+        coVerify(exactly = 0) { api.listSessionQuestionsV2(any()) }
+        coVerify(exactly = 0) { api.respondToQuestionV2(any(), any(), any()) }
+        coVerify(exactly = 0) { api.rejectQuestionV2(any(), any()) }
+    }
+
+    @Test
     fun `question legacy http errors propagate without v2 fallback`() = runTest {
         val api = mockk<OpenCodeApi>()
         val reply = QuestionReplyRequest(listOf(listOf("Yes")))
@@ -107,6 +193,40 @@ class WorkspaceClientTest {
 
         coVerify(exactly = 0) { api.respondToQuestionV2(any(), any(), any()) }
         coVerify(exactly = 0) { api.rejectQuestionV2(any(), any()) }
+        coVerify(exactly = 0) { api.listSessionQuestionsV2(any()) }
+    }
+
+    @Test
+    fun `question legacy html server errors propagate without v2 fallback`() = runTest {
+        val api = mockk<OpenCodeApi>()
+        val reply = QuestionReplyRequest(listOf(listOf("Yes")))
+        coEvery { api.respondToQuestion("que_1", reply, "/repo", null) } returns htmlServerError()
+        coEvery { api.rejectQuestion("que_1", "/repo", null) } returns htmlServerError()
+        coEvery { api.listPendingQuestions("/repo", null) } returns htmlServerError()
+        val client = questionClient(api)
+
+        assertHttpError(500) { client.respondToQuestion("ses_1", "que_1", reply) }
+        assertHttpError(500) { client.rejectQuestion("ses_1", "que_1") }
+        assertHttpError(500) { client.listSessionQuestions("ses_1") }
+
+        coVerify(exactly = 0) { api.respondToQuestionV2(any(), any(), any()) }
+        coVerify(exactly = 0) { api.rejectQuestionV2(any(), any()) }
+        coVerify(exactly = 0) { api.listSessionQuestionsV2(any()) }
+    }
+
+    @Test
+    fun `question malformed successful json propagates without v2 fallback`() = runTest {
+        val api = mockk<OpenCodeApi>()
+        coEvery { api.listPendingQuestions("/repo", null) } returns jsonResponse("{malformed")
+        val client = questionClient(api)
+
+        try {
+            client.listSessionQuestions("ses_1")
+            fail("Expected malformed legacy JSON to fail")
+        } catch (_: SerializationException) {
+            // Expected from decoding the raw successful legacy body.
+        }
+
         coVerify(exactly = 0) { api.listSessionQuestionsV2(any()) }
     }
 
@@ -288,6 +408,29 @@ class WorkspaceClientTest {
         } catch (error: HttpException) {
             assertEquals(code, error.code())
         }
+    }
+
+    private fun jsonResponse(content: String): Response<ResponseBody> =
+        Response.success(content.toResponseBody("application/json".toMediaType()))
+
+    private fun htmlSuccessFromBodyContentType(): Response<ResponseBody> =
+        Response.success("<html>Legacy route</html>".toResponseBody("text/html".toMediaType()))
+
+    private fun htmlSuccessFromHeader(): Response<ResponseBody> {
+        val body = "<html>Legacy route</html>".toResponseBody(null)
+        val rawResponse = okhttp3.Response.Builder()
+            .request(okhttp3.Request.Builder().url("http://test.local").build())
+            .protocol(okhttp3.Protocol.HTTP_1_1)
+            .code(200)
+            .message("OK")
+            .header("Content-Type", "Text/HTML; charset=utf-8")
+            .build()
+        return Response.success(body, rawResponse)
+    }
+
+    private fun htmlServerError(): Response<ResponseBody> {
+        val mediaType = "text/html".toMediaType()
+        return Response.error(500, "<html>Server error</html>".toResponseBody(mediaType))
     }
 
     private fun questionRequest(sessionId: String) = QuestionRequestDto(


### PR DESCRIPTION
## Summary
- classify legacy question responses before JSON decoding
- fall back to v2 only for HTTP 404 or successful HTML route responses
- propagate other HTTP failures and malformed JSON without an unsafe retry
- close raw response bodies on every fallback and error path
- forward the production Json configuration through workspace clients

## Regression coverage
- HTML HTTP 500 never falls back
- malformed successful JSON never falls back
- HTTP 404 and successful HTML still fall back
- raw response bodies close on fallback and error paths
- provider forwards configured Json decoding behavior

## Verification
- `./gradlew :app:testDebugUnitTest --tests dev.blazelight.p4oc.data.workspace.WorkspaceClientTest --tests dev.blazelight.p4oc.data.session.SessionRepositoryProviderTest`
- `./gradlew :app:compileDebugKotlin :app:detekt :app:testDebugUnitTest`
- independent Sol review: SHIP