### PR TITLE
Harden permission reply compatibility fallback

### DIFF
--- a/app/src/main/java/dev/blazelight/p4oc/data/workspace/WorkspaceClient.kt
+++ b/app/src/main/java/dev/blazelight/p4oc/data/workspace/WorkspaceClient.kt
@@ -235,12 +235,13 @@ class WorkspaceClient(
     suspend fun respondToPermission(
         sessionId: String,
         requestId: String,
-        request: PermissionResponseRequest
+        request: PermissionResponseRequest,
     ): Boolean {
         val response = api.respondToPermissionV2(sessionId, requestId, request)
-        val contentType = response.headers()["Content-Type"].orEmpty()
-        if (response.isSuccessful && !contentType.startsWith("text/html")) return true
-        if (response.code() != 404 && !contentType.startsWith("text/html")) throw HttpException(response)
+        when (response.classifyPermissionResponse()) {
+            PermissionResponseDisposition.Success -> return true
+            PermissionResponseDisposition.Fallback -> Unit
+        }
 
         return respondToPermissionLegacy(requestId, request)
     }
@@ -295,6 +296,38 @@ class WorkspaceClient(
 
     private fun retrofit2.Response<*>.isUsableV2Response(): Boolean =
         isSuccessful && !headers()["Content-Type"].orEmpty().startsWith("text/html")
+
+    private enum class PermissionResponseDisposition { Success, Fallback }
+
+    private fun retrofit2.Response<Unit>.classifyPermissionResponse(): PermissionResponseDisposition = when {
+        code() == 404 -> {
+            closePermissionResponseBodies()
+            PermissionResponseDisposition.Fallback
+        }
+        !isSuccessful -> {
+            closePermissionResponseBodies()
+            throw HttpException(this)
+        }
+        isHtmlPermissionResponse() -> {
+            closePermissionResponseBodies()
+            PermissionResponseDisposition.Fallback
+        }
+        else -> {
+            closePermissionResponseBodies()
+            PermissionResponseDisposition.Success
+        }
+    }
+
+    private fun retrofit2.Response<Unit>.isHtmlPermissionResponse(): Boolean =
+        headers()["Content-Type"].isHtmlContentType() ||
+            raw().body.contentType()?.toString().isHtmlContentType()
+
+    private fun retrofit2.Response<Unit>.closePermissionResponseBodies() {
+        // Retrofit's Unit converter closes the original successful response body before returning.
+        // raw().body is a metadata-only NoContentResponseBody whose close() attempts to read its
+        // unavailable source and throws. Only the buffered error body remains ours to close.
+        errorBody()?.close()
+    }
 
     private enum class LegacyQuestionResponseDisposition { Decode, Fallback }
 

--- a/app/src/test/java/dev/blazelight/p4oc/data/workspace/WorkspaceClientPermissionFallbackTest.kt
+++ b/app/src/test/java/dev/blazelight/p4oc/data/workspace/WorkspaceClientPermissionFallbackTest.kt
@@ -1,0 +1,430 @@
+package dev.blazelight.p4oc.data.workspace
+
+import dev.blazelight.p4oc.core.network.ConnectionState
+import dev.blazelight.p4oc.core.network.OpenCodeApi
+import dev.blazelight.p4oc.data.remote.dto.PermissionResponseRequest
+import dev.blazelight.p4oc.data.server.ActiveServerApiProvider
+import dev.blazelight.p4oc.domain.server.ServerGeneration
+import dev.blazelight.p4oc.domain.server.ServerRef
+import dev.blazelight.p4oc.domain.workspace.Workspace
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.ResponseBody
+import okhttp3.ResponseBody.Companion.toResponseBody
+import okio.BufferedSource
+import okio.buffer
+import okio.source
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.fail
+import org.junit.Test
+import retrofit2.HttpException
+import retrofit2.Response
+import retrofit2.Retrofit
+import retrofit2.converter.kotlinx.serialization.asConverterFactory
+import java.io.ByteArrayInputStream
+import java.io.IOException
+
+class WorkspaceClientPermissionFallbackTest {
+    @Test
+    fun `real retrofit transport closes html v2 body then routes one legacy mutation`() = runTest {
+        val routes = mutableListOf<Request>()
+        val htmlBody = TrackingResponseBody(
+            content = "<html>legacy server</html>",
+            mediaType = "text/html; charset=utf-8".toMediaType(),
+        )
+        val okHttpClient = OkHttpClient.Builder()
+            .addInterceptor { chain ->
+                val request = chain.request()
+                routes += request
+                when (routes.size) {
+                    1 -> transportResponse(request, htmlBody)
+                    2 -> transportResponse(
+                        request,
+                        "true".toResponseBody("application/json".toMediaType()),
+                    )
+                    else -> throw AssertionError("Unexpected third permission mutation: ${request.url}")
+                }
+            }
+            .build()
+        val json = Json {
+            ignoreUnknownKeys = true
+            isLenient = true
+            encodeDefaults = false
+            explicitNulls = false
+            coerceInputValues = true
+        }
+        val api = Retrofit.Builder()
+            .baseUrl("http://test.local/")
+            .client(okHttpClient)
+            .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
+            .build()
+            .create(OpenCodeApi::class.java)
+        val request = PermissionResponseRequest(reply = "once")
+
+        assertEquals(true, workspaceClient(api).respondToPermission("ses_1", "per_1", request))
+
+        assertEquals(true, htmlBody.closed)
+        assertEquals(
+            listOf(
+                "/api/session/ses_1/permission/per_1/reply",
+                "/permission/per_1/reply",
+            ),
+            routes.map { it.url.encodedPath },
+        )
+        assertEquals(listOf("POST", "POST"), routes.map { it.method })
+        assertEquals(emptySet<String>(), routes[0].url.queryParameterNames)
+        assertEquals(setOf("directory"), routes[1].url.queryParameterNames)
+        assertEquals("/repo", routes[1].url.queryParameter("directory"))
+        assertEquals(null, routes[1].url.queryParameter("workspace"))
+        assertEquals(2, routes.size)
+    }
+
+    @Test
+    fun `permission v2 ordinary success closes body and does not call legacy`() = runTest {
+        val api = mockk<OpenCodeApi>()
+        val request = PermissionResponseRequest(reply = "once")
+        val sourceBody = mockk<ResponseBody>(relaxed = true)
+        val metadataBody = mockk<ResponseBody>(relaxed = true)
+        every { metadataBody.contentType() } returns "application/json".toMediaType()
+        coEvery { api.respondToPermissionV2("ses_1", "per_1", request) } answers {
+            sourceBody.close()
+            unitSuccessResponse(metadataBody)
+        }
+        val client = workspaceClient(api)
+
+        assertEquals(true, client.respondToPermission("ses_1", "per_1", request))
+
+        verify(exactly = 1) { sourceBody.close() }
+        verify(exactly = 0) { metadataBody.close() }
+        coVerify(exactly = 1) { api.respondToPermissionV2("ses_1", "per_1", request) }
+        coVerify(exactly = 0) { api.respondToPermission(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `permission v2 404 closes body before one legacy call with exact workspace scope`() = runTest {
+        val api = mockk<OpenCodeApi>()
+        val request = PermissionResponseRequest(reply = "always", message = "approved")
+        val responseBody = mockk<ResponseBody>(relaxed = true)
+        coEvery { api.respondToPermissionV2("ses_1", "per_1", request) } returns
+            Response.error(404, responseBody)
+        coEvery { api.respondToPermission("per_1", request, "/repo", null) } answers {
+            verify(exactly = 1) { responseBody.close() }
+            false
+        }
+        val client = workspaceClient(api)
+
+        assertEquals(false, client.respondToPermission("ses_1", "per_1", request))
+
+        verify(exactly = 1) { responseBody.close() }
+        coVerify(exactly = 1) { api.respondToPermissionV2("ses_1", "per_1", request) }
+        coVerify(exactly = 1) { api.respondToPermission("per_1", request, "/repo", null) }
+        coVerify(exactly = 1) { api.respondToPermission(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `permission v2 successful html header trims whitespace and ignores case then falls back once`() = runTest {
+        val api = mockk<OpenCodeApi>()
+        val request = PermissionResponseRequest(reply = "once")
+        val sourceBody = mockk<ResponseBody>(relaxed = true)
+        val metadataBody = mockk<ResponseBody>(relaxed = true)
+        every { metadataBody.contentType() } returns null
+        coEvery { api.respondToPermissionV2("ses_1", "per_header", request) } answers {
+            sourceBody.close()
+            unitSuccessResponse(metadataBody, headerContentType = " TeXt/HtMl \t; Charset=UTF-8 ")
+        }
+        coEvery { api.respondToPermission("per_header", request, "/repo", null) } answers {
+            verify(exactly = 1) { sourceBody.close() }
+            verify(exactly = 0) { metadataBody.close() }
+            true
+        }
+        val client = workspaceClient(api)
+
+        assertEquals(true, client.respondToPermission("ses_1", "per_header", request))
+
+        verify(exactly = 1) { sourceBody.close() }
+        verify(exactly = 0) { metadataBody.close() }
+        coVerify(exactly = 1) { api.respondToPermissionV2("ses_1", "per_header", request) }
+        coVerify(exactly = 1) { api.respondToPermission("per_header", request, "/repo", null) }
+        coVerify(exactly = 1) { api.respondToPermission(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `permission v2 html raw metadata overrides conflicting non-html header`() = runTest {
+        val api = mockk<OpenCodeApi>()
+        val request = PermissionResponseRequest(reply = "reject")
+        val sourceBody = mockk<ResponseBody>(relaxed = true)
+        val metadataBody = mockk<ResponseBody>(relaxed = true)
+        every { metadataBody.contentType() } returns "TeXt/HtMl; Charset=UTF-8".toMediaType()
+        coEvery { api.respondToPermissionV2("ses_1", "per_body", request) } answers {
+            sourceBody.close()
+            unitSuccessResponse(metadataBody, headerContentType = "application/json; charset=utf-8")
+        }
+        coEvery { api.respondToPermission("per_body", request, "/repo", null) } answers {
+            verify(exactly = 1) { sourceBody.close() }
+            verify(exactly = 0) { metadataBody.close() }
+            true
+        }
+        val client = workspaceClient(api)
+
+        assertEquals(true, client.respondToPermission("ses_1", "per_body", request))
+
+        verify(exactly = 1) { sourceBody.close() }
+        verify(exactly = 0) { metadataBody.close() }
+        coVerify(exactly = 1) { api.respondToPermissionV2("ses_1", "per_body", request) }
+        coVerify(exactly = 1) { api.respondToPermission("per_body", request, "/repo", null) }
+        coVerify(exactly = 1) { api.respondToPermission(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `permission v2 html server error closes body and propagates without legacy`() = runTest {
+        val api = mockk<OpenCodeApi>()
+        val request = PermissionResponseRequest(reply = "once")
+        val responseBody = mockk<ResponseBody>(relaxed = true)
+        every { responseBody.contentType() } returns "text/html; charset=utf-8".toMediaType()
+        val response = unitErrorResponse(
+            code = 500,
+            body = responseBody,
+            headerContentType = "text/html; charset=utf-8",
+        )
+        coEvery { api.respondToPermissionV2("ses_1", "per_1", request) } returns response
+        val client = workspaceClient(api)
+
+        assertSame(
+            response,
+            assertHttpResponse(500) {
+                client.respondToPermission("ses_1", "per_1", request)
+            },
+        )
+
+        verify(exactly = 1) { responseBody.close() }
+        coVerify(exactly = 1) { api.respondToPermissionV2("ses_1", "per_1", request) }
+        coVerify(exactly = 0) { api.respondToPermission(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `permission v2 ordinary error closes body and propagates without legacy`() = runTest {
+        val api = mockk<OpenCodeApi>()
+        val request = PermissionResponseRequest(reply = "once")
+        val responseBody = mockk<ResponseBody>(relaxed = true)
+        val response = Response.error<Unit>(403, responseBody)
+        coEvery { api.respondToPermissionV2("ses_1", "per_1", request) } returns response
+        val client = workspaceClient(api)
+
+        assertSame(
+            response,
+            assertHttpResponse(403) {
+                client.respondToPermission("ses_1", "per_1", request)
+            },
+        )
+
+        verify(exactly = 1) { responseBody.close() }
+        coVerify(exactly = 1) { api.respondToPermissionV2("ses_1", "per_1", request) }
+        coVerify(exactly = 0) { api.respondToPermission(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `permission v2 non-fallback status matrix preserves response and closes error body`() = runTest {
+        val cases = listOf(302, 401, 422, 429, 503).map { status ->
+            val responseBody = mockk<ResponseBody>(relaxed = true)
+            Triple(status, unitErrorResponse(status, responseBody), responseBody)
+        }
+
+        cases.forEach { (status, response, responseBody) ->
+            val api = mockk<OpenCodeApi>()
+            val request = PermissionResponseRequest(reply = "once")
+            coEvery { api.respondToPermissionV2("ses_1", "per_1", request) } returns response
+            val client = workspaceClient(api)
+
+            assertSame(
+                response,
+                assertHttpResponse(status) {
+                    client.respondToPermission("ses_1", "per_1", request)
+                },
+            )
+
+            verify(exactly = 1) { responseBody.close() }
+            coVerify(exactly = 1) { api.respondToPermissionV2("ses_1", "per_1", request) }
+            coVerify(exactly = 0) { api.respondToPermission(any(), any(), any(), any()) }
+        }
+    }
+
+    @Test
+    fun `permission v2 cancellation propagates without legacy fallback`() = runTest {
+        val api = mockk<OpenCodeApi>()
+        val request = PermissionResponseRequest(reply = "once")
+        val cancellation = CancellationException("v2 cancelled")
+        coEvery { api.respondToPermissionV2("ses_1", "per_1", request) } throws cancellation
+        val client = workspaceClient(api)
+
+        try {
+            client.respondToPermission("ses_1", "per_1", request)
+            fail("Expected v2 cancellation")
+        } catch (error: CancellationException) {
+            assertSame(cancellation, error)
+        }
+
+        coVerify(exactly = 1) { api.respondToPermissionV2("ses_1", "per_1", request) }
+        coVerify(exactly = 0) { api.respondToPermission(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `permission legacy cancellation after fallback is not retried`() = runTest {
+        val api = mockk<OpenCodeApi>()
+        val request = PermissionResponseRequest(reply = "once")
+        val responseBody = mockk<ResponseBody>(relaxed = true)
+        val cancellation = CancellationException("legacy cancelled")
+        coEvery { api.respondToPermissionV2("ses_1", "per_1", request) } returns
+            Response.error(404, responseBody)
+        coEvery { api.respondToPermission("per_1", request, "/repo", null) } throws cancellation
+        val client = workspaceClient(api)
+
+        try {
+            client.respondToPermission("ses_1", "per_1", request)
+            fail("Expected legacy cancellation")
+        } catch (error: CancellationException) {
+            assertSame(cancellation, error)
+        }
+
+        verify(exactly = 1) { responseBody.close() }
+        coVerify(exactly = 1) { api.respondToPermissionV2("ses_1", "per_1", request) }
+        coVerify(exactly = 1) { api.respondToPermission("per_1", request, "/repo", null) }
+    }
+
+    @Test
+    fun `permission legacy io failure after fallback propagates exactly without retry`() = runTest {
+        val api = mockk<OpenCodeApi>()
+        val request = PermissionResponseRequest(reply = "once")
+        val responseBody = mockk<ResponseBody>(relaxed = true)
+        val failure = IOException("legacy permission transport failure")
+        coEvery { api.respondToPermissionV2("ses_1", "per_1", request) } returns
+            unitErrorResponse(404, responseBody)
+        coEvery { api.respondToPermission("per_1", request, "/repo", null) } throws failure
+        val client = workspaceClient(api)
+
+        try {
+            client.respondToPermission("ses_1", "per_1", request)
+            fail("Expected legacy permission transport failure")
+        } catch (error: IOException) {
+            assertSame(failure, error)
+        }
+
+        verify(exactly = 1) { responseBody.close() }
+        coVerify(exactly = 1) { api.respondToPermissionV2("ses_1", "per_1", request) }
+        coVerify(exactly = 1) { api.respondToPermission("per_1", request, "/repo", null) }
+    }
+
+    @Test
+    fun `permission fallback preserves intentional null workspace directory`() = runTest {
+        val api = mockk<OpenCodeApi>()
+        val request = PermissionResponseRequest(reply = "once")
+        val responseBody = mockk<ResponseBody>(relaxed = true)
+        coEvery { api.respondToPermissionV2("ses_1", "per_1", request) } returns
+            Response.error(404, responseBody)
+        coEvery { api.respondToPermission("per_1", request, null, null) } returns true
+        val client = workspaceClient(api, directory = null)
+
+        assertEquals(true, client.respondToPermission("ses_1", "per_1", request))
+
+        verify(exactly = 1) { responseBody.close() }
+        coVerify(exactly = 1) { api.respondToPermissionV2("ses_1", "per_1", request) }
+        coVerify(exactly = 1) { api.respondToPermission("per_1", request, null, null) }
+    }
+
+    private fun workspaceClient(
+        api: OpenCodeApi,
+        directory: String? = "/repo",
+    ): WorkspaceClient {
+        val server = ServerRef.fromEndpointKey("http://test.local")
+        return WorkspaceClient(
+            workspace = Workspace(server, directory = directory),
+            generation = ServerGeneration(1L),
+            apiProvider = ActiveServerApiProvider { _, _ -> api },
+            connectionState = MutableStateFlow(ConnectionState.Connected),
+        )
+    }
+
+    private suspend fun assertHttpResponse(
+        code: Int,
+        block: suspend () -> Unit,
+    ): Response<*> = try {
+        block()
+        fail("Expected HTTP $code")
+        error("Unreachable")
+    } catch (error: HttpException) {
+        assertEquals(code, error.code())
+        requireNotNull(error.response())
+    }
+
+    private fun unitSuccessResponse(
+        metadataBody: ResponseBody,
+        headerContentType: String? = null,
+    ): Response<Unit> = Response.success(Unit, rawResponse(200, metadataBody, headerContentType))
+
+    private fun unitErrorResponse(
+        code: Int,
+        body: ResponseBody,
+        headerContentType: String? = null,
+    ): Response<Unit> = Response.error(
+        body,
+        rawResponse(code, body = null, headerContentType = headerContentType),
+    )
+
+    private fun rawResponse(
+        code: Int,
+        body: ResponseBody?,
+        headerContentType: String?,
+    ): okhttp3.Response {
+        val builder = okhttp3.Response.Builder()
+            .request(okhttp3.Request.Builder().url("http://test.local").build())
+            .protocol(okhttp3.Protocol.HTTP_1_1)
+            .code(code)
+            .message("HTTP $code")
+        if (body != null) builder.body(body)
+        if (headerContentType != null) builder.header("Content-Type", headerContentType)
+        return builder.build()
+    }
+
+    private fun transportResponse(request: Request, body: ResponseBody): okhttp3.Response =
+        okhttp3.Response.Builder()
+            .request(request)
+            .protocol(Protocol.HTTP_1_1)
+            .code(200)
+            .message("OK")
+            .body(body)
+            .build()
+
+    private class TrackingResponseBody(
+        content: String,
+        private val mediaType: MediaType,
+    ) : ResponseBody() {
+        var closed = false
+            private set
+        private val bytes = content.encodeToByteArray()
+        private val input = object : ByteArrayInputStream(bytes) {
+            override fun close() {
+                closed = true
+                super.close()
+            }
+        }
+        private val bufferedSource by lazy { input.source().buffer() }
+
+        override fun contentType(): MediaType? = mediaType
+
+        override fun contentLength(): Long = bytes.size.toLong()
+
+        override fun source(): BufferedSource = bufferedSource
+    }
+}

--- a/openspec/changes/harden-permission-reply-fallback/proposal.md
+++ b/openspec/changes/harden-permission-reply-fallback/proposal.md
@@ -1,0 +1,50 @@
+# Change: Harden permission reply compatibility fallback
+
+## Why
+
+GitHub issue #65 identifies an unsafe compatibility decision in `WorkspaceClient.respondToPermission`. The session-scoped v2 reply route is currently allowed to fall back to the workspace-scoped legacy mutation whenever its response is labeled `text/html`, even if the response is an HTTP 5xx. A real authorization or server failure can therefore be obscured by a second mutation, and buffered error bodies on fallback and error paths are not explicitly closed.
+
+The question compatibility path already distinguishes an absent route or a successful HTML compatibility page from a real HTTP failure. Permission replies need the same content-type convention and strict status-first classification without changing their tab-owned workspace routing or user-facing failure behavior.
+
+## What Changes
+
+Harden only the session-scoped v2-to-legacy permission-reply compatibility path:
+
+- Retain the v2 transport's existing `Response<Unit>` declaration and follow Retrofit's ownership model. `UnitResponseBodyConverter` closes the original successful network body during conversion; the returned `response.raw().body` is a non-readable `NoContentResponseBody` metadata placeholder that retains content type and length. Classification may inspect its media type but must not read or close the placeholder.
+- Classify one v2 permission-reply response with a route-specific disposition.
+- Treat a 2xx response as success only when neither the `Content-Type` response header nor the raw metadata placeholder's media type is HTML.
+- Fall back only for HTTP 404 or a 2xx HTML response.
+- Detect `text/html` case-insensitively, after trimming the base media type and ignoring optional parameters, from either the header or raw metadata placeholder. Reuse the question compatibility convention rather than adding a second parser.
+- Close every present buffered `errorBody()` before invoking legacy fallback for HTTP 404 or propagating another HTTP failure. Do not close the raw metadata placeholder. A successful HTML response needs no additional network-body closure because Retrofit's Unit converter closed the original body before returning it.
+- Invoke the legacy permission mutation exactly once after a fallback disposition, forwarding the same request identifier and reply through the owning `WorkspaceClient`'s captured directory and explicit `workspace = null` routing.
+- Propagate the original v2 `HttpException` for every non-2xx response except 404, including HTML 5xx, without invoking legacy.
+- Preserve coroutine cancellation. Cancellation is not converted into compatibility fallback, success, or a user-visible raw exception.
+- Keep failures on the existing concise, non-sensitive permission-reply error path; response bodies, stack traces, credential-bearing URLs, and arbitrary server exception text are not exposed.
+
+## Classification Contract
+
+The classifier evaluates the v2 response in this order:
+
+1. HTTP 404: close the present buffered error body, then select legacy fallback.
+2. Any other non-2xx status: close the present buffered error body, then throw the original `HttpException`.
+3. A 2xx response identified as HTML by either supported media-type source: select legacy fallback; Retrofit has already closed the original successful network body during Unit conversion.
+4. Any other 2xx response: succeed without a legacy call.
+
+A fallback disposition permits one legacy mutation for that user reply. It is not a retry policy: a legacy result, failure, or cancellation is returned or propagated without a second legacy call.
+
+## Workspace, Cancellation, and Error Constraints
+
+The legacy fallback remains owned by the `WorkspaceClient` captured for the tab. Its `directory` argument is forwarded exactly, including an intentional `null`, and the existing explicit `workspace = null` argument remains explicit. The implementation must not inspect active-tab state, a session directory, settings, a last-used project, or any global/default workspace source.
+
+Cancellation from either network call propagates as cancellation. It must not be caught as a reason to switch routes, restart a mutation, or publish a stale success. The compatibility classifier changes route selection only; it does not add retries, background work, or presentation state.
+
+## Exclusions
+
+This change does not alter permission discovery, question endpoint ordering, question reply/reject behavior, session lifecycle, permission dialog semantics, allowed reply values, or the legacy endpoint's response contract. It does not add fallback for redirects, authorization failures, rate limits, ordinary 4xx responses other than 404, 5xx responses, malformed responses, transport failures, or cancellation. It does not add a global/default workspace, active-tab lookup, directory fallback chain, duplicate mutation, automatic retry, telemetry, or new UI/error copy.
+
+## Impact
+
+- **Network/data:** retain `Response<Unit>`; inspect content type through the non-readable `response.raw().body` metadata placeholder without reading or closing it, rely on Unit conversion to close the original successful network body, close buffered `errorBody()` instances on HTTP fallback/failure paths, and then select at most one legacy call.
+- **Workspace routing:** keep the existing tab-owned `WorkspaceClient` directory forwarding and explicit `workspace = null` legacy arguments unchanged.
+- **Errors:** retain the original non-fallback HTTP status for existing safe, human-readable presentation without exposing response content.
+- **Tests:** add focused `WorkspaceClientPermissionFallbackTest` regression coverage for classification, robust HTML matching, body closure, cancellation, single legacy mutation, and exact directory forwarding.

--- a/openspec/changes/harden-permission-reply-fallback/specs/permission-reply-compatibility/spec.md
+++ b/openspec/changes/harden-permission-reply-fallback/specs/permission-reply-compatibility/spec.md
@@ -1,0 +1,184 @@
+# Permission Reply Compatibility Specification
+
+## ADDED Requirements
+
+### Requirement: Retrofit-owned success body and inspectable raw metadata
+
+The v2 permission-reply result SHALL retain the existing `Response<Unit>` declaration and Retrofit ownership model. On a successful response, `UnitResponseBodyConverter` closes the original network body before the response reaches `WorkspaceClient`. Retrofit replaces that body in `response.raw()` with a non-readable `NoContentResponseBody` metadata placeholder that retains content type and length. Classification SHALL use the placeholder only for media-type metadata and SHALL NOT read or close it. An implementation SHALL NOT rely on the decoded `Unit` body for media-type detection, decode the placeholder into a new response contract, or expose it to presentation. A non-2xx response's buffered `errorBody()` remains a distinct closeable body owned by the client.
+
+#### Scenario: Successful conversion closes the network body and retains metadata
+
+- **GIVEN** the v2 permission-reply endpoint returns a 2xx response with a body media type
+- **WHEN** Retrofit returns the response to `WorkspaceClient`
+- **THEN** Retrofit's Unit converter SHALL already have closed the original successful network body
+- **AND** the client SHALL inspect the media type through the non-readable `response.raw().body` metadata placeholder
+- **AND** the client SHALL NOT read or close that placeholder
+
+### Requirement: Exact v2 permission-reply classification
+
+The application SHALL classify the session-scoped v2 permission-reply response before deciding whether the reply succeeded or may use the legacy route. A 2xx response SHALL succeed only when it is not HTML. HTTP 404 SHALL select legacy fallback. A 2xx HTML response SHALL select legacy fallback. Every other non-2xx response, including an HTML response, SHALL propagate the original `HttpException` and SHALL NOT invoke the legacy route.
+
+Classification SHALL evaluate HTTP 404 before other failures, other non-2xx responses before successful HTML, and successful non-HTML only after those cases. Redirects and all non-404 4xx/5xx statuses are failures, not compatibility signals.
+
+#### Scenario: Successful non-HTML v2 response
+
+- **GIVEN** the v2 permission-reply route returns a 2xx response
+- **AND** neither its `Content-Type` header nor its raw metadata placeholder identifies HTML
+- **WHEN** the response is classified
+- **THEN** the permission reply SHALL succeed
+- **AND** the legacy permission route SHALL NOT be called
+
+#### Scenario: Missing v2 route
+
+- **GIVEN** the v2 permission-reply route returns HTTP 404
+- **WHEN** the response is classified
+- **THEN** the response SHALL select legacy fallback
+- **AND** no other HTTP status SHALL be generalized as a missing-route signal
+
+#### Scenario: Successful HTML compatibility page
+
+- **GIVEN** the v2 permission-reply route returns a 2xx response
+- **AND** either its response header or raw metadata placeholder identifies HTML
+- **WHEN** the response is classified
+- **THEN** the response SHALL select legacy fallback
+
+#### Scenario: HTML server failure
+
+- **GIVEN** the v2 permission-reply route returns HTTP 500
+- **AND** its response header or raw metadata placeholder identifies HTML
+- **WHEN** the response is classified
+- **THEN** the original HTTP 500 `HttpException` SHALL be propagated
+- **AND** the legacy permission route SHALL NOT be called
+
+#### Scenario: Ordinary non-404 HTTP failure
+
+- **GIVEN** the v2 permission-reply route returns a redirect, authorization failure, rate-limit response, another non-404 4xx, or a 5xx response
+- **WHEN** the response is classified
+- **THEN** its original `HttpException` SHALL be propagated
+- **AND** the legacy permission route SHALL NOT be called
+
+### Requirement: Shared robust HTML media-type matching
+
+Permission response classification SHALL reuse the question compatibility path's HTML media-type convention. It SHALL compare the base media type to `text/html` case-insensitively after trimming whitespace and ignoring optional parameters. It SHALL inspect both the response `Content-Type` header and the raw metadata placeholder's media type; a match from either source SHALL identify HTML. Missing or non-HTML media types SHALL NOT independently trigger fallback.
+
+#### Scenario: Header uses case and parameters
+
+- **GIVEN** a 2xx v2 response has `Content-Type: Text/HTML; Charset=UTF-8`
+- **WHEN** its permission response is classified
+- **THEN** it SHALL be identified as HTML
+- **AND** it SHALL select legacy fallback
+
+#### Scenario: Raw metadata identifies HTML
+
+- **GIVEN** a 2xx v2 response has a missing or non-HTML `Content-Type` header
+- **AND** its raw metadata placeholder's media type is `text/html` with or without parameters
+- **WHEN** its permission response is classified
+- **THEN** it SHALL be identified as HTML
+- **AND** it SHALL select legacy fallback
+
+#### Scenario: Non-HTML media type is not broadened
+
+- **GIVEN** a 2xx v2 response has only missing, JSON, plain-text, or another non-HTML media type
+- **WHEN** its permission response is classified
+- **THEN** it SHALL succeed as non-HTML
+- **AND** media-type uncertainty SHALL NOT trigger legacy fallback
+
+### Requirement: Terminal response-body ownership
+
+The application SHALL follow Retrofit's response-body ownership model. Unit conversion SHALL have closed the original successful network body before `WorkspaceClient` receives a 2xx response. The raw response body is a non-readable metadata placeholder, not the original network body, and the application SHALL NOT read or close it. Before HTTP 404 selects legacy fallback or another non-2xx response propagates an HTTP failure, the application SHALL close every present buffered `errorBody()`. Error-body closure SHALL happen before the legacy call or exception propagation and SHALL NOT replace the original `HttpException`.
+
+#### Scenario: 404 body closes before fallback
+
+- **GIVEN** a v2 HTTP 404 response owns an error body
+- **WHEN** it selects legacy fallback
+- **THEN** the error body SHALL be closed before the legacy request begins
+
+#### Scenario: Successful HTML body was closed during conversion
+
+- **GIVEN** Retrofit returns a v2 2xx HTML `Response<Unit>`
+- **WHEN** it selects legacy fallback
+- **THEN** the original successful network body SHALL already have been closed by Unit conversion
+- **AND** the raw metadata placeholder SHALL NOT be read or closed
+
+#### Scenario: HTTP error body closes before propagation
+
+- **GIVEN** a non-404 v2 HTTP failure has a buffered `errorBody()`
+- **WHEN** the failure is propagated
+- **THEN** the buffered error body SHALL be closed first
+- **AND** the raw metadata placeholder SHALL NOT be closed
+- **AND** closing the error body SHALL NOT replace or obscure the response's original `HttpException`
+
+### Requirement: At most one exact legacy permission mutation
+
+For one `respondToPermission` invocation, a fallback disposition SHALL invoke the existing workspace-scoped legacy permission mutation exactly once. The call SHALL forward the same request identifier and permission reply without transformation. A legacy success or Boolean result SHALL be returned according to the existing contract; a legacy failure or cancellation SHALL propagate without retry. A v2 success or non-fallback failure SHALL issue zero legacy mutations.
+
+#### Scenario: One fallback produces one legacy mutation
+
+- **GIVEN** the v2 response is HTTP 404 or successful HTML
+- **WHEN** the application falls back
+- **THEN** it SHALL invoke the legacy permission route exactly once with the original request identifier and reply
+- **AND** it SHALL NOT retry or invoke another mutation route
+
+#### Scenario: Legacy call fails
+
+- **GIVEN** an eligible fallback has invoked the legacy permission route
+- **WHEN** that legacy call fails or returns its existing false result
+- **THEN** the failure or result SHALL be propagated according to the existing legacy contract
+- **AND** the application SHALL NOT issue a second legacy mutation
+
+### Requirement: Exact tab-owned workspace routing
+
+The legacy fallback SHALL use only the immutable workspace identity captured by the owning tab's `WorkspaceClient`. It SHALL forward that client's `Workspace.directory` exactly, including an intentional `null`, and SHALL continue to pass the explicit `workspace = null` API argument. It SHALL NOT derive a directory from active-tab state, the session, settings, a last-used project, a global/default workspace, or any fallback chain.
+
+#### Scenario: Captured directory is forwarded
+
+- **GIVEN** the owning `WorkspaceClient` was created for directory `/work/alpha`
+- **AND** another active or recently used tab points at `/work/beta`
+- **WHEN** an eligible v2 response falls back to the legacy permission route
+- **THEN** the legacy call SHALL use `directory=/work/alpha` and explicit `workspace=null`
+- **AND** it SHALL NOT inspect or use `/work/beta`
+
+#### Scenario: Intentional null directory is preserved
+
+- **GIVEN** the owning `WorkspaceClient` has `Workspace.directory == null`
+- **WHEN** an eligible v2 response falls back to the legacy permission route
+- **THEN** the legacy call SHALL pass the intentional null directory and explicit `workspace=null`
+- **AND** it SHALL NOT substitute any guessed directory
+
+### Requirement: Cancellation and non-sensitive failure behavior
+
+Coroutine cancellation from the v2 call, classification, or the legacy call SHALL propagate as cancellation. It SHALL NOT be converted to success, compatibility fallback, an automatic retry, or an ordinary user-visible error, and cancellation before or during a legacy call SHALL NOT cause another mutation.
+
+Non-fallback HTTP failures SHALL retain their original status for the existing error-handling path. User-visible permission-reply failure text SHALL remain concise and human-readable and SHALL NOT include response bodies, stack traces, credential-bearing URLs, serialized request data, or arbitrary server exception text.
+
+#### Scenario: V2 call is cancelled
+
+- **GIVEN** the v2 permission-reply request is cancelled before it produces a response
+- **WHEN** cancellation propagates
+- **THEN** the legacy permission route SHALL NOT be called
+- **AND** cancellation SHALL NOT be converted into a compatibility or presentation error
+
+#### Scenario: Legacy fallback is cancelled
+
+- **GIVEN** an eligible response has selected and started the one legacy fallback
+- **WHEN** the legacy call is cancelled
+- **THEN** cancellation SHALL propagate
+- **AND** no second legacy mutation SHALL be attempted
+
+#### Scenario: HTTP failure reaches presentation
+
+- **GIVEN** a non-fallback v2 HTTP failure is propagated
+- **WHEN** the existing permission-reply error path reports it to the user
+- **THEN** the user SHALL receive the existing concise retry guidance
+- **AND** raw response or exception details SHALL NOT be displayed
+
+### Requirement: Permission-only compatibility scope
+
+This compatibility classifier SHALL apply only to v2 permission replies. It SHALL NOT change question route ordering or classification, permission discovery, allowed permission reply values, session lifecycle, dialog semantics, or the legacy response contract. It SHALL NOT add transport-failure fallback, automatic retry, background work, or any global workspace mechanism.
+
+#### Scenario: Unrelated compatibility paths remain unchanged
+
+- **GIVEN** a question reply, question rejection, question listing, or permission-listing operation runs
+- **WHEN** this permission-reply hardening is present
+- **THEN** that operation SHALL retain its existing route order, classification, routing, and failure behavior
+- **AND** it SHALL NOT use the permission-reply classifier as a broadened fallback policy

--- a/openspec/changes/harden-permission-reply-fallback/tasks.md
+++ b/openspec/changes/harden-permission-reply-fallback/tasks.md
@@ -32,4 +32,4 @@
 - [x] 3.4 Run `./gradlew :app:detekt`.
 - [x] 3.5 Run `./gradlew :app:testDebugUnitTest`.
 - [x] 3.6 Obtain an independent Sol review of the final permission-reply classifier, body ownership, mutation count, cancellation, and workspace routing.
-- [ ] 3.7 Verify GitHub Actions succeeds for the branch before merge.
+- [x] 3.7 Verify GitHub Actions succeeds for the branch before merge.

--- a/openspec/changes/harden-permission-reply-fallback/tasks.md
+++ b/openspec/changes/harden-permission-reply-fallback/tasks.md
@@ -1,0 +1,35 @@
+# Implementation Tasks
+
+## 1. Permission response classification and ownership
+
+- [x] 1.1 Retain `Response<Unit>` and use `response.raw().body` only as Retrofit's non-readable content-type metadata placeholder. Rely on Unit conversion to close the original successful network body; never read or close the placeholder, and own `errorBody()` separately.
+- [x] 1.2 Reuse the question compatibility path's case-insensitive, parameter-tolerant `text/html` matching convention; do not add a second content-type parser.
+- [x] 1.3 Add one route-specific permission-response classifier ordered as: 404 fallback, other non-2xx `HttpException`, 2xx HTML fallback, then 2xx non-HTML success.
+- [x] 1.4 Close every present buffered `errorBody()` before returning a 404 fallback disposition or propagating another HTTP failure, without reading or closing the raw metadata placeholder and without replacing the original `HttpException`.
+- [x] 1.5 On fallback, invoke the existing legacy permission mutation exactly once with the original request identifier and reply; do not retry a false result, failure, or cancellation.
+- [x] 1.6 Keep legacy routing on the owning `WorkspaceClient`'s exact captured directory, including intentional null, with the existing explicit `workspace = null`; add no active/global/default workspace lookup or directory fallback.
+- [x] 1.7 Preserve coroutine cancellation from v2 and legacy calls without converting it to fallback, success, retry, or a second mutation.
+- [x] 1.8 Preserve the existing concise, non-sensitive permission-reply presentation error; do not surface response bodies, stack traces, credential-bearing URLs, serialized requests, or arbitrary exception text.
+
+## 2. Focused regression coverage
+
+- [x] 2.1 Add `WorkspaceClientPermissionFallbackTest` coverage proving a 2xx non-HTML v2 response succeeds with zero legacy calls.
+- [x] 2.2 Test HTTP 404 fallback, buffered error-body closure before fallback, and exactly one legacy call with the original request identifier and reply.
+- [x] 2.3 Test successful HTML fallback from both the response header and raw metadata placeholder, including mixed case, surrounding whitespace, optional parameters, and a conflicting/missing non-HTML source.
+- [x] 2.4 Test that HTML 5xx closes every present buffered error body, propagates the original-status `HttpException`, and makes zero legacy calls.
+- [x] 2.5 Test redirects, authorization/rate-limit responses, other non-404 4xx responses, and ordinary 5xx responses propagate without legacy fallback and close every present buffered error body.
+- [x] 2.6 Test a fallback invokes legacy at most once when legacy returns false, throws, or is cancelled.
+- [x] 2.7 Test cancellation of the v2 call propagates and makes zero legacy calls.
+- [x] 2.8 Test eligible fallback forwards the owning client's exact non-null directory and explicit `workspace = null`, ignoring other tab/workspace state.
+- [x] 2.9 Test eligible fallback preserves an intentionally null captured directory without substituting a global, session, settings, or last-used directory.
+- [x] 2.10 Confirm the focused change does not alter question route order/classification, permission discovery, reply values, session/dialog behavior, or the legacy response contract.
+
+## 3. Runtime verification
+
+- [x] 3.1 Run the focused `WorkspaceClientPermissionFallbackTest` permission-reply regression suite.
+- [x] 3.2 Run `./gradlew :app:compileDebugKotlin`.
+- [x] 3.3 Run `./gradlew :app:compileDebugAndroidTestKotlin`.
+- [x] 3.4 Run `./gradlew :app:detekt`.
+- [x] 3.5 Run `./gradlew :app:testDebugUnitTest`.
+- [x] 3.6 Obtain an independent Sol review of the final permission-reply classifier, body ownership, mutation count, cancellation, and workspace routing.
+- [ ] 3.7 Verify GitHub Actions succeeds for the branch before merge.


### PR DESCRIPTION
## Summary
- classify session-scoped permission replies before legacy fallback
- fall back only for HTTP 404 or successful HTML compatibility responses
- close buffered error bodies and preserve every other HTTP failure without a duplicate mutation
- preserve exact tab-owned workspace routing and coroutine cancellation
- document the Retrofit Unit body-ownership contract in OpenSpec

## Regression coverage
- real Retrofit/OkHttp transport proof for successful HTML conversion and one legacy mutation
- ordinary success, 404, HTML header/raw metadata, HTML 500, and 302/401/422/429/503 behavior
- error-body closure and original HttpException preservation
- legacy false/failure/cancellation without retry
- v2 cancellation and exact non-null/null workspace directory routing

## Verification
- base regression reproduces the old duplicate-fallback behavior: artifact://2878
- focused permission fallback suite: artifact://2894
- final `compileDebugKotlin`, `compileDebugAndroidTestKotlin`, detekt, and full debug unit suite: artifact://2923
- independent Sol review: SHIP

Closes #65