### PR TITLE
Render chat image attachments safely

### DIFF
--- a/app/src/androidTest/java/dev/blazelight/p4oc/ui/components/chat/ChatAttachmentPresentationTest.kt
+++ b/app/src/androidTest/java/dev/blazelight/p4oc/ui/components/chat/ChatAttachmentPresentationTest.kt
@@ -1,0 +1,340 @@
+package dev.blazelight.p4oc.ui.components.chat
+
+import android.graphics.Bitmap
+import android.graphics.Color
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertContentDescriptionEquals
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import dev.blazelight.p4oc.R
+import dev.blazelight.p4oc.data.media.ChatMediaLoadResult
+import dev.blazelight.p4oc.data.media.ChatMediaLoader
+import dev.blazelight.p4oc.domain.model.Message
+import dev.blazelight.p4oc.domain.model.MessageWithParts
+import dev.blazelight.p4oc.domain.model.ModelRef
+import dev.blazelight.p4oc.domain.model.Part
+import dev.blazelight.p4oc.domain.model.TokenUsage
+import dev.blazelight.p4oc.domain.model.ToolState
+import dev.blazelight.p4oc.ui.components.toolwidgets.ToolGroupWidget
+import dev.blazelight.p4oc.ui.components.toolwidgets.ToolWidgetState
+import dev.blazelight.p4oc.ui.theme.PocketCodeTheme
+import kotlinx.serialization.json.buildJsonObject
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.ByteArrayOutputStream
+import java.util.concurrent.atomic.AtomicInteger
+
+@RunWith(AndroidJUnit4::class)
+class ChatAttachmentPresentationTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun attachmentOnlyUserMessageRendersImage() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val attachment = imagePart(id = "user-image", messageId = "user-message")
+
+        setChatContent(loadedLoader(attachment.id)) {
+            ChatMessage(
+                messageWithParts = MessageWithParts(
+                    message = userMessage(id = "user-message"),
+                    parts = listOf(attachment),
+                ),
+                onToolApprove = {},
+                onToolDeny = {},
+                onToolAlways = {},
+            )
+        }
+
+        waitForTag("chat_attachment_image_user-image")
+            .assertIsDisplayed()
+            .assertHasClickAction()
+            .assert(
+                SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Button)
+            )
+            .assertContentDescriptionEquals(
+                context.getString(
+                    R.string.chat_attachment_open_image,
+                    attachment.filename.orEmpty(),
+                )
+            )
+    }
+
+    @Test
+    fun topLevelAssistantImageRenders() {
+        val attachment = imagePart(id = "assistant-image", messageId = "assistant-message")
+
+        setChatContent(loadedLoader(attachment.id)) {
+            AssistantMessages(
+                messagesWithParts = listOf(
+                    MessageWithParts(
+                        message = assistantMessage(id = "assistant-message"),
+                        parts = listOf(attachment),
+                    ),
+                ),
+                onToolApprove = {},
+                onToolDeny = {},
+                onToolAlways = {},
+            )
+        }
+
+        waitForTag("chat_attachment_image_assistant-image")
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun completedToolImageRendersInCompactGroup() {
+        val attachment = imagePart(id = "tool-image", messageId = "assistant-message")
+        val tool = Part.Tool(
+            id = "tool-part",
+            sessionID = SESSION_ID,
+            messageID = "assistant-message",
+            callID = "tool-call",
+            toolName = "read",
+            state = ToolState.Completed(
+                input = buildJsonObject {},
+                output = "completed",
+                title = "Read image",
+                startedAt = 1L,
+                endedAt = 2L,
+                attachments = listOf(attachment),
+            ),
+        )
+
+        setChatContent(loadedLoader(attachment.id)) {
+            ToolGroupWidget(
+                tools = listOf(tool),
+                defaultState = ToolWidgetState.COMPACT,
+                onToolApprove = {},
+                onToolDeny = {},
+                onToolAlways = {},
+            )
+        }
+
+        waitForTag("chat_attachment_image_tool-image")
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun loadedPreviewOpensAndClosesFullscreenViewer() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val attachment = imagePart(id = "fullscreen-image", messageId = "assistant-message")
+
+        setChatContent(loadedLoader(attachment.id)) {
+            AssistantMessages(
+                messagesWithParts = listOf(
+                    MessageWithParts(
+                        message = assistantMessage(id = "assistant-message"),
+                        parts = listOf(attachment),
+                    ),
+                ),
+                onToolApprove = {},
+                onToolDeny = {},
+                onToolAlways = {},
+            )
+        }
+
+        waitForTag("chat_attachment_image_fullscreen-image").performClick()
+        waitForTag("chat_attachment_fullscreen_fullscreen-image")
+            .assertIsDisplayed()
+        composeRule.onNodeWithContentDescription(
+            context.getString(
+                R.string.chat_attachment_image_description,
+                attachment.filename.orEmpty(),
+            ),
+            useUnmergedTree = true,
+        ).assertIsDisplayed()
+
+        val closeButton = composeRule.onNodeWithTag(
+            "chat_attachment_close_fullscreen-image",
+            useUnmergedTree = true,
+        ).assertIsDisplayed()
+            .assertHasClickAction()
+            .assert(
+                SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Button)
+            )
+            .assertContentDescriptionEquals(
+                context.getString(R.string.chat_attachment_close_preview)
+            )
+        closeButton.performClick()
+        waitForTagToDisappear("chat_attachment_fullscreen_fullscreen-image")
+        composeRule.onNodeWithTag(
+            "chat_attachment_fullscreen_fullscreen-image",
+            useUnmergedTree = true,
+        ).assertDoesNotExist()
+    }
+
+    @Test
+    fun unavailableImageShowsGenericMessageWithoutSourceDetails() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val attachment = imagePart(
+            id = "unavailable-image",
+            messageId = "assistant-message",
+            url = SENSITIVE_URL,
+        )
+
+        setChatContent(ChatMediaLoader { ChatMediaLoadResult.Unavailable }) {
+            AssistantMessages(
+                messagesWithParts = listOf(
+                    MessageWithParts(
+                        message = assistantMessage(id = "assistant-message"),
+                        parts = listOf(attachment),
+                    ),
+                ),
+                onToolApprove = {},
+                onToolDeny = {},
+                onToolAlways = {},
+            )
+        }
+
+        waitForTag("chat_attachment_unavailable_unavailable-image")
+            .assertIsDisplayed()
+            .assertTextEquals(context.getString(R.string.chat_attachment_image_unavailable))
+        composeRule.onNodeWithText("super-secret", substring = true).assertDoesNotExist()
+    }
+
+    @Test
+    fun nonImageAttachmentShowsMetadataWithoutLoadingMedia() {
+        val loadInvocations = AtomicInteger()
+        val attachment = Part.File(
+            id = "document",
+            sessionID = SESSION_ID,
+            messageID = "assistant-message",
+            mime = "application/pdf",
+            filename = "release-notes.pdf",
+            url = SENSITIVE_URL,
+        )
+
+        setChatContent(
+            loader = ChatMediaLoader {
+                loadInvocations.incrementAndGet()
+                ChatMediaLoadResult.Unavailable
+            },
+        ) {
+            ChatAttachment(part = attachment)
+        }
+
+        waitForTag("chat_attachment_document").assertIsDisplayed()
+        composeRule.onNodeWithText(
+            "release-notes.pdf",
+            useUnmergedTree = true,
+        ).assertIsDisplayed()
+        composeRule.onNodeWithText(
+            "application/pdf",
+            useUnmergedTree = true,
+        ).assertIsDisplayed()
+        composeRule.waitForIdle()
+        assertEquals(0, loadInvocations.get())
+    }
+
+    private fun setChatContent(
+        loader: ChatMediaLoader,
+        content: @Composable () -> Unit,
+    ) {
+        composeRule.setContent {
+            PocketCodeTheme {
+                CompositionLocalProvider(LocalChatMediaLoader provides loader) {
+                    content()
+                }
+            }
+        }
+    }
+
+    private fun waitForTag(tag: String) = composeRule
+        .onAllNodesWithTag(tag, useUnmergedTree = true)
+        .also { nodes ->
+            composeRule.waitUntil(timeoutMillis = ASYNC_TIMEOUT_MILLIS) {
+                nodes.fetchSemanticsNodes().isNotEmpty()
+            }
+        }
+        .let {
+            composeRule.onNodeWithTag(tag, useUnmergedTree = true)
+        }
+
+    private fun waitForTagToDisappear(tag: String) {
+        composeRule.waitUntil(timeoutMillis = ASYNC_TIMEOUT_MILLIS) {
+            composeRule.onAllNodesWithTag(tag, useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .isEmpty()
+        }
+    }
+
+    private fun loadedLoader(vararg partIds: String) = ChatMediaLoader { part ->
+        if (part.id in partIds) {
+            ChatMediaLoadResult.Loaded(bytes = TINY_PNG_BYTES, mimeType = "image/png")
+        } else {
+            ChatMediaLoadResult.Unavailable
+        }
+    }
+
+    private fun imagePart(
+        id: String,
+        messageId: String,
+        url: String = "data:image/png;base64,ignored-by-fake",
+    ) = Part.File(
+        id = id,
+        sessionID = SESSION_ID,
+        messageID = messageId,
+        mime = "image/png",
+        filename = "$id.png",
+        url = url,
+    )
+
+    private fun userMessage(id: String) = Message.User(
+        id = id,
+        sessionID = SESSION_ID,
+        createdAt = 1L,
+        agent = "build",
+        model = ModelRef(providerID = "provider", modelID = "model"),
+    )
+
+    private fun assistantMessage(id: String) = Message.Assistant(
+        id = id,
+        sessionID = SESSION_ID,
+        createdAt = 1L,
+        completedAt = 2L,
+        parentID = "user-message",
+        providerID = "provider",
+        modelID = "model",
+        mode = "build",
+        agent = "build",
+        cost = 0.0,
+        tokens = TokenUsage(input = 0, output = 0),
+        finish = "stop",
+    )
+
+    private companion object {
+        const val SESSION_ID = "session"
+        const val ASYNC_TIMEOUT_MILLIS = 5_000L
+        const val SENSITIVE_URL = "https://server.example/image.png?token=super-secret"
+        val TINY_PNG_BYTES: ByteArray by lazy {
+            val bitmap = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888).apply {
+                setPixel(0, 0, Color.WHITE)
+            }
+            try {
+                ByteArrayOutputStream().use { output ->
+                    check(bitmap.compress(Bitmap.CompressFormat.PNG, 100, output))
+                    output.toByteArray()
+                }
+            } finally {
+                bitmap.recycle()
+            }
+        }
+    }
+}

--- a/app/src/main/java/dev/blazelight/p4oc/core/network/OpenCodeApi.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/core/network/OpenCodeApi.kt
@@ -294,6 +294,14 @@ interface OpenCodeApi {
         @Query("workspace") workspace: String?
     ): FileContentDto
 
+    @Streaming
+    @GET("file/content")
+    suspend fun readFileRaw(
+        @Query("path") path: String,
+        @Query("directory") directory: String?,
+        @Query("workspace") workspace: String?
+    ): Response<ResponseBody>
+
     @GET("file/status")
     suspend fun getFileStatus(
         @Query("directory") directory: String?,

--- a/app/src/main/java/dev/blazelight/p4oc/data/media/ChatMediaLoader.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/data/media/ChatMediaLoader.kt
@@ -1,0 +1,297 @@
+package dev.blazelight.p4oc.data.media
+
+import dev.blazelight.p4oc.core.network.ServerConnectionRegistry
+import dev.blazelight.p4oc.core.network.TerminalTransport
+import dev.blazelight.p4oc.data.remote.dto.FileContentDto
+import dev.blazelight.p4oc.data.workspace.WorkspaceClient
+import dev.blazelight.p4oc.domain.model.Part
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.suspendCancellableCoroutine
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+import java.io.InputStream
+import java.net.URI
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.Base64
+import java.util.concurrent.TimeUnit
+
+fun interface ChatMediaLoader {
+    suspend fun load(part: Part.File): ChatMediaLoadResult
+}
+
+sealed interface ChatMediaLoadResult {
+    data class Loaded(
+        val bytes: ByteArray,
+        val mimeType: String,
+    ) : ChatMediaLoadResult
+
+    data object Unavailable : ChatMediaLoadResult
+}
+
+class WorkspaceChatMediaLoader internal constructor(
+    private val workspaceDirectory: String?,
+    private val workspaceFileReader: suspend (path: String, maxResponseBytes: Long) -> FileContentDto,
+    private val terminalTransportLookup: () -> TerminalTransport?,
+    private val httpCallFactory: (client: OkHttpClient, request: Request) -> Call = { client, request ->
+        client.newCall(request)
+    },
+) : ChatMediaLoader {
+    constructor(
+        workspaceClient: WorkspaceClient,
+        serverConnectionRegistry: ServerConnectionRegistry?,
+    ) : this(
+        workspaceDirectory = workspaceClient.workspace.directory,
+        workspaceFileReader = workspaceClient::readFileBounded,
+        terminalTransportLookup = {
+            serverConnectionRegistry
+                ?.terminalTransport(workspaceClient.workspace.server, workspaceClient.generation)
+        },
+    )
+
+    override suspend fun load(part: Part.File): ChatMediaLoadResult {
+        if (imageMimeType(part.mime) == null || part.url != part.url.trim()) {
+            return ChatMediaLoadResult.Unavailable
+        }
+
+        return try {
+            when {
+                part.url.startsWith(DATA_SCHEME, ignoreCase = true) -> loadDataUrl(part.url)
+                part.url.startsWith(FILE_SCHEME, ignoreCase = true) -> loadWorkspaceFile(part.url)
+                else -> loadHttpUrl(part.url)
+            }
+        } catch (error: CancellationException) {
+            throw error
+        } catch (_: Exception) {
+            ChatMediaLoadResult.Unavailable
+        }
+    }
+
+    private fun loadDataUrl(url: String): ChatMediaLoadResult {
+        val commaIndex = url.indexOf(',')
+        var loaded: ChatMediaLoadResult.Loaded? = null
+        if (commaIndex > DATA_SCHEME.length) {
+            val descriptor = url.substring(DATA_SCHEME.length, commaIndex)
+            val base64Marker = descriptor.lastIndexOf(';')
+            if (base64Marker > 0 && descriptor.hasBase64EncodingAt(base64Marker)) {
+                val mimeType = imageMimeType(descriptor.substring(0, base64Marker))
+                val bytes = decodeBoundedBase64(url.substring(commaIndex + 1))
+                if (mimeType != null && bytes != null) {
+                    loaded = ChatMediaLoadResult.Loaded(bytes, mimeType)
+                }
+            }
+        }
+        return loaded ?: ChatMediaLoadResult.Unavailable
+    }
+
+    private suspend fun loadWorkspaceFile(url: String): ChatMediaLoadResult {
+        val loaded = workspaceRelativePath(url)?.let { path ->
+            val content = workspaceFileReader(path, MAX_CHAT_MEDIA_FILE_RESPONSE_BYTES)
+            val mimeType = imageMimeType(content.mimeType)
+            val bytes = if (content.hasBase64Encoding()) decodeBoundedBase64(content.content) else null
+            if (mimeType != null && bytes != null) {
+                ChatMediaLoadResult.Loaded(bytes, mimeType)
+            } else {
+                null
+            }
+        }
+        return loaded ?: ChatMediaLoadResult.Unavailable
+    }
+
+    private fun workspaceRelativePath(url: String): String? {
+        val uri = URI(url)
+        val decodedPath = uri.path
+        val root = workspaceDirectory?.let(Paths::get)?.normalize()
+        val candidate = decodedPath
+            ?.takeIf { it.isSafeFilePath() }
+            ?.let(Paths::get)
+            ?.normalize()
+        return if (uri.hasSupportedFileShape()) {
+            containedWorkspaceRelativePath(root, candidate)?.toApiPath()
+        } else {
+            null
+        }
+    }
+
+    private suspend fun loadHttpUrl(url: String): ChatMediaLoadResult {
+        val parsed = url.toHttpUrlOrNull()
+            ?.takeIf { it.isSafeHttpUrl() }
+            ?: return ChatMediaLoadResult.Unavailable
+        val transport = terminalTransportLookup()
+        val serverOrigin = transport
+            ?.connection
+            ?.config
+            ?.url
+            ?.toHttpUrlOrNull()
+            ?.takeIf { it.isSafeHttpUrl() }
+        val loaded = if (transport != null && serverOrigin != null && parsed.isSafeFor(serverOrigin)) {
+            val redirectSafeClient = transport.authClient.newBuilder()
+                .followRedirects(false)
+                .followSslRedirects(false)
+                .readTimeout(MEDIA_HTTP_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .callTimeout(MEDIA_HTTP_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .build()
+            val request = Request.Builder().url(parsed).get().build()
+            redirectSafeClient.fetchBoundedImage(request)
+        } else {
+            null
+        }
+        return loaded ?: ChatMediaLoadResult.Unavailable
+    }
+
+    private suspend fun OkHttpClient.fetchBoundedImage(request: Request): ChatMediaLoadResult =
+        suspendCancellableCoroutine { continuation ->
+            val call = httpCallFactory(this, request)
+            continuation.invokeOnCancellation { call.cancel() }
+            call.enqueue(
+                object : Callback {
+                    override fun onFailure(call: Call, e: IOException) {
+                        continuation.resume(ChatMediaLoadResult.Unavailable) { _, _, _ -> }
+                    }
+
+                    override fun onResponse(call: Call, response: Response) {
+                        val result = try {
+                            response.use(::decodeImageResponse)
+                        } catch (_: Exception) {
+                            ChatMediaLoadResult.Unavailable
+                        }
+                        continuation.resume(result) { _, _, _ -> }
+                    }
+                }
+            )
+        }
+
+    private fun decodeImageResponse(response: Response): ChatMediaLoadResult {
+        val loaded = if (response.isSuccessful && !response.isRedirect) {
+            val body = response.body
+            val mimeType = imageMimeType(body.contentType()?.toString())
+            val bytes = mimeType?.let { body.byteStream().readBounded(body.contentLength()) }
+            if (mimeType != null && bytes != null) {
+                ChatMediaLoadResult.Loaded(bytes, mimeType)
+            } else {
+                null
+            }
+        } else {
+            null
+        }
+        return loaded ?: ChatMediaLoadResult.Unavailable
+    }
+
+    private fun InputStream.readBounded(contentLength: Long): ByteArray? {
+        val hasInvalidDeclaredLength = contentLength > MAX_CHAT_MEDIA_BYTES || contentLength > Int.MAX_VALUE
+        return if (hasInvalidDeclaredLength) {
+            null
+        } else {
+            val initialSize = if (contentLength < 0L) STREAM_BUFFER_SIZE else contentLength.toInt()
+            val output = ByteArrayOutputStream(initialSize)
+            val buffer = ByteArray(STREAM_BUFFER_SIZE)
+            output.takeIf { readIntoBounded(output, buffer) }?.toByteArray()
+        }
+    }
+
+    private fun InputStream.readIntoBounded(output: ByteArrayOutputStream, buffer: ByteArray): Boolean {
+        var total = 0L
+        var read = read(buffer)
+        while (read >= 0 && total <= MAX_CHAT_MEDIA_BYTES) {
+            if (read > 0) {
+                total += read
+                output.writeIfWithinLimit(buffer, read, total)
+            }
+            read = if (total <= MAX_CHAT_MEDIA_BYTES) read(buffer) else -1
+        }
+        return total <= MAX_CHAT_MEDIA_BYTES
+    }
+
+    private fun ByteArrayOutputStream.writeIfWithinLimit(buffer: ByteArray, count: Int, total: Long) {
+        if (total <= MAX_CHAT_MEDIA_BYTES) write(buffer, 0, count)
+    }
+
+    private fun decodeBoundedBase64(encoded: String): ByteArray? =
+        if (encoded.length > MAX_CHAT_MEDIA_BASE64_CHARS) {
+            null
+        } else {
+            try {
+                Base64.getDecoder().decode(encoded).takeIf { it.size <= MAX_CHAT_MEDIA_BYTES }
+            } catch (_: IllegalArgumentException) {
+                null
+            }
+        }
+
+    private fun imageMimeType(value: String?): String? = value
+        ?.toMediaTypeOrNull()
+        ?.takeIf { it.isSupportedImage() }
+        ?.let { "${it.type}/${it.subtype}" }
+
+    private fun String.hasBase64EncodingAt(separatorIndex: Int): Boolean =
+        substring(separatorIndex + 1).equals(BASE64_ENCODING, ignoreCase = true)
+
+    private fun FileContentDto.hasBase64Encoding(): Boolean =
+        encoding.equals(BASE64_ENCODING, ignoreCase = true)
+
+    private fun String.isSafeFilePath(): Boolean = '\u0000' !in this && '\\' !in this
+
+    private fun URI.hasSupportedFileShape(): Boolean =
+        hasSupportedFileScheme() && hasNoAuthority() && hasNoQueryOrFragment()
+
+    private fun URI.hasSupportedFileScheme(): Boolean =
+        scheme.equals(FILE_SCHEME_NAME, ignoreCase = true) && !isOpaque
+
+    private fun URI.hasNoAuthority(): Boolean = rawAuthority.isNullOrEmpty()
+
+    private fun URI.hasNoQueryOrFragment(): Boolean = rawQuery == null && rawFragment == null
+
+    private fun HttpUrl.isSafeFor(origin: HttpUrl): Boolean =
+        isSafeHttpUrl() && hasSameOrigin(origin)
+
+    private fun HttpUrl.isSafeHttpUrl(): Boolean = hasSupportedHttpScheme() && hasNoUserInfo()
+
+    private fun HttpUrl.hasSupportedHttpScheme(): Boolean = scheme == HTTP_SCHEME || scheme == HTTPS_SCHEME
+
+    private fun HttpUrl.hasNoUserInfo(): Boolean = username.isEmpty() && password.isEmpty()
+
+    private fun HttpUrl.hasSameOrigin(other: HttpUrl): Boolean =
+        scheme == other.scheme && host == other.host && port == other.port
+
+    private companion object {
+        const val DATA_SCHEME = "data:"
+        const val FILE_SCHEME = "file:"
+        const val FILE_SCHEME_NAME = "file"
+        const val HTTP_SCHEME = "http"
+        const val HTTPS_SCHEME = "https"
+        const val BASE64_ENCODING = "base64"
+        const val IMAGE_TYPE = "image"
+        const val WILDCARD_SUBTYPE = "*"
+        const val STREAM_BUFFER_SIZE = 8 * 1024
+        const val MEDIA_HTTP_TIMEOUT_SECONDS = 60L
+    }
+}
+
+private fun containedWorkspaceRelativePath(root: Path?, candidate: Path?): Path? {
+    if (root == null || candidate == null) return null
+    return if (areAbsolute(root, candidate) && candidate.isDescendantOf(root)) {
+        root.relativize(candidate)
+    } else {
+        null
+    }
+}
+
+private fun areAbsolute(root: Path, candidate: Path): Boolean = root.isAbsolute && candidate.isAbsolute
+
+private fun Path.isDescendantOf(root: Path): Boolean = this != root && startsWith(root)
+
+private fun Path.toApiPath(): String = iterator().asSequence().joinToString("/") { it.toString() }
+
+private fun okhttp3.MediaType.isSupportedImage(): Boolean =
+    type == "image" && subtype.isNotBlank() && subtype != "*"
+
+internal const val MAX_CHAT_MEDIA_BYTES: Int = 8 * 1024 * 1024
+internal const val MAX_CHAT_MEDIA_BASE64_CHARS: Int = ((MAX_CHAT_MEDIA_BYTES + 2) / 3) * 4
+internal const val MAX_CHAT_MEDIA_FILE_RESPONSE_BYTES: Long = 11_184_812L + 64L * 1024L

--- a/app/src/main/java/dev/blazelight/p4oc/data/workspace/WorkspaceClient.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/data/workspace/WorkspaceClient.kt
@@ -41,13 +41,20 @@ import dev.blazelight.p4oc.data.remote.dto.VcsInfoDto
 import dev.blazelight.p4oc.data.server.ActiveServerApiProvider
 import dev.blazelight.p4oc.domain.server.ServerGeneration
 import dev.blazelight.p4oc.domain.workspace.Workspace
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import okhttp3.ResponseBody
+import okio.Buffer
 
 import retrofit2.HttpException
 import java.io.IOException
+
+private const val BOUNDED_FILE_READ_CHUNK_BYTES = 8L * 1024
+private const val FILE_RESPONSE_TOO_LARGE_MESSAGE = "File response exceeds the allowed size"
 
 class WorkspaceClient(
     override val workspace: Workspace,
@@ -294,6 +301,53 @@ class WorkspaceClient(
     suspend fun listFiles(path: String): List<FileNodeDto> = api.listFiles(path, directory, workspace = null)
 
     suspend fun readFile(path: String): FileContentDto = api.readFile(path, directory, workspace = null)
+
+    suspend fun readFileBounded(path: String, maxResponseBytes: Long): FileContentDto {
+        require(maxResponseBytes > 0) { "maxResponseBytes must be positive" }
+        val response = api.readFileRaw(path, directory, workspace = null)
+        try {
+            if (!response.isSuccessful) throw HttpException(response)
+            val content = response.body()?.let { body ->
+                body.readUtf8BoundedCancellable(maxResponseBytes)
+            }.orEmpty()
+            return json.decodeFromString(content)
+        } finally {
+            response.body()?.close()
+            response.errorBody()?.close()
+        }
+    }
+
+    private suspend fun ResponseBody.readUtf8BoundedCancellable(maxResponseBytes: Long): String =
+        withContext(Dispatchers.IO) {
+            suspendCancellableCoroutine { continuation ->
+                continuation.invokeOnCancellation { close() }
+                continuation.resumeWith(
+                    runCatching { readUtf8Bounded(maxResponseBytes) },
+                )
+            }
+        }
+
+    private fun ResponseBody.readUtf8Bounded(maxResponseBytes: Long): String {
+        val declaredBytes = contentLength()
+        if (declaredBytes > maxResponseBytes) throw IOException(FILE_RESPONSE_TOO_LARGE_MESSAGE)
+
+        val bufferedBytes = Buffer()
+        val responseSource = source()
+        var streamedBytes = 0L
+        while (true) {
+            val remainingBytes = maxResponseBytes - streamedBytes
+            val readLimit = if (remainingBytes >= BOUNDED_FILE_READ_CHUNK_BYTES) {
+                BOUNDED_FILE_READ_CHUNK_BYTES
+            } else {
+                remainingBytes + 1L
+            }
+            val readBytes = responseSource.read(bufferedBytes, readLimit)
+            if (readBytes == -1L) break
+            if (readBytes > remainingBytes) throw IOException(FILE_RESPONSE_TOO_LARGE_MESSAGE)
+            streamedBytes += readBytes
+        }
+        return bufferedBytes.readUtf8()
+    }
 
     suspend fun getFileStatus(): List<FileStatusDto> = api.getFileStatus(directory, workspace = null)
 

--- a/app/src/main/java/dev/blazelight/p4oc/ui/components/chat/ChatAttachment.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/components/chat/ChatAttachment.kt
@@ -1,0 +1,334 @@
+package dev.blazelight.p4oc.ui.components.chat
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import coil.compose.AsyncImage
+import dev.blazelight.p4oc.R
+import dev.blazelight.p4oc.data.media.ChatMediaLoadResult
+import dev.blazelight.p4oc.data.media.ChatMediaLoader
+import dev.blazelight.p4oc.domain.model.Part
+import dev.blazelight.p4oc.ui.components.TuiLoadingIndicator
+import dev.blazelight.p4oc.ui.theme.LocalOpenCodeTheme
+import dev.blazelight.p4oc.ui.theme.Sizing
+import dev.blazelight.p4oc.ui.theme.Spacing
+import dev.blazelight.p4oc.ui.theme.TuiShapes
+import kotlinx.coroutines.CancellationException
+
+val LocalChatMediaLoader = staticCompositionLocalOf<ChatMediaLoader> {
+    ChatMediaLoader { ChatMediaLoadResult.Unavailable }
+}
+
+@Composable
+@Suppress("FunctionNaming")
+fun ChatAttachmentList(
+    parts: List<Part.File>,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(Spacing.xs),
+    ) {
+        parts.forEach { part ->
+            ChatAttachment(part = part)
+        }
+    }
+}
+
+@Composable
+@Suppress("FunctionNaming")
+fun ChatAttachment(
+    part: Part.File,
+    modifier: Modifier = Modifier,
+) {
+    val theme = LocalOpenCodeTheme.current
+    val filename = part.filename?.takeIf { it.isNotBlank() }
+        ?: stringResource(R.string.chat_attachment_unnamed)
+    val mimeType = part.mime.takeIf { it.isNotBlank() }
+        ?: stringResource(R.string.chat_attachment_unknown_mime)
+    val isImage = part.mime.trim().startsWith(prefix = "image/", ignoreCase = true)
+
+    Surface(
+        modifier = modifier
+            .fillMaxWidth()
+            .testTag("chat_attachment_${part.id}"),
+        color = theme.backgroundPanel,
+        shape = TuiShapes.extraSmall,
+        border = BorderStroke(Sizing.strokeThin, theme.border),
+    ) {
+        Column(
+            modifier = Modifier.padding(Spacing.sm),
+            verticalArrangement = Arrangement.spacedBy(Spacing.xs),
+        ) {
+            AttachmentMetadata(filename = filename, mimeType = mimeType)
+            if (isImage) {
+                ChatImageAttachment(part = part, filename = filename)
+            }
+        }
+    }
+}
+
+@Composable
+@Suppress("FunctionNaming")
+private fun AttachmentMetadata(filename: String, mimeType: String) {
+    val theme = LocalOpenCodeTheme.current
+    Column(verticalArrangement = Arrangement.spacedBy(Spacing.hairline)) {
+        Text(
+            text = filename,
+            style = MaterialTheme.typography.labelMedium,
+            color = theme.text,
+            fontFamily = FontFamily.Monospace,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+        Text(
+            text = mimeType,
+            style = MaterialTheme.typography.labelSmall,
+            color = theme.textMuted,
+            fontFamily = FontFamily.Monospace,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}
+
+@Composable
+@Suppress("FunctionNaming")
+private fun ChatImageAttachment(part: Part.File, filename: String) {
+    val loader = LocalChatMediaLoader.current
+    val loadState = remember(loader, part) {
+        mutableStateOf<ChatMediaLoadResult?>(null)
+    }
+
+    LaunchedEffect(loader, part) {
+        loadState.value = try {
+            loader.load(part)
+        } catch (cancellation: CancellationException) {
+            throw cancellation
+        } catch (_: Exception) {
+            ChatMediaLoadResult.Unavailable
+        }
+    }
+
+    when (val result = loadState.value) {
+        null -> AttachmentLoading(filename = filename)
+        ChatMediaLoadResult.Unavailable -> AttachmentUnavailable(partId = part.id)
+        is ChatMediaLoadResult.Loaded -> LoadedImagePreview(
+            part = part,
+            filename = filename,
+            loaded = result,
+        )
+    }
+}
+
+@Composable
+@Suppress("FunctionNaming")
+private fun AttachmentLoading(filename: String, modifier: Modifier = Modifier) {
+    val description = stringResource(R.string.chat_attachment_loading, filename)
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .heightIn(
+                min = Sizing.listItemHeightLg,
+                max = Sizing.chatAttachmentPreviewMaxHeight,
+            )
+            .semantics { contentDescription = description },
+        contentAlignment = Alignment.Center,
+    ) {
+        TuiLoadingIndicator(text = description)
+    }
+}
+
+@Composable
+@Suppress("FunctionNaming")
+private fun AttachmentUnavailable(partId: String) {
+    val theme = LocalOpenCodeTheme.current
+    Text(
+        text = stringResource(R.string.chat_attachment_image_unavailable),
+        style = MaterialTheme.typography.labelSmall,
+        color = theme.error,
+        modifier = Modifier.testTag("chat_attachment_unavailable_$partId"),
+    )
+}
+
+@Composable
+@Suppress("FunctionNaming")
+private fun LoadedImagePreview(
+    part: Part.File,
+    filename: String,
+    loaded: ChatMediaLoadResult.Loaded,
+) {
+    var imageDecoded by remember(part, loaded) { mutableStateOf(false) }
+    var imageDecodeFailed by remember(part, loaded) { mutableStateOf(false) }
+    var showFullscreen by remember(part, loaded) { mutableStateOf(false) }
+    val imageDescription = stringResource(R.string.chat_attachment_image_description, filename)
+    val openDescription = stringResource(R.string.chat_attachment_open_image, filename)
+
+    if (imageDecodeFailed) {
+        AttachmentUnavailable(partId = part.id)
+    } else {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(
+                    min = Sizing.listItemHeightLg,
+                    max = Sizing.chatAttachmentPreviewMaxHeight,
+                ),
+            contentAlignment = Alignment.Center,
+        ) {
+            AsyncImage(
+                model = loaded.bytes,
+                contentDescription = if (imageDecoded) openDescription else imageDescription,
+                contentScale = ContentScale.Fit,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = Sizing.chatAttachmentPreviewMaxHeight)
+                    .then(
+                        if (imageDecoded) {
+                            Modifier
+                                .testTag("chat_attachment_image_${part.id}")
+                                .clickable(role = Role.Button) { showFullscreen = true }
+                        } else {
+                            Modifier
+                        }
+                    ),
+                onSuccess = {
+                    imageDecoded = true
+                    imageDecodeFailed = false
+                },
+                onError = {
+                    imageDecoded = false
+                    imageDecodeFailed = true
+                },
+            )
+            if (!imageDecoded) {
+                AttachmentLoading(filename = filename, modifier = Modifier.fillMaxSize())
+            }
+        }
+    }
+
+    if (showFullscreen && imageDecoded && !imageDecodeFailed) {
+        FullscreenAttachmentImage(
+            partId = part.id,
+            filename = filename,
+            bytes = loaded.bytes,
+            onDismiss = { showFullscreen = false },
+        )
+    }
+}
+
+@Composable
+@Suppress("FunctionNaming")
+private fun FullscreenAttachmentImage(
+    partId: String,
+    filename: String,
+    bytes: ByteArray,
+    onDismiss: () -> Unit,
+) {
+    val theme = LocalOpenCodeTheme.current
+    val imageDescription = stringResource(R.string.chat_attachment_image_description, filename)
+    val closeDescription = stringResource(R.string.chat_attachment_close_preview)
+
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(
+            dismissOnBackPress = true,
+            dismissOnClickOutside = true,
+            usePlatformDefaultWidth = false,
+            decorFitsSystemWindows = false,
+        ),
+    ) {
+        Surface(
+            modifier = Modifier
+                .fillMaxSize()
+                .testTag("chat_attachment_fullscreen_$partId"),
+            color = theme.background,
+            shape = TuiShapes.extraLarge,
+        ) {
+            Box(modifier = Modifier.fillMaxSize()) {
+                AsyncImage(
+                    model = bytes,
+                    contentDescription = imageDescription,
+                    contentScale = ContentScale.Fit,
+                    modifier = Modifier.fillMaxSize(),
+                )
+                FullscreenAttachmentCloseButton(
+                    partId = partId,
+                    closeDescription = closeDescription,
+                    onDismiss = onDismiss,
+                    modifier = Modifier.align(Alignment.TopEnd),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+@Suppress("FunctionNaming")
+private fun FullscreenAttachmentCloseButton(
+    partId: String,
+    closeDescription: String,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val theme = LocalOpenCodeTheme.current
+    IconButton(
+        onClick = onDismiss,
+        modifier = modifier
+            .windowInsetsPadding(
+                WindowInsets.safeDrawing.only(
+                    WindowInsetsSides.Top + WindowInsetsSides.End
+                )
+            )
+            .padding(Spacing.sm)
+            .size(Sizing.iconButtonLg)
+            .background(theme.backgroundPanel, TuiShapes.extraSmall)
+            .testTag("chat_attachment_close_$partId")
+            .semantics { contentDescription = closeDescription },
+    ) {
+        Icon(
+            imageVector = Icons.Default.Close,
+            contentDescription = null,
+            tint = theme.text,
+        )
+    }
+}

--- a/app/src/main/java/dev/blazelight/p4oc/ui/components/chat/ChatMessage.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/components/chat/ChatMessage.kt
@@ -41,7 +41,8 @@ import kotlinx.serialization.json.contentOrNull
 
 internal fun MessageWithParts.hasVisibleUserText(): Boolean =
     message is Message.User && parts.any { part ->
-        part is Part.Text && !part.synthetic && !part.ignored && part.text.isNotBlank()
+        (part is Part.Text && !part.synthetic && !part.ignored && part.text.isNotBlank()) ||
+            part is Part.File
     }
 
 @Composable
@@ -128,12 +129,13 @@ private fun UserMessage(
     val haptic = LocalHapticFeedback.current
     val density = LocalDensity.current
     var revertActionWidthPx by remember { mutableIntStateOf(0) }
-    if (!messageWithParts.hasVisibleUserText()) return
 
     // Filter out synthetic text parts (system prompts, AGENTS.md content, etc.)
     val textParts = messageWithParts.parts
         .filterIsInstance<Part.Text>()
-        .filter { !it.synthetic && !it.ignored }
+        .filter { !it.synthetic && !it.ignored && it.text.isNotBlank() }
+    val fileParts = messageWithParts.parts.filterIsInstance<Part.File>()
+    if (textParts.isEmpty() && fileParts.isEmpty()) return
     val text = textParts.joinToString("\n") { it.text }
 
     // TUI style: flat panel surface with a "you" label — matches the design's user block.
@@ -146,13 +148,19 @@ private fun UserMessage(
             modifier = Modifier
                 .fillMaxWidth()
                 .background(theme.backgroundPanel)
-                .combinedClickable(
-                    onClick = {},
-                    onLongClick = {
-                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                        clipboardManager.setText(AnnotatedString(text))
-                    },
-                    onLongClickLabel = "Copy message"
+                .then(
+                    if (text.isNotBlank()) {
+                        Modifier.combinedClickable(
+                            onClick = {},
+                            onLongClick = {
+                                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                                clipboardManager.setText(AnnotatedString(text))
+                            },
+                            onLongClickLabel = "Copy message"
+                        )
+                    } else {
+                        Modifier
+                    }
                 )
                 .padding(horizontal = Spacing.mdLg, vertical = Spacing.md)
         ) {
@@ -174,7 +182,13 @@ private fun UserMessage(
                     color = theme.textMuted,
                     modifier = Modifier.padding(bottom = Spacing.xxs)
                 )
-                StreamingMarkdown(text = text, modifier = Modifier.fillMaxWidth())
+                if (text.isNotBlank()) {
+                    StreamingMarkdown(text = text, modifier = Modifier.fillMaxWidth())
+                }
+                if (fileParts.isNotEmpty()) {
+                    if (text.isNotBlank()) Spacer(Modifier.height(Spacing.sm))
+                    ChatAttachmentList(parts = fileParts)
+                }
 
                 if (isQueued) {
                     Text(
@@ -295,7 +309,7 @@ private fun renderOtherPart(part: Part) {
     when (part) {
         is Part.Text -> TextPart(part)
         is Part.Reasoning -> ReasoningPart(part)
-        is Part.File -> FilePart(part)
+        is Part.File -> ChatAttachment(part)
         is Part.Patch -> CompactPatchPart(part)
         is Part.Subtask -> activityMarker(stringResource(R.string.chat_delegated_to, part.agent, part.description))
         is Part.Retry -> activityMarker(stringResource(R.string.chat_retry_attempt, part.attempt))
@@ -597,41 +611,6 @@ private fun String.stripReasoningTitleMarkdown(): String =
 private const val REASONING_TITLE_MAX_CHARS = 80
 private val REASONING_TITLE_METADATA_KEYS = listOf("title", "summary", "subject", "heading")
 private val REASONING_WHITESPACE_REGEX = Regex("\\s+")
-
-@Composable
-private fun FilePart(part: Part.File) {
-    val theme = LocalOpenCodeTheme.current
-    Surface(
-        color = theme.backgroundElement,
-        shape = RectangleShape,
-        modifier = Modifier.fillMaxWidth()
-    ) {
-        Row(
-            modifier = Modifier.padding(Spacing.sm),
-            horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Icon(
-                Icons.Default.AttachFile,
-                contentDescription = stringResource(R.string.cd_attach_file),
-                modifier = Modifier.size(Sizing.iconXs),
-                tint = theme.textMuted
-            )
-            Column {
-                Text(
-                    text = part.filename ?: "File",
-                    style = MaterialTheme.typography.labelSmall,
-                    color = theme.text
-                )
-                Text(
-                    text = part.mime,
-                    style = MaterialTheme.typography.labelSmall,
-                    color = theme.textMuted
-                )
-            }
-        }
-    }
-}
 
 @Composable
 private fun CompactPatchPart(part: Part.Patch) {

--- a/app/src/main/java/dev/blazelight/p4oc/ui/components/toolwidgets/ToolGroupWidget.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/components/toolwidgets/ToolGroupWidget.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.unit.dp
 import dev.blazelight.p4oc.R
 import dev.blazelight.p4oc.domain.model.Part
 import dev.blazelight.p4oc.domain.model.ToolState
+import dev.blazelight.p4oc.ui.components.chat.ChatAttachmentList
 import dev.blazelight.p4oc.ui.theme.LocalOpenCodeTheme
 import dev.blazelight.p4oc.ui.theme.Sizing
 import dev.blazelight.p4oc.ui.theme.Spacing
@@ -51,6 +52,12 @@ private data class ToolGroup(
     val state: AggregateToolState,
     val tools: List<Part.Tool>
 )
+
+internal fun completedToolAttachments(state: ToolState): List<Part.File> = if (state is ToolState.Completed) {
+    state.attachments?.filterIsInstance<Part.File>().orEmpty()
+} else {
+    emptyList()
+}
 
 /**
  * Tool group widget with progressive disclosure.
@@ -196,6 +203,9 @@ fun ToolGroupWidget(
                                 onClick = { currentState = currentState.next() },
                                 modifier = Modifier.fillMaxWidth()
                             )
+                            completedToolAttachments(tool.state).takeIf { it.isNotEmpty() }?.let { attachments ->
+                                ChatAttachmentList(parts = attachments)
+                            }
 
                             // Show approval buttons for live or recovered pending permissions.
                             if (tool.callID in pendingPermissionIdsByCallId.keys) {
@@ -225,6 +235,9 @@ fun ToolGroupWidget(
                                 onOpenSubSession = onOpenSubSession,
                                 modifier = Modifier.fillMaxWidth()
                             )
+                            completedToolAttachments(tool.state).takeIf { it.isNotEmpty() }?.let { attachments ->
+                                ChatAttachmentList(parts = attachments)
+                            }
                             if (tool.callID in pendingPermissionIdsByCallId.keys) {
                                 PendingApprovalButtonsInline(
                                     requestId = pendingPermissionIdsByCallId[tool.callID] ?: tool.callID,

--- a/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ChatScreen.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ChatScreen.kt
@@ -48,6 +48,7 @@ import dev.blazelight.p4oc.ui.components.chat.ChatInputBar
 import dev.blazelight.p4oc.ui.components.chat.ChatJumpNavigationButtons
 import dev.blazelight.p4oc.ui.components.chat.FilePickerDialog
 import dev.blazelight.p4oc.ui.components.chat.InlinePermissionPrompt
+import dev.blazelight.p4oc.ui.components.chat.LocalChatMediaLoader
 import dev.blazelight.p4oc.ui.components.chat.ModelAgentSelectorBar
 import dev.blazelight.p4oc.ui.components.command.CommandPalette
 import dev.blazelight.p4oc.ui.components.command.rememberResolvedCommandMetadata
@@ -597,17 +598,19 @@ fun ChatScreen(
                                 Modifier
                             }
                             Box(modifier = highlight) {
-                                MessageBlockView(
-                                    block = block,
-                                    onToolApprove = { viewModel.respondToPermission(it, "once") },
-                                    onToolDeny = { viewModel.respondToPermission(it, "reject") },
-                                    onToolAlways = { viewModel.respondToPermission(it, "always") },
-                                    onOpenSubSession = onOpenSubSession,
-                                    onProviderAuthRequired = onProviderAuthRequired,
-                                    defaultToolWidgetState = defaultToolWidgetState,
-                                    pendingPermissionsByCallId = pendingPermissionsByCallId,
-                                    onRevert = { messageId -> showRevertDialog = messageId }
-                                )
+                                CompositionLocalProvider(LocalChatMediaLoader provides viewModel.mediaLoader) {
+                                    MessageBlockView(
+                                        block = block,
+                                        onToolApprove = { viewModel.respondToPermission(it, "once") },
+                                        onToolDeny = { viewModel.respondToPermission(it, "reject") },
+                                        onToolAlways = { viewModel.respondToPermission(it, "always") },
+                                        onOpenSubSession = onOpenSubSession,
+                                        onProviderAuthRequired = onProviderAuthRequired,
+                                        defaultToolWidgetState = defaultToolWidgetState,
+                                        pendingPermissionsByCallId = pendingPermissionsByCallId,
+                                        onRevert = { messageId -> showRevertDialog = messageId }
+                                    )
+                                }
                             }
                         }
 

--- a/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ChatViewModel.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/screens/chat/ChatViewModel.kt
@@ -13,6 +13,8 @@ import dev.blazelight.p4oc.core.network.ApiResult
 import dev.blazelight.p4oc.core.network.ConnectionState
 import dev.blazelight.p4oc.core.network.ServerConnectionRegistry
 import dev.blazelight.p4oc.core.network.safeApiCall
+import dev.blazelight.p4oc.data.media.ChatMediaLoader
+import dev.blazelight.p4oc.data.media.WorkspaceChatMediaLoader
 import dev.blazelight.p4oc.data.remote.dto.ExecuteCommandRequest
 import dev.blazelight.p4oc.data.remote.dto.InitSessionRequest
 import dev.blazelight.p4oc.data.remote.dto.PartInputDto
@@ -80,6 +82,7 @@ class ChatViewModel constructor(
         serverConnectionRegistry,
     )
     val filePickerManager = FilePickerManager(workspaceClient, viewModelScope, uploadCoordinator, settingsDataStore)
+    val mediaLoader: ChatMediaLoader = WorkspaceChatMediaLoader(workspaceClient, serverConnectionRegistry)
 
     // --- Core state ---
     private val _uiState = MutableStateFlow(ChatUiState(inputText = restoredInputText()))

--- a/app/src/main/java/dev/blazelight/p4oc/ui/theme/Sizing.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/ui/theme/Sizing.kt
@@ -72,6 +72,9 @@ object Sizing {
     // Scrollable embedded content (e.g. inline full-text blocks)
     val embeddedScrollMaxHeight: Dp = 360.dp
 
+    // Chat media
+    val chatAttachmentPreviewMaxHeight: Dp = 240.dp
+
     // Component-specific
     // Knob-slider switch (design): 36x20 track, 14x14 sliding knob, 2dp inset
     val switchTrackWidth: Dp = 36.dp

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -959,6 +959,13 @@
     <string name="upload_phase_failed">failed</string>
     <string name="upload_probe_failed_for">%1$s · could not read source</string>
     <string name="attachment_unavailable">unavailable</string>
+    <string name="chat_attachment_unnamed">Attachment</string>
+    <string name="chat_attachment_unknown_mime">unknown type</string>
+    <string name="chat_attachment_loading">Loading image %1$s</string>
+    <string name="chat_attachment_image_unavailable">Image preview unavailable</string>
+    <string name="chat_attachment_image_description">Image attachment: %1$s</string>
+    <string name="chat_attachment_open_image">Open full-screen image: %1$s</string>
+    <string name="chat_attachment_close_preview">Close image preview</string>
     <string name="start_work_title">Start work</string>
     <string name="start_work_in">In</string>
     <string name="start_work_change">Change</string>

--- a/app/src/test/java/dev/blazelight/p4oc/data/media/ChatMediaLoaderTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/data/media/ChatMediaLoaderTest.kt
@@ -1,0 +1,464 @@
+package dev.blazelight.p4oc.data.media
+
+import dev.blazelight.p4oc.core.network.Connection
+import dev.blazelight.p4oc.core.network.ServerConfig
+import dev.blazelight.p4oc.core.network.ServerConnectionRegistry
+import dev.blazelight.p4oc.core.network.TerminalTransport
+import dev.blazelight.p4oc.data.remote.dto.FileContentDto
+import dev.blazelight.p4oc.data.workspace.WorkspaceClient
+import dev.blazelight.p4oc.domain.model.Part
+import dev.blazelight.p4oc.domain.server.ServerGeneration
+import dev.blazelight.p4oc.domain.server.ServerRef
+import dev.blazelight.p4oc.domain.workspace.Workspace
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import okhttp3.Call
+import okhttp3.MediaType
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody
+import okio.BufferedSource
+import okio.buffer
+import okio.source
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.ByteArrayInputStream
+import java.io.InputStream
+import java.util.Base64
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+class ChatMediaLoaderTest {
+    @Test
+    fun `loads bounded base64 image data URLs`() = runTest {
+        val bytes = byteArrayOf(1, 2, 3, 4)
+        val loader = loader()
+
+        val result = loader.load(
+            filePart(
+                url = "data:image/png;base64,${Base64.getEncoder().encodeToString(bytes)}",
+                mime = "image/png",
+            )
+        ) as ChatMediaLoadResult.Loaded
+
+        assertArrayEquals(bytes, result.bytes)
+        assertEquals("image/png", result.mimeType)
+    }
+
+    @Test
+    fun `rejects malformed oversized and non-image data URLs`() = runTest {
+        val loader = loader()
+        val cases = listOf(
+            filePart("data:image/png;base64,%%%"),
+            filePart("data:text/plain;base64,AQID"),
+            filePart("data:image/png,AQID"),
+            filePart("data:image/png;base64,${"A".repeat(MAX_CHAT_MEDIA_BASE64_CHARS + 1)}"),
+            filePart("data:image/png;base64,AQID", mime = "text/plain"),
+        )
+
+        cases.forEach { assertUnavailable(loader.load(it)) }
+    }
+
+    @Test
+    fun `loads contained workspace file through bounded reader`() = runTest {
+        val expected = byteArrayOf(9, 8, 7)
+        var readPath: String? = null
+        var responseCap: Long? = null
+        val loader = loader(
+            workspaceDirectory = "/repo/project",
+            workspaceFileReader = { path, maxResponseBytes ->
+                readPath = path
+                responseCap = maxResponseBytes
+                imageFileContent(expected)
+            },
+        )
+
+        val result = loader.load(
+            filePart("file:///repo/project/images/My%20Image.png")
+        ) as ChatMediaLoadResult.Loaded
+
+        assertEquals("images/My Image.png", readPath)
+        assertEquals(MAX_CHAT_MEDIA_FILE_RESPONSE_BYTES, responseCap)
+        assertArrayEquals(expected, result.bytes)
+        assertEquals("image/png", result.mimeType)
+    }
+
+    @Test
+    fun `rejects escaped outside and remote-authority file URIs before reading`() = runTest {
+        val reads = AtomicInteger()
+        val loader = loader(
+            workspaceDirectory = "/repo/project",
+            workspaceFileReader = { _, _ ->
+                reads.incrementAndGet()
+                imageFileContent(byteArrayOf(1))
+            },
+        )
+        val cases = listOf(
+            "file:///repo/project/../secret.png",
+            "file:///other/image.png",
+            "file://remote/repo/project/image.png",
+            "file:///repo/project",
+        )
+
+        cases.forEach { assertUnavailable(loader.load(filePart(it))) }
+        assertEquals(0, reads.get())
+    }
+
+    @Test
+    fun `rejects unsafe workspace file responses`() = runTest {
+        val loader = loader(
+            workspaceDirectory = "/repo",
+            workspaceFileReader = { path, _ ->
+                when (path) {
+                    "wrong-encoding.png" -> imageFileContent(byteArrayOf(1)).copy(encoding = "utf-8")
+                    "wrong-mime.png" -> imageFileContent(byteArrayOf(1)).copy(mimeType = "text/plain")
+                    "malformed.png" -> imageFileContent(byteArrayOf()).copy(content = "***")
+                    else -> imageFileContent(byteArrayOf()).copy(
+                        content = "A".repeat(MAX_CHAT_MEDIA_BASE64_CHARS + 1),
+                    )
+                }
+            },
+        )
+
+        listOf("wrong-encoding.png", "wrong-mime.png", "malformed.png", "oversized.png")
+            .forEach { path -> assertUnavailable(loader.load(filePart("file:///repo/$path"))) }
+    }
+
+    @Test
+    fun `production lookup uses connection origin and exact-generation auth client atomically`() = runTest {
+        val expected = byteArrayOf(4, 5, 6)
+        val body = TrackingByteArrayBody(expected, "image/webp".toMediaType())
+        var authorization: String? = null
+        val server = ServerRef.fromEndpoint("https://server.test:4096")
+        val generation = ServerGeneration(7)
+        val workspaceClient = mockk<WorkspaceClient> {
+            every { workspace } returns Workspace(server, "/repo")
+            every { this@mockk.generation } returns generation
+        }
+        val authClient = OkHttpClient.Builder()
+            .addInterceptor { chain ->
+                chain.proceed(
+                    chain.request().newBuilder()
+                        .header("Authorization", "Bearer exact-generation")
+                        .build()
+                )
+            }
+            .addInterceptor { chain ->
+                authorization = chain.request().header("Authorization")
+                syntheticResponse(chain.request(), body = body)
+            }
+            .build()
+        val transport = terminalTransport(
+            authClient = authClient,
+            serverUrl = "https://server.test",
+        )
+        val registry = mockk<ServerConnectionRegistry> {
+            every { terminalTransport(server, generation) } returns transport
+        }
+        val loader = WorkspaceChatMediaLoader(workspaceClient, registry)
+
+        val result = loader.load(
+            filePart("https://server.test/media/image.webp", mime = "image/webp")
+        ) as ChatMediaLoadResult.Loaded
+        val explicitPort = loader.load(
+            filePart("https://server.test:4096/media/image.webp", mime = "image/webp")
+        )
+
+        assertEquals("Bearer exact-generation", authorization)
+        assertArrayEquals(expected, result.bytes)
+        assertEquals("image/webp", result.mimeType)
+        assertUnavailable(explicitPort)
+        assertTrue(body.closed)
+        verify(exactly = 2) { registry.terminalTransport(server, generation) }
+    }
+
+    @Test
+    fun `rejects cross-origin credentials and unsupported schemes without a request`() = runTest {
+        val lookups = AtomicInteger()
+        val requests = AtomicInteger()
+        val client = syntheticClient {
+            requests.incrementAndGet()
+            syntheticResponse(it, body = TrackingByteArrayBody(byteArrayOf(1), IMAGE_PNG))
+        }
+        val loader = loader(
+            terminalTransportLookup = {
+                lookups.incrementAndGet()
+                terminalTransport(client)
+            },
+        )
+        val cases = listOf(
+            "https://other.test/image.png",
+            "https://user:secret@server.test/image.png",
+            "ftp://server.test/image.png",
+            "content://server.test/image.png",
+            "javascript:alert(1)",
+        )
+
+        cases.forEach { assertUnavailable(loader.load(filePart(it))) }
+        assertEquals(1, lookups.get())
+        assertEquals(0, requests.get())
+    }
+
+    @Test
+    fun `rejects redirect and non-image HTTP responses and closes their bodies`() = runTest {
+        val requests = mutableListOf<String>()
+        val redirectBody = TrackingByteArrayBody(byteArrayOf(), IMAGE_PNG)
+        val textBody = TrackingByteArrayBody("not an image".toByteArray(), TEXT_PLAIN)
+        val client = syntheticClient { request ->
+            requests += request.url.encodedPath
+            when (request.url.encodedPath) {
+                "/redirect" -> syntheticResponse(
+                    request = request,
+                    code = 302,
+                    body = redirectBody,
+                    location = "https://server.test/final.png",
+                )
+                else -> syntheticResponse(request, body = textBody)
+            }
+        }
+        val loader = loader(terminalTransportLookup = { terminalTransport(client) })
+
+        assertUnavailable(loader.load(filePart("https://server.test/redirect")))
+        assertUnavailable(loader.load(filePart("https://server.test/not-image")))
+
+        assertEquals(listOf("/redirect", "/not-image"), requests)
+        assertTrue(redirectBody.closed)
+        assertTrue(textBody.closed)
+    }
+
+    @Test
+    fun `rejects HTTP when exact-generation transport is missing stale or has no origin`() = runTest {
+        // The registry lookup returns null for both an absent transport and a stale generation.
+        val unavailableTransportLoader = loader(terminalTransportLookup = { null })
+        val malformedOriginLoader = loader(
+            terminalTransportLookup = {
+                terminalTransport(
+                    authClient = OkHttpClient(),
+                    serverUrl = "not a server URL",
+                )
+            },
+        )
+
+        assertUnavailable(unavailableTransportLoader.load(filePart("https://server.test/image.png")))
+        assertUnavailable(malformedOriginLoader.load(filePart("https://server.test/image.png")))
+    }
+
+    @Test
+    fun `rejects known oversized and unknown-length HTTP bodies crossing cap`() = runTest {
+        val knownBody = GeneratingResponseBody(
+            declaredLength = MAX_CHAT_MEDIA_BYTES.toLong() + 1L,
+            bytesToEmit = MAX_CHAT_MEDIA_BYTES.toLong() + 1L,
+        )
+        val unknownBody = GeneratingResponseBody(
+            declaredLength = -1L,
+            bytesToEmit = MAX_CHAT_MEDIA_BYTES.toLong() + 1L,
+        )
+        val client = syntheticClient { request ->
+            val body = if (request.url.encodedPath == "/known") knownBody else unknownBody
+            syntheticResponse(request, body = body)
+        }
+        val loader = loader(terminalTransportLookup = { terminalTransport(client) })
+
+        assertUnavailable(loader.load(filePart("https://server.test/known")))
+        assertUnavailable(loader.load(filePart("https://server.test/unknown")))
+
+        assertEquals(0, knownBody.readCount.get())
+        assertTrue(unknownBody.readCount.get() > 0)
+        assertTrue(knownBody.closed)
+        assertTrue(unknownBody.closed)
+    }
+
+    @Test
+    fun `cancellation cancels in-flight HTTP call and is not converted to unavailable`() = runTest {
+        val started = CountDownLatch(1)
+        val canceled = CountDownLatch(1)
+        val call = mockk<Call>(relaxed = true)
+        every { call.enqueue(any()) } answers { started.countDown() }
+        every { call.cancel() } answers { canceled.countDown() }
+        val loader = loader(
+            terminalTransportLookup = { terminalTransport(OkHttpClient()) },
+            httpCallFactory = { _, _ -> call },
+        )
+        val result = async { loader.load(filePart("https://server.test/slow.png")) }
+        runCurrent()
+
+        assertTrue(started.await(AWAIT_SECONDS, TimeUnit.SECONDS))
+        result.cancelAndJoin()
+
+        assertTrue(result.isCancelled)
+        assertTrue(canceled.await(AWAIT_SECONDS, TimeUnit.SECONDS))
+        verify(exactly = 1) { call.cancel() }
+    }
+
+    @Test
+    fun `derived HTTP client replaces inherited infinite read and call timeouts`() = runTest {
+        val body = TrackingByteArrayBody(byteArrayOf(1), IMAGE_PNG)
+        val authClient = syntheticClient { request -> syntheticResponse(request, body = body) }
+            .newBuilder()
+            .readTimeout(0, TimeUnit.SECONDS)
+            .callTimeout(0, TimeUnit.SECONDS)
+            .build()
+        var derivedClient: OkHttpClient? = null
+        val loader = loader(
+            terminalTransportLookup = { terminalTransport(authClient) },
+            httpCallFactory = { client, request ->
+                derivedClient = client
+                client.newCall(request)
+            },
+        )
+
+        val result = loader.load(filePart("https://server.test/image.png"))
+
+        assertTrue(result is ChatMediaLoadResult.Loaded)
+        assertEquals(0, authClient.readTimeoutMillis)
+        assertEquals(0, authClient.callTimeoutMillis)
+        assertEquals(EXPECTED_MEDIA_TIMEOUT_MILLIS, derivedClient?.readTimeoutMillis)
+        assertEquals(EXPECTED_MEDIA_TIMEOUT_MILLIS, derivedClient?.callTimeoutMillis)
+        assertTrue(body.closed)
+    }
+
+    private fun loader(
+        workspaceDirectory: String? = "/repo",
+        workspaceFileReader: suspend (String, Long) -> FileContentDto = { _, _ ->
+            error("Unexpected workspace read")
+        },
+        terminalTransportLookup: () -> TerminalTransport? = { null },
+        httpCallFactory: (OkHttpClient, Request) -> Call = { client, request -> client.newCall(request) },
+    ): WorkspaceChatMediaLoader = WorkspaceChatMediaLoader(
+        workspaceDirectory = workspaceDirectory,
+        workspaceFileReader = workspaceFileReader,
+        terminalTransportLookup = terminalTransportLookup,
+        httpCallFactory = httpCallFactory,
+    )
+
+    private fun terminalTransport(
+        authClient: OkHttpClient,
+        serverUrl: String = "https://server.test/api",
+    ): TerminalTransport = TerminalTransport(
+        connection = mockk<Connection> {
+            every { config } returns ServerConfig(url = serverUrl)
+        },
+        authClient = authClient,
+    )
+
+    private fun filePart(url: String, mime: String = "image/png"): Part.File = Part.File(
+        id = "part-1",
+        sessionID = "session-1",
+        messageID = "message-1",
+        mime = mime,
+        filename = null,
+        url = url,
+    )
+
+    private fun imageFileContent(bytes: ByteArray): FileContentDto = FileContentDto(
+        type = "text",
+        content = Base64.getEncoder().encodeToString(bytes),
+        encoding = "base64",
+        mimeType = "image/png",
+    )
+
+    private fun assertUnavailable(result: ChatMediaLoadResult) {
+        assertSame(ChatMediaLoadResult.Unavailable, result)
+    }
+
+    private fun syntheticClient(handler: (Request) -> Response): OkHttpClient = OkHttpClient.Builder()
+        .addInterceptor { chain -> handler(chain.request()) }
+        .build()
+
+    private fun syntheticResponse(
+        request: Request,
+        code: Int = 200,
+        body: ResponseBody,
+        location: String? = null,
+    ): Response = Response.Builder()
+        .request(request)
+        .protocol(Protocol.HTTP_1_1)
+        .code(code)
+        .message("Synthetic")
+        .body(body)
+        .apply { location?.let { header("Location", it) } }
+        .build()
+
+    private class TrackingByteArrayBody(
+        bytes: ByteArray,
+        private val mediaType: MediaType,
+    ) : ResponseBody() {
+        var closed = false
+            private set
+        private val input = object : ByteArrayInputStream(bytes) {
+            override fun close() {
+                closed = true
+                super.close()
+            }
+        }
+        private val bufferedSource by lazy { input.source().buffer() }
+
+        override fun contentType(): MediaType = mediaType
+
+        override fun contentLength(): Long = input.available().toLong()
+
+        override fun source(): BufferedSource = bufferedSource
+    }
+
+    private class GeneratingResponseBody(
+        private val declaredLength: Long,
+        bytesToEmit: Long,
+    ) : ResponseBody() {
+        val readCount = AtomicInteger()
+        var closed = false
+            private set
+        private val input = GeneratingInputStream(bytesToEmit, readCount) { closed = true }
+        private val bufferedSource by lazy { input.source().buffer() }
+
+        override fun contentType(): MediaType = IMAGE_PNG
+
+        override fun contentLength(): Long = declaredLength
+
+        override fun source(): BufferedSource = bufferedSource
+    }
+
+    private class GeneratingInputStream(
+        private var remaining: Long,
+        private val readCount: AtomicInteger,
+        private val onClose: () -> Unit,
+    ) : InputStream() {
+        override fun read(): Int {
+            if (remaining == 0L) return -1
+            remaining -= 1L
+            readCount.incrementAndGet()
+            return 0
+        }
+
+        override fun read(buffer: ByteArray, offset: Int, length: Int): Int {
+            if (remaining == 0L) return -1
+            val count = minOf(remaining, length.toLong()).toInt()
+            buffer.fill(0, offset, offset + count)
+            remaining -= count
+            readCount.incrementAndGet()
+            return count
+        }
+
+        override fun close() {
+            onClose()
+        }
+    }
+
+    private companion object {
+        val IMAGE_PNG: MediaType = "image/png".toMediaType()
+        val TEXT_PLAIN: MediaType = "text/plain".toMediaType()
+        const val AWAIT_SECONDS = 5L
+        const val EXPECTED_MEDIA_TIMEOUT_MILLIS = 60_000
+    }
+}

--- a/app/src/test/java/dev/blazelight/p4oc/data/workspace/WorkspaceClientTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/data/workspace/WorkspaceClientTest.kt
@@ -3,6 +3,7 @@ package dev.blazelight.p4oc.data.workspace
 import dev.blazelight.p4oc.core.network.ConnectionState
 import dev.blazelight.p4oc.core.network.OpenCodeApi
 import dev.blazelight.p4oc.data.remote.dto.ConfigDto
+import dev.blazelight.p4oc.data.remote.dto.FileContentDto
 import dev.blazelight.p4oc.data.remote.dto.ForkSessionRequest
 import dev.blazelight.p4oc.data.remote.dto.ProvidersResponseDto
 import dev.blazelight.p4oc.data.remote.dto.QuestionDto
@@ -21,6 +22,10 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.SerializationException
@@ -29,13 +34,22 @@ import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.ResponseBody
 import okhttp3.ResponseBody.Companion.toResponseBody
+import okio.Buffer
+import okio.BufferedSource
+import okio.Source
+import okio.Timeout
+import okio.buffer
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Test
 import org.koin.dsl.koinApplication
 import retrofit2.HttpException
 import retrofit2.Response
+import java.io.IOException
 import java.net.SocketTimeoutException
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 class WorkspaceClientTest {
     @Test
@@ -314,6 +328,144 @@ class WorkspaceClientTest {
     }
 
     @Test
+    fun `bounded file read uses raw workspace endpoint and injected production json`() = runTest {
+        val api = mockk<OpenCodeApi>()
+        val responseJson = """
+            {
+              "type": "text",
+              "content": "hello",
+              "futureServerField": { "nested": true }
+            }
+        """.trimIndent()
+        coEvery { api.readFileRaw("assets/image.json", "/repo", null) } returns
+            Response.success(responseJson.toResponseBody("application/json".toMediaType()))
+        val productionJson = Json {
+            ignoreUnknownKeys = true
+            isLenient = true
+            coerceInputValues = true
+        }
+        val client = workspaceClient(api, productionJson)
+
+        assertEquals(
+            FileContentDto(type = "text", content = "hello"),
+            client.readFileBounded("assets/image.json", maxResponseBytes = 1024),
+        )
+
+        coVerify(exactly = 1) { api.readFileRaw("assets/image.json", "/repo", null) }
+        coVerify(exactly = 0) { api.readFile(any(), any(), any()) }
+    }
+
+    @Test
+    fun `bounded file read rejects declared oversize before streaming`() = runTest {
+        val api = mockk<OpenCodeApi>()
+        val responseBody = mockk<ResponseBody>(relaxed = true)
+        every { responseBody.contentLength() } returns 65L
+        coEvery { api.readFileRaw("large.json", "/repo", null) } returns Response.success(responseBody)
+        val client = workspaceClient(api)
+
+        assertFileResponseTooLarge {
+            client.readFileBounded("large.json", maxResponseBytes = 64)
+        }
+
+        verify(exactly = 0) { responseBody.source() }
+        verify(exactly = 1) { responseBody.close() }
+    }
+
+    @Test
+    fun `bounded file read stops unknown length stream after limit plus one`() = runTest {
+        val api = mockk<OpenCodeApi>()
+        val responseSource = Buffer().writeUtf8("0123456789abcdef")
+        val responseBody = mockk<ResponseBody>(relaxed = true)
+        every { responseBody.contentLength() } returns -1L
+        every { responseBody.source() } returns responseSource
+        coEvery { api.readFileRaw("stream.json", "/repo", null) } returns Response.success(responseBody)
+        val client = workspaceClient(api)
+
+        assertFileResponseTooLarge {
+            client.readFileBounded("stream.json", maxResponseBytes = 8)
+        }
+
+        assertEquals(7L, responseSource.size)
+        verify(exactly = 1) { responseBody.close() }
+    }
+
+    @Test
+    fun `bounded file read closes non-success error body`() = runTest {
+        val api = mockk<OpenCodeApi>()
+        val errorBody = mockk<ResponseBody>(relaxed = true)
+        coEvery { api.readFileRaw("forbidden.json", "/repo", null) } returns Response.error(403, errorBody)
+        val client = workspaceClient(api)
+
+        assertHttpError(403) {
+            client.readFileBounded("forbidden.json", maxResponseBytes = 1024)
+        }
+
+        verify(exactly = 1) { errorBody.close() }
+    }
+
+    @Test
+    fun `bounded file read closes body and propagates malformed json`() = runTest {
+        val api = mockk<OpenCodeApi>()
+        val malformedSource = Buffer().writeUtf8("{malformed")
+        val responseBody = mockk<ResponseBody>(relaxed = true)
+        every { responseBody.contentLength() } returns malformedSource.size
+        every { responseBody.source() } returns malformedSource
+        coEvery { api.readFileRaw("malformed.json", "/repo", null) } returns Response.success(responseBody)
+        val client = workspaceClient(api)
+
+        try {
+            client.readFileBounded("malformed.json", maxResponseBytes = 1024)
+            fail("Expected malformed file JSON to fail")
+        } catch (_: SerializationException) {
+            // Expected from the injected JSON decoder after the bounded stream is fully read.
+        }
+
+        verify(exactly = 1) { responseBody.close() }
+    }
+
+    @Test
+    fun `cancelling bounded file read closes body to unblock interrupt-resistant stream`() = runTest {
+        val api = mockk<OpenCodeApi>()
+        val responseBody = BlockingResponseBody()
+        coEvery { api.readFileRaw("slow.json", "/repo", null) } returns Response.success(responseBody)
+        val client = workspaceClient(api)
+        val result = async(Dispatchers.IO) {
+            client.readFileBounded("slow.json", maxResponseBytes = 1024)
+        }
+
+        try {
+            assertTrue(responseBody.readStarted.await(AWAIT_SECONDS, TimeUnit.SECONDS))
+            result.cancel()
+            assertTrue(responseBody.closed.await(AWAIT_SECONDS, TimeUnit.SECONDS))
+
+            try {
+                result.await()
+                fail("Expected bounded file read cancellation to propagate")
+            } catch (_: CancellationException) {
+                // Expected: cancellation must not be converted to a file result.
+            }
+        } finally {
+            responseBody.close()
+            result.cancelAndJoin()
+        }
+    }
+
+    @Test
+    fun `bounded file read rejects nonpositive limit before resolving api`() = runTest {
+        val api = mockk<OpenCodeApi>()
+        val client = workspaceClient(api)
+
+        try {
+            client.readFileBounded("file.json", maxResponseBytes = 0)
+            fail("Expected nonpositive response limit to fail")
+        } catch (error: IllegalArgumentException) {
+            assertEquals("maxResponseBytes must be positive", error.message)
+        }
+
+        coVerify(exactly = 0) { api.readFileRaw(any(), any(), any()) }
+    }
+
+    @Test
     fun `clients with identical session ids keep distinct api and connection authority`() = runTest {
         val firstApi = mockk<OpenCodeApi>()
         val secondApi = mockk<OpenCodeApi>()
@@ -391,13 +543,16 @@ class WorkspaceClientTest {
         coVerify(exactly = 1) { api.listProjects(null, null) }
     }
 
-    private fun questionClient(api: OpenCodeApi): WorkspaceClient {
+    private fun questionClient(api: OpenCodeApi): WorkspaceClient = workspaceClient(api)
+
+    private fun workspaceClient(api: OpenCodeApi, json: Json = Json.Default): WorkspaceClient {
         val server = ServerRef.fromEndpointKey("http://test.local")
         return WorkspaceClient(
             workspace = Workspace(server, directory = "/repo"),
             generation = ServerGeneration(1L),
             apiProvider = ActiveServerApiProvider { _, _ -> api },
             connectionState = MutableStateFlow(ConnectionState.Connected),
+            json = json,
         )
     }
 
@@ -408,6 +563,46 @@ class WorkspaceClientTest {
         } catch (error: HttpException) {
             assertEquals(code, error.code())
         }
+    }
+
+    private suspend fun assertFileResponseTooLarge(block: suspend () -> Unit) {
+        try {
+            block()
+            fail("Expected bounded file response to be rejected")
+        } catch (error: IOException) {
+            assertEquals("File response exceeds the allowed size", error.message)
+        }
+    }
+
+    private class BlockingResponseBody : ResponseBody() {
+        val readStarted = CountDownLatch(1)
+        val closed = CountDownLatch(1)
+        private val blockingSource = object : Source {
+            override fun read(sink: Buffer, byteCount: Long): Long {
+                readStarted.countDown()
+                while (true) {
+                    try {
+                        closed.await()
+                        return -1L
+                    } catch (_: InterruptedException) {
+                        // Deliberately ignore thread interruption: only closing the body may unblock this source.
+                    }
+                }
+            }
+
+            override fun timeout(): Timeout = Timeout.NONE
+
+            override fun close() {
+                closed.countDown()
+            }
+        }
+        private val bufferedSource: BufferedSource = blockingSource.buffer()
+
+        override fun contentType(): okhttp3.MediaType? = null
+
+        override fun contentLength(): Long = -1L
+
+        override fun source(): BufferedSource = bufferedSource
     }
 
     private fun jsonResponse(content: String): Response<ResponseBody> =
@@ -444,4 +639,8 @@ class WorkspaceClientTest {
             )
         ),
     )
+
+    private companion object {
+        const val AWAIT_SECONDS = 5L
+    }
 }

--- a/app/src/test/java/dev/blazelight/p4oc/ui/components/toolwidgets/ToolAttachmentPresentationTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/ui/components/toolwidgets/ToolAttachmentPresentationTest.kt
@@ -1,0 +1,69 @@
+package dev.blazelight.p4oc.ui.components.toolwidgets
+
+import dev.blazelight.p4oc.domain.model.Part
+import dev.blazelight.p4oc.domain.model.ToolState
+import kotlinx.serialization.json.buildJsonObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ToolAttachmentPresentationTest {
+
+    @Test
+    fun completedToolAttachments_preservesServerFileOrder() {
+        val first = filePart(id = "first", filename = "first.png")
+        val second = filePart(id = "second", filename = "second.jpg")
+
+        val result = completedToolAttachments(completed(attachments = listOf(first, second)))
+
+        assertEquals(listOf(first, second), result)
+    }
+
+    @Test
+    fun completedToolAttachments_excludesNonFileAttachments() {
+        val file = filePart(id = "image", filename = "capture.png")
+        val text = Part.Text(
+            id = "text",
+            sessionID = "session",
+            messageID = "message",
+            text = "not an attachment preview",
+        )
+
+        val result = completedToolAttachments(completed(attachments = listOf(text, file)))
+
+        assertEquals(listOf(file), result)
+    }
+
+    @Test
+    fun completedToolAttachments_returnsEmptyForNonCompletedStates() {
+        val input = buildJsonObject { }
+
+        val states = listOf<ToolState>(
+            ToolState.Pending(input = input, rawInput = ""),
+            ToolState.Running(input = input, title = "Running", startedAt = 1L),
+            ToolState.Error(input = input, error = "Failed", startedAt = 1L, endedAt = 2L),
+        )
+
+        states.forEach { state ->
+            assertTrue(completedToolAttachments(state).isEmpty())
+        }
+    }
+
+    private fun completed(attachments: List<Part>?): ToolState.Completed = ToolState.Completed(
+        input = buildJsonObject { },
+        output = "Done",
+        title = "Completed",
+        startedAt = 1L,
+        endedAt = 2L,
+        attachments = attachments,
+    )
+
+    private fun filePart(id: String, filename: String): Part.File = Part.File(
+        id = id,
+        sessionID = "session",
+        messageID = "message",
+        mime = "image/png",
+        filename = filename,
+        url = "data:image/png;base64,$id",
+    )
+}


### PR DESCRIPTION
## Summary
- render user, assistant, and completed-tool image attachments through one shared preview
- add bounded `data:`, workspace `file:`, and exact-generation same-origin HTTP(S) media loading
- add accessible in-app fullscreen viewing and concise non-image metadata
- keep attachment-only user turns visible and generic failure states free of source details

## Security
- cap decoded image payloads at 8 MiB
- derive origin and auth atomically from the exact-generation terminal transport
- reject redirects, cross-origin/userinfo requests, unsupported MIME/schemes, path escapes, and oversized streams
- make bounded workspace reads cancellation-close the exact response body

## Verification
- `:app:testDebugUnitTest --tests dev.blazelight.p4oc.data.media.ChatMediaLoaderTest --tests dev.blazelight.p4oc.data.workspace.WorkspaceClientTest`
- `:app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=dev.blazelight.p4oc.ui.components.chat.ChatAttachmentPresentationTest` on Samsung `R58X70XHB9P`
- `:app:compileDebugKotlin :app:compileDebugAndroidTestKotlin :app:detekt :app:testDebugUnitTest`
- explicit Samsung install/cold-launch crash smoke

Closes #61